### PR TITLE
deploy.yaml: add workflow_dispatch + robust path detection

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,6 +4,13 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      force_deploy:
+        description: Force backend + frontend deploy regardless of detected changes
+        required: false
+        type: boolean
+        default: true
 
 concurrency:
   group: newsletter-service-prod
@@ -36,6 +43,17 @@ jobs:
         run: |
           set -euo pipefail
 
+          # workflow_dispatch: honor the force_deploy input directly.
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            force="${{ inputs.force_deploy }}"
+            echo "backend_changed=${force}" >> "$GITHUB_OUTPUT"
+            echo "frontend_changed=${force}" >> "$GITHUB_OUTPUT"
+            echo "js_changed=${force}" >> "$GITHUB_OUTPUT"
+            echo "rust_changed=${force}" >> "$GITHUB_OUTPUT"
+            echo "deploy_needed=${force}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           BASE_SHA="${{ github.event.before }}"
           HEAD_SHA="${{ github.sha }}"
 
@@ -46,6 +64,26 @@ jobs:
           if [[ -z "${BASE_SHA}" ]]; then
             echo "backend_changed=true" >> "$GITHUB_OUTPUT"
             echo "frontend_changed=true" >> "$GITHUB_OUTPUT"
+            echo "deploy_needed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Use `git log --name-only` over the BASE..HEAD range instead of
+          # `git diff BASE HEAD`. The diff form returned empty on the runner
+          # for at least one merge commit (e7a1379..c4168e3 in PR #235) even
+          # though it correctly reported the changed file locally. The log
+          # form lists files touched by every commit in the range, which is
+          # robust to merge-commit edge cases.
+          changed_files="$(git log --name-only --pretty=format: "${BASE_SHA}..${HEAD_SHA}" 2>/dev/null | sort -u | grep -v '^$' || true)"
+
+          # If we still got nothing despite a non-empty range, fail open and
+          # deploy. Skipping a real change is worse than re-deploying a no-op.
+          if [[ -z "${changed_files}" && "${BASE_SHA}" != "${HEAD_SHA}" ]]; then
+            echo "WARNING: no files detected between ${BASE_SHA}..${HEAD_SHA}; forcing deploy" >&2
+            echo "backend_changed=true" >> "$GITHUB_OUTPUT"
+            echo "frontend_changed=true" >> "$GITHUB_OUTPUT"
+            echo "js_changed=true" >> "$GITHUB_OUTPUT"
+            echo "rust_changed=true" >> "$GITHUB_OUTPUT"
             echo "deploy_needed=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -82,7 +120,7 @@ jobs:
                 rust_changed=true
                 ;;
             esac
-          done < <(git diff --name-only "${BASE_SHA}" "${HEAD_SHA}")
+          done <<< "${changed_files}"
 
           if [[ "${backend_changed}" == "true" || "${frontend_changed}" == "true" ]]; then
             deploy_needed=true


### PR DESCRIPTION
## Why
[PR #235](https://github.com/readysetcloud/newsletter-service/pull/235) merged cleanly but its deploy was [skipped](https://github.com/readysetcloud/newsletter-service/actions/runs/26169101372): the path-detect step's \`git diff --name-only BASE HEAD\` returned empty on the runner, even though running the same diff between the same SHAs locally correctly reports the changed file. Net effect: the SSM-publishing change is in main but hasn't deployed to AWS yet, and there's no \`workflow_dispatch\` to re-trigger.

## Changes
1. **\`workflow_dispatch\` trigger** with a \`force_deploy\` boolean input (defaults to \`true\`). Lets you re-run a missed deploy from the Actions UI without inventing a no-op commit.
2. **Switch detect logic from \`git diff\` to \`git log --name-only\`** over the same \`BASE..HEAD\` range. The log form enumerates files touched by every commit in the range and is robust to the merge-commit edge case that caused PR #235 to skip. The case statements stay identical.
3. **Fail-open safety net**: if detection returns empty for a non-empty SHA range, the step logs a warning and forces \`deploy_needed=true\`. Skipping a real change is worse than re-deploying a no-op.

## After merge
Click **Run workflow** on the [Deploy to Production](https://github.com/readysetcloud/newsletter-service/actions/workflows/deploy.yaml) workflow with \`force_deploy=true\` (the default). That picks up the SSM-publishing change from PR #235 and creates the \`/newsletter-service/{staging,production}/*\` params. After that, [allenheltondev/content-tracking#14](https://github.com/allenheltondev/content-tracking/pull/14) is unblocked.

## Test plan
- [ ] Merge this PR
- [ ] Confirm the merge itself triggers a deploy run (the new detect logic should flag \`.github/workflows/deploy.yaml\` as a non-deployable path → deploy_needed=false → run is short but no deploy, which is correct)
- [ ] Manually trigger \"Deploy to Production\" workflow with default inputs
- [ ] Confirm \`aws ssm get-parameter --name /newsletter-service/staging/newsletter-api-base-url\` returns a value

🤖 Generated with [Claude Code](https://claude.com/claude-code)