### PR TITLE
fix(onboarding): don't gate brand submit button on form validity

### DIFF
--- a/dashboard-ui/src/components/forms/BrandForm.tsx
+++ b/dashboard-ui/src/components/forms/BrandForm.tsx
@@ -13,7 +13,6 @@ import { BrandPhotoUpload } from './BrandPhotoUpload';
 import { BrandIdInput } from './BrandIdInput';
 import { brandSchema, BrandFormData, industryOptions } from '../../schemas/brandSchema';
 import { BrandInfo } from '../../types';
-import { useFormValidationState } from '../../hooks/useRealTimeValidation';
 import { getUserFriendlyErrorMessage } from '../../utils/errorHandling';
 
 type BrandFormInput = z.input<typeof brandSchema>;
@@ -84,12 +83,12 @@ const BrandFormInner: React.FC<BrandFormProps> = ({
     getValues
   } = form;
 
-  // Enhanced validation state
-  const { isFormValid } = useFormValidationState(form);
-
   // Editing an existing brand vs. creating one (onboarding / first-time setup).
-  // When creating, the logo is optional and submit should be gated purely on
-  // form validity. The "must have changes" guard only makes sense when editing.
+  // In edit mode we keep a "must have changes" guard so an unchanged form can't be
+  // re-saved. We intentionally do NOT gate the button on form validity: a disabled
+  // button gives the user no idea what's wrong. Instead the button stays clickable
+  // and react-hook-form's handleSubmit surfaces a focused error next to whichever
+  // field is invalid (and blocks the actual submit).
   const isEditMode = !!initialData?.brandId;
 
   // Watch specific form values for preview updates
@@ -291,7 +290,7 @@ const BrandFormInner: React.FC<BrandFormProps> = ({
         )}
         <Button
           type="submit"
-          disabled={(isEditMode && !isDirty && !logoFile && !hasLogoChanged) || !isFormValid || isSubmitting}
+          disabled={isSubmitting || (isEditMode && !isDirty && !logoFile && !hasLogoChanged)}
           isLoading={isSubmitting}
         >
           {isSubmitting ? 'Saving...' : submitButtonText}

--- a/dashboard-ui/src/components/forms/__tests__/BrandFormSubmit.test.tsx
+++ b/dashboard-ui/src/components/forms/__tests__/BrandFormSubmit.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { BrandForm } from '../BrandForm';
+import { ToastProvider } from '../../ui/Toast';
+
+// BrandIdInput fires a debounced availability check; keep it deterministic.
+vi.mock('../../../services/brandService', () => ({
+  checkBrandIdAvailability: vi
+    .fn()
+    .mockResolvedValue({ available: true, brandId: 'mycompany', suggestions: [] }),
+}));
+
+const renderCreateForm = (onSubmit = vi.fn()) =>
+  render(
+    <ToastProvider>
+      <BrandForm
+        onSubmit={onSubmit}
+        submitButtonText="Complete Brand Setup"
+        showCancelButton={false}
+      />
+    </ToastProvider>
+  );
+
+describe('BrandForm submit gating (onboarding / create mode)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('keeps the submit button enabled so the user is never stuck', () => {
+    renderCreateForm();
+    expect(
+      screen.getByRole('button', { name: /complete brand setup/i })
+    ).not.toBeDisabled();
+  });
+
+  it('submits when the required fields are valid', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    renderCreateForm(onSubmit);
+
+    fireEvent.change(screen.getByPlaceholderText(/enter your brand name/i), {
+      target: { value: 'My Company' },
+    });
+    // Brand ID auto-generates from the name; wait for it to populate.
+    await waitFor(() =>
+      expect(screen.getByLabelText('Brand ID *')).toHaveValue('mycompany')
+    );
+    fireEvent.change(screen.getByLabelText('Industry *'), {
+      target: { value: 'technology' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /complete brand setup/i }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+  });
+
+  it('blocks submit and surfaces a focused error when a required field is missing', async () => {
+    const onSubmit = vi.fn();
+    renderCreateForm(onSubmit);
+
+    // Fill only the brand name; leave the required industry unselected.
+    fireEvent.change(screen.getByPlaceholderText(/enter your brand name/i), {
+      target: { value: 'My Company' },
+    });
+    await waitFor(() =>
+      expect(screen.getByLabelText('Brand ID *')).toHaveValue('mycompany')
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /complete brand setup/i }));
+
+    expect(await screen.findByText(/industry is required/i)).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #261. After that merged, the **"Complete Brand Setup" button was still disabled** in onboarding.

### Root cause
The button was gated on `isFormValid` (derived from react-hook-form's recorded errors). With `mode: 'onChange'` + a zod resolver, touching/submitting a field records its error. When a required field was left empty or invalid — most commonly a **website typed without `http://`** (the schema requires a full URL) or an **unselected industry** — an error got recorded and the button silently disabled, with no indication of *which* field was the problem. The user, focused on the brand ID they'd just edited, had no way to tell what was blocking them.

I confirmed with a diagnostic harness that when every required field is valid the button *does* enable — so the gate "worked," it just produced a dead-end with no feedback.

### Fix
Stop gating the button on validity. The button stays clickable; `handleSubmit` validates on click, blocks invalid submits, and surfaces a **focused error next to the offending field** (RHF also auto-focuses the first invalid field). Edit mode keeps its "must have changes" guard so an unchanged brand can't be re-saved.

```diff
- disabled={(isEditMode && !isDirty && !logoFile && !hasLogoChanged) || !isFormValid || isSubmitting}
+ disabled={isSubmitting || (isEditMode && !isDirty && !logoFile && !hasLogoChanged)}
```

(`useFormValidationState` is no longer needed here and was removed.)

## Tests
New `BrandFormSubmit.test.tsx`:
- create-mode button stays enabled (never a dead-end)
- a valid form submits (`onSubmit` called)
- an incomplete form blocks submit **and** shows "Industry is required" on the field instead of silently disabling

All 29 forms tests pass; `type-check` and `lint` clean.

## Note
The most likely real trigger was the **website URL validation** rejecting input without a protocol. If you'd like, I can make that field lenient (auto-prepend `https://`) as a small follow-up — say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)