### PR TITLE
Custom domain for NewsletterApi + fix SSM-param duplicates from #235

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -70,6 +70,11 @@ Conditions:
   DeployCustomDomain: !And
     - !Condition HasDomainName
     - !Condition HasHostedZoneId
+  # Gates the dedicated NewsletterApi custom domain (api.newsletter.<DomainName>).
+  # Production only by design; staging continues to expose the execute-api URL.
+  DeployNewsletterApiCustomDomain: !And
+    - !Condition DeployProductionResources
+    - !Condition DeployCustomDomain
   HasRedirectCustomDomain: !Not [!Equals [!Ref RedirectCustomDomain, ""]]
   HasVerifiedFromEmail: !Not [!Equals [!Ref VerifiedFromEmail, ""]]
   HasFrontendCustomDomain: !Not [!Equals [!Ref FrontendCustomDomain, ""]]
@@ -4282,6 +4287,49 @@ Resources:
                 Action: lambda:InvokeFunction
                 Resource: !GetAtt AggregateIssueAnalyticsFunction.Arn
 
+  # Dedicated custom domain for NewsletterApi, prod only. Sits alongside the
+  # UI at newsletter.<DomainName>; consumers like content-tracking call
+  # https://api.newsletter.<DomainName> instead of the execute-api URL.
+  NewsletterApiCertificate:
+    Type: AWS::CertificateManager::Certificate
+    Condition: DeployNewsletterApiCustomDomain
+    Properties:
+      DomainName: !Sub api.newsletter.${DomainName}
+      ValidationMethod: DNS
+      DomainValidationOptions:
+        - DomainName: !Sub api.newsletter.${DomainName}
+          HostedZoneId: !Ref HostedZoneId
+
+  NewsletterApiDomain:
+    Type: AWS::ApiGateway::DomainName
+    Condition: DeployNewsletterApiCustomDomain
+    Properties:
+      DomainName: !Sub api.newsletter.${DomainName}
+      RegionalCertificateArn: !Ref NewsletterApiCertificate
+      EndpointConfiguration:
+        Types: [REGIONAL]
+      SecurityPolicy: TLS_1_2
+
+  NewsletterApiBasePathMapping:
+    Type: AWS::ApiGateway::BasePathMapping
+    Condition: DeployNewsletterApiCustomDomain
+    DependsOn: NewsletterApipublicStage
+    Properties:
+      DomainName: !Ref NewsletterApiDomain
+      RestApiId: !Ref NewsletterApi
+      Stage: public
+
+  NewsletterApiDnsRecord:
+    Type: AWS::Route53::RecordSet
+    Condition: DeployNewsletterApiCustomDomain
+    Properties:
+      HostedZoneId: !Ref HostedZoneId
+      Name: !Sub api.newsletter.${DomainName}
+      Type: A
+      AliasTarget:
+        DNSName: !GetAtt NewsletterApiDomain.RegionalDomainName
+        HostedZoneId: !GetAtt NewsletterApiDomain.RegionalHostedZoneId
+
   # Cross-service contract: consumers (e.g. content-tracking) resolve these
   # SSM paths at deploy time via AWS::SSM::Parameter::Value<String> rather
   # than depending on CloudFormation Exports or hardcoded URLs.
@@ -4293,7 +4341,10 @@ Resources:
         - /newsletter-service/production/newsletter-api-base-url
         - /newsletter-service/staging/newsletter-api-base-url
       Type: String
-      Value: !Sub https://${NewsletterApi}.execute-api.${AWS::Region}.amazonaws.com/public
+      Value: !If
+        - DeployNewsletterApiCustomDomain
+        - !Sub https://api.newsletter.${DomainName}
+        - !Sub https://${NewsletterApi}.execute-api.${AWS::Region}.amazonaws.com/public
       Description: Base URL of newsletter-service's public API for cross-service consumers
 
   CampaignShortLinkBaseParameter:

--- a/template.yaml
+++ b/template.yaml
@@ -2895,7 +2895,12 @@ Resources:
   CampaignShortLinkBaseParam:
     Type: AWS::SSM::Parameter
     Properties:
-      Name: !Sub "/newsletter-service/${Environment}/campaign-short-link-base"
+      # Cross-service contract: consumers (e.g. content-tracking) lookup the
+      # non-prod URL under /staging/ regardless of whether the source stack
+      # was deployed with Environment=sandbox or Environment=stage.
+      Name: !Sub
+        - /newsletter-service/${SsmEnv}/campaign-short-link-base
+        - SsmEnv: !If [DeployProductionResources, production, staging]
       Type: String
       Value: !If
         - HasRedirectCustomDomain
@@ -2906,10 +2911,15 @@ Resources:
   NewsletterApiBaseUrlParam:
     Type: AWS::SSM::Parameter
     Properties:
-      Name: !Sub "/newsletter-service/${Environment}/newsletter-api-base-url"
+      Name: !Sub
+        - /newsletter-service/${SsmEnv}/newsletter-api-base-url
+        - SsmEnv: !If [DeployProductionResources, production, staging]
       Type: String
-      Value: !Sub "https://${NewsletterApi}.execute-api.${AWS::Region}.amazonaws.com/public"
-      Description: NewsletterApi base URL (append /links to mint, /links/{code} to delete)
+      Value: !If
+        - DeployNewsletterApiCustomDomain
+        - !Sub https://api.newsletter.${DomainName}
+        - !Sub "https://${NewsletterApi}.execute-api.${AWS::Region}.amazonaws.com/public"
+      Description: NewsletterApi base URL for cross-service consumers (append /links to mint, /links/{code} to delete)
 
   RedirectCFDistribution:
     Type: AWS::CloudFront::Distribution
@@ -4329,37 +4339,6 @@ Resources:
       AliasTarget:
         DNSName: !GetAtt NewsletterApiDomain.RegionalDomainName
         HostedZoneId: !GetAtt NewsletterApiDomain.RegionalHostedZoneId
-
-  # Cross-service contract: consumers (e.g. content-tracking) resolve these
-  # SSM paths at deploy time via AWS::SSM::Parameter::Value<String> rather
-  # than depending on CloudFormation Exports or hardcoded URLs.
-  NewsletterApiBaseUrlParameter:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: !If
-        - DeployProductionResources
-        - /newsletter-service/production/newsletter-api-base-url
-        - /newsletter-service/staging/newsletter-api-base-url
-      Type: String
-      Value: !If
-        - DeployNewsletterApiCustomDomain
-        - !Sub https://api.newsletter.${DomainName}
-        - !Sub https://${NewsletterApi}.execute-api.${AWS::Region}.amazonaws.com/public
-      Description: Base URL of newsletter-service's public API for cross-service consumers
-
-  CampaignShortLinkBaseParameter:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: !If
-        - DeployProductionResources
-        - /newsletter-service/production/campaign-short-link-base
-        - /newsletter-service/staging/campaign-short-link-base
-      Type: String
-      Value: !If
-        - HasRedirectCustomDomain
-        - !Sub https://${RedirectCustomDomain}/c
-        - !Sub https://${RedirectCFDistribution.DomainName}/c
-      Description: Base URL for campaign short links. The /c/{shortId} route is built separately; this parameter exposes the URL prefix that content-tracking embeds in mint responses.
 
 Outputs:
   NewsletterApiUrl:


### PR DESCRIPTION
## Summary
Two coupled fixes for cross-service URL publishing.

### 1. Remove SSM param duplicates (the breakage)
PR #235 was merged before catching that PR #232 (one day earlier) had already added \`CampaignShortLinkBaseParam\` and \`NewsletterApiBaseUrlParam\` at lines 2895 and 2906 of \`template.yaml\`. The duplicates produced the same SSM Name in prod (\`/newsletter-service/production/*\`), which trips \`AWS::EarlyValidation::ResourceExistenceCheck\` at change-set creation time. Every prod deploy since #235 has failed for this reason; manually deleting the SSM params in AWS didn't help because the hook fires before any AWS call.

This PR deletes the duplicate resources added by #235 (\`NewsletterApiBaseUrlParameter\`, \`CampaignShortLinkBaseParameter\`) and folds their improvements into the existing originals.

### 2. Align the non-prod SSM path to \`/staging/\`
The existing resources used \`/newsletter-service/\${Environment}/...\`, which produces \`/staging/\` for prod ✅ but \`/stage/\` for PR deploys and \`/sandbox/\` for local-dev deploys ❌. Cross-service consumers (content-tracking) use \`/staging/\` as the canonical non-prod label. Updated to \`!If [DeployProductionResources, production, staging]\` so every non-prod deploy publishes to the same path.

### 3. Add the \`api.newsletter.<DomainName>\` custom domain (the original intent of this PR)
Production only, gated on \`DeployNewsletterApiCustomDomain\` = \`DeployProductionResources AND DeployCustomDomain\`. Adds:
- \`NewsletterApiCertificate\` — ACM cert for \`api.newsletter.\${DomainName}\`, DNS-validated against the existing \`HostedZoneId\`
- \`NewsletterApiDomain\` — REGIONAL API Gateway custom domain, TLS_1_2
- \`NewsletterApiBasePathMapping\` — empty base path → \`NewsletterApi\` stage \`public\`. Consumers call \`https://api.newsletter.<DomainName>/<route>\` directly, no \`/public\` prefix.
- \`NewsletterApiDnsRecord\` — A-alias to the regional domain.

\`NewsletterApiBaseUrlParam\`'s value flips to \`https://api.newsletter.\${DomainName}\` when the condition is true, falls back to the execute-api URL otherwise.

## Why all in one PR
The custom-domain change *has to* reach into the existing \`NewsletterApiBaseUrlParam\` value (because that's the only NewsletterApi SSM resource that should exist in the template after dedup). Splitting these into separate PRs would create an awkward intermediate state where prod has no API URL published.

## Test plan
- [ ] After merge, \`Deploy to Production\` succeeds (the duplicate is gone, ResourceExistenceCheck passes)
- [ ] CFN recreates \`/newsletter-service/production/{newsletter-api-base-url,campaign-short-link-base}\` (drifted by manual deletion)
- [ ] Cert + domain + DNS record provision cleanly in prod
- [ ] \`curl https://api.newsletter.readysetcloud.io/<route>\` returns the same response as the execute-api URL
- [ ] \`aws ssm get-parameter --name /newsletter-service/production/newsletter-api-base-url\` returns \`https://api.newsletter.readysetcloud.io\`
- [ ] Next PR-stage deploy publishes \`/newsletter-service/staging/*\` (not \`/stage/*\`)

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)