### PR TITLE
fix(senders): repair status check, verification redirect, and clean up verification email

### DIFF
--- a/dashboard-ui/src/pages/verify-sender/VerifySenderPage.tsx
+++ b/dashboard-ui/src/pages/verify-sender/VerifySenderPage.tsx
@@ -1,153 +1,99 @@
 import { useEffect, useMemo } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
-import { CheckCircleIcon, ExclamationTriangleIcon, ArrowPathIcon } from '@heroicons/react/24/outline';
+import { CheckCircleIcon, ExclamationTriangleIcon, EnvelopeIcon } from '@heroicons/react/24/outline';
 import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
 import { useToast } from '@/components/ui/Toast';
 
+type VerificationVariant = 'success' | 'failed' | 'info';
+
 interface VerificationResult {
-  success: boolean;
+  variant: VerificationVariant;
+  title: string;
   message: string;
-  senderId?: string;
-  email?: string;
-  verificationStatus?: string;
-  alreadyVerified?: boolean;
-  expired?: boolean;
-  error?: string;
 }
 
+/**
+ * Landing page that Amazon SES redirects to after the recipient clicks the
+ * sender verification link. SES appends `?status=success` or `?status=failed`
+ * based on the configured success/failure redirect URLs (see the
+ * VERIFY_SUCCESS_URL / VERIFY_FAILURE_URL env vars on the verification template
+ * bootstrap function).
+ */
 export function VerifySenderPage() {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const { addToast } = useToast();
-  const token = searchParams.get('token');
+  const status = searchParams.get('status');
 
   const result = useMemo<VerificationResult>(() => {
-    if (!token) {
-      return {
-        success: false,
-        message: 'No verification token provided. Please use the link from your email.',
-        error: 'Missing token'
-      };
+    switch (status) {
+      case 'success':
+        return {
+          variant: 'success',
+          title: 'Email Verified!',
+          message: 'Your sender email address has been verified. You can now send newsletters from it.'
+        };
+      case 'failed':
+        return {
+          variant: 'failed',
+          title: 'Verification Failed',
+          message:
+            "We couldn't verify this email address. The link may have expired or already been used. You can request a new verification email from your sender settings."
+        };
+      default:
+        return {
+          variant: 'info',
+          title: 'Check Your Email',
+          message:
+            'Open the verification link in the email we sent to confirm your sender address. You can manage senders and re-send verification from your sender settings.'
+        };
     }
-
-    return {
-      success: false,
-      message: 'Email verification is now handled automatically. Please check your email for the verification link and follow the instructions provided.',
-      error: 'Deprecated verification method'
-    };
-  }, [token]);
-
-  const isVerifying = false;
+  }, [status]);
 
   useEffect(() => {
-    if (!token) return;
+    if (status === 'success') {
+      addToast({
+        type: 'success',
+        title: 'Sender verified',
+        message: 'Your sender email is ready to use.'
+      });
+    } else if (status === 'failed') {
+      addToast({
+        type: 'error',
+        title: 'Verification failed',
+        message: 'We could not verify your sender email.'
+      });
+    }
+  }, [status, addToast]);
 
-    addToast({
-      type: 'info',
-      title: 'Verification Method Updated',
-      message: 'Email verification now uses a streamlined process. Please check your email for the verification link.'
-    });
-  }, [token, addToast]);
-
-  const handleGoToDashboard = () => {
-    navigate('/senders');
-  };
-
-  const handleRequestNewVerification = () => {
-    navigate('/senders', {
-      state: {
-        message: 'Please request a new verification email from your sender settings.'
-      }
-    });
-  };
-
-  if (isVerifying) {
-    return (
-      <div className="min-h-screen bg-background flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
-        <Card className="max-w-md w-full space-y-8 p-8">
-          <div className="text-center">
-            <ArrowPathIcon className="mx-auto h-12 w-12 text-primary-500 animate-spin" />
-            <h2 className="mt-6 text-3xl font-bold text-foreground">
-              Verifying Email
-            </h2>
-            <p className="mt-2 text-sm text-muted-foreground">
-              Please wait while we verify your sender email address...
-            </p>
-          </div>
-        </Card>
-      </div>
-    );
-  }
+  const goToSenders = () => navigate('/senders');
+  const goToDashboard = () => navigate('/');
 
   return (
     <div className="min-h-screen bg-background flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
       <Card className="max-w-md w-full space-y-8 p-8">
         <div className="text-center">
-          {result?.success ? (
-            <>
-              <CheckCircleIcon className="mx-auto h-12 w-12 text-success-500" />
-              <h2 className="mt-6 text-3xl font-bold text-foreground">
-                {result.alreadyVerified ? 'Already Verified' : 'Email Verified!'}
-              </h2>
-              <p className="mt-2 text-sm text-muted-foreground">
-                {result.message}
-              </p>
-              {result.email && (
-                <div className="mt-4 p-4 bg-success-50 rounded-lg">
-                  <p className="text-sm font-medium text-success-800">
-                    Verified Email: {result.email}
-                  </p>
-                </div>
-              )}
-            </>
-          ) : (
-            <>
-              <ExclamationTriangleIcon className="mx-auto h-12 w-12 text-error-500" />
-              <h2 className="mt-6 text-3xl font-bold text-foreground">
-                Verification Failed
-              </h2>
-              <p className="mt-2 text-sm text-muted-foreground">
-                {result?.message || 'Unable to verify your email address.'}
-              </p>
-              {result?.expired && (
-                <div className="mt-4 p-4 bg-warning-50 rounded-lg">
-                  <p className="text-sm font-medium text-warning-800">
-                    The verification link has expired. Please request a new one.
-                  </p>
-                </div>
-              )}
-            </>
+          {result.variant === 'success' && (
+            <CheckCircleIcon className="mx-auto h-12 w-12 text-success-500" />
           )}
+          {result.variant === 'failed' && (
+            <ExclamationTriangleIcon className="mx-auto h-12 w-12 text-error-500" />
+          )}
+          {result.variant === 'info' && (
+            <EnvelopeIcon className="mx-auto h-12 w-12 text-primary-500" />
+          )}
+          <h2 className="mt-6 text-3xl font-bold text-foreground">{result.title}</h2>
+          <p className="mt-2 text-sm text-muted-foreground">{result.message}</p>
         </div>
 
         <div className="mt-8 space-y-4">
-          {result?.success ? (
-            <Button
-              onClick={handleGoToDashboard}
-              className="w-full"
-              variant="primary"
-            >
-              Go to Sender Settings
-            </Button>
-          ) : (
-            <>
-              <Button
-                onClick={handleRequestNewVerification}
-                className="w-full"
-                variant="primary"
-              >
-                {result?.expired ? 'Request New Verification' : 'Go to Sender Settings'}
-              </Button>
-              <Button
-                onClick={() => navigate('/')}
-                className="w-full"
-                variant="secondary"
-              >
-                Go to Dashboard
-              </Button>
-            </>
-          )}
+          <Button onClick={goToSenders} className="w-full" variant="primary">
+            Go to Sender Settings
+          </Button>
+          <Button onClick={goToDashboard} className="w-full" variant="secondary">
+            Go to Dashboard
+          </Button>
         </div>
 
         <div className="mt-6 text-center">

--- a/functions/src/api/router.rs
+++ b/functions/src/api/router.rs
@@ -52,7 +52,7 @@ pub async fn route_request(event: Request) -> Result<Response<Body>, Error> {
         // Senders endpoints
         (&Method::GET, "/senders") => senders::list_senders(event).await,
         (&Method::POST, "/senders") => senders::create_sender(event).await,
-        (&Method::PUT, path) if path.starts_with("/senders/") && path.ends_with("/status") => {
+        (&Method::GET, path) if path.starts_with("/senders/") && path.ends_with("/status") => {
             let sender_id = extract_sender_id(path);
             senders::get_sender_status(event, sender_id).await
         }
@@ -670,7 +670,7 @@ mod tests {
 
     #[test]
     fn test_method_validation_senders_endpoints() {
-        // Senders: GET list, POST create, PUT update, PUT status, DELETE
+        // Senders: GET list, POST create, PUT update, GET status, DELETE
         assert!(is_valid_api_path("/senders"));
         assert!(is_valid_api_path("/senders/sender-123"));
         assert!(is_valid_api_path("/senders/sender-123/status"));

--- a/functions/src/senders/bootstrap-verification-template.rs
+++ b/functions/src/senders/bootstrap-verification-template.rs
@@ -244,20 +244,53 @@ async fn update_template(
 }
 
 fn generate_template_content() -> String {
+    // Note: Amazon SES automatically appends the verification link and a
+    // standard "If you didn't request this" disclaimer beneath this content,
+    // so the template itself focuses on branding and clear instructions.
     r#"<!DOCTYPE html>
-<html>
-  <body>
-    <h1>Newsletter Service</h1>
-
-    <h2>Verify Your Sender Email</h2>
-    <p>Hello!</p>
-
-    <p>You're adding a new sender address to your account. To finish setup and start sending from this address, please confirm ownership by clicking the verification link below.</p>
-
-    <p><strong>After clicking the verification link, please return to your dashboard to confirm your email is verified and ready to use.</strong></p>
-
-    <hr />
-    <p><small>This verification ensures you own this email address and can send newsletters from it.</small></p>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Verify your sender email</title>
+  </head>
+  <body style="margin:0; padding:0; background-color:#f4f5f7; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif; color:#1f2933;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#f4f5f7; padding:32px 0;">
+      <tr>
+        <td align="center">
+          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:560px; background-color:#ffffff; border-radius:12px; overflow:hidden; box-shadow:0 1px 3px rgba(0,0,0,0.08);">
+            <tr>
+              <td style="background-color:#4f46e5; padding:24px 32px;">
+                <span style="color:#ffffff; font-size:18px; font-weight:600; letter-spacing:0.2px;">Newsletter Service</span>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:32px;">
+                <h1 style="margin:0 0 16px; font-size:22px; font-weight:600; color:#111827;">Verify your sender email</h1>
+                <p style="margin:0 0 16px; font-size:15px; line-height:1.6; color:#374151;">Hi there,</p>
+                <p style="margin:0 0 16px; font-size:15px; line-height:1.6; color:#374151;">
+                  You're adding a new sender address to your account. To finish setup and start sending newsletters from this address, confirm that you own it by clicking the verification link below.
+                </p>
+                <p style="margin:0 0 16px; font-size:15px; line-height:1.6; color:#374151;">
+                  After verifying, head back to your dashboard &mdash; your sender will show as <strong>verified</strong> and ready to use.
+                </p>
+                <p style="margin:0; font-size:13px; line-height:1.6; color:#6b7280;">
+                  This step confirms you own the address and helps keep your newsletters out of spam folders.
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:0 32px 32px;">
+                <hr style="border:none; border-top:1px solid #e5e7eb; margin:0 0 16px;" />
+                <p style="margin:0; font-size:12px; line-height:1.6; color:#9ca3af;">
+                  You're receiving this email because someone added this address as a sender in Newsletter Service.
+                </p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
   </body>
 </html>"#.trim().to_string()
 }
@@ -281,7 +314,7 @@ mod tests {
         let content = generate_template_content();
         assert!(content.contains("<!DOCTYPE html>"));
         assert!(content.contains("Newsletter Service"));
-        assert!(content.contains("Verify Your Sender Email"));
+        assert!(content.contains("Verify your sender email"));
         assert!(content.contains("verification link"));
     }
 
@@ -289,9 +322,11 @@ mod tests {
     fn test_template_content_structure() {
         let content = generate_template_content();
         assert!(content.starts_with("<!DOCTYPE html>"));
-        assert!(content.contains("<h1>"));
-        assert!(content.contains("<h2>"));
-        assert!(content.contains("<p>"));
+        // Tags carry inline styles, so match on the opening tag prefix.
+        assert!(content.contains("<html"));
+        assert!(content.contains("<body"));
+        assert!(content.contains("<h1"));
+        assert!(content.contains("<p"));
         assert!(content.contains("</html>"));
     }
 
@@ -300,12 +335,12 @@ mod tests {
         let content = generate_template_content();
         // Verify key messaging elements
         assert!(content.contains("adding a new sender address"));
-        assert!(content.contains("confirm ownership"));
-        assert!(content.contains("return to your dashboard"));
-        // Verify HTML structure is valid
-        assert_eq!(content.matches("<html>").count(), 1);
+        assert!(content.contains("confirm that you own"));
+        assert!(content.contains("dashboard"));
+        // Verify HTML structure is valid (single, balanced html/body wrappers)
+        assert_eq!(content.matches("<html").count(), 1);
         assert_eq!(content.matches("</html>").count(), 1);
-        assert_eq!(content.matches("<body>").count(), 1);
+        assert_eq!(content.matches("<body").count(), 1);
         assert_eq!(content.matches("</body>").count(), 1);
     }
 

--- a/functions/src/senders/bootstrap-verification-template.rs
+++ b/functions/src/senders/bootstrap-verification-template.rs
@@ -214,7 +214,10 @@ async fn create_template(
         .failure_redirection_url(failure_url)
         .send()
         .await
-        .map_err(|e| format!("Failed to create template: {}", e))?;
+        // Debug formatting surfaces the underlying SES service message
+        // (e.g. "Disallowed tags / attributes"); Display alone just says
+        // "service error".
+        .map_err(|e| format!("Failed to create template: {:?}", e))?;
 
     Ok(())
 }
@@ -238,27 +241,29 @@ async fn update_template(
         .failure_redirection_url(failure_url)
         .send()
         .await
-        .map_err(|e| format!("Failed to update template: {}", e))?;
+        // Debug formatting surfaces the underlying SES service message
+        // (e.g. "Disallowed tags / attributes"); Display alone just says
+        // "service error".
+        .map_err(|e| format!("Failed to update template: {:?}", e))?;
 
     Ok(())
 }
 
 fn generate_template_content() -> String {
-    // Note: Amazon SES automatically appends the verification link and a
-    // standard "If you didn't request this" disclaimer beneath this content,
-    // so the template itself focuses on branding and clear instructions.
+    // Notes on SES custom verification email templates:
+    // - SES automatically appends the verification link and a standard
+    //   "If you didn't request this" disclaimer beneath this content, so the
+    //   template focuses on branding and clear instructions.
+    // - SES rejects certain tags/attributes. Confirmed disallowed and avoided
+    //   here: <meta>, <title> (and therefore <head>); and the attributes
+    //   role, cellpadding, cellspacing, align. All styling must be inline CSS.
     r#"<!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Verify your sender email</title>
-  </head>
   <body style="margin:0; padding:0; background-color:#f4f5f7; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif; color:#1f2933;">
-    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#f4f5f7; padding:32px 0;">
+    <table style="width:100%; border-collapse:collapse; background-color:#f4f5f7;">
       <tr>
-        <td align="center">
-          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:560px; background-color:#ffffff; border-radius:12px; overflow:hidden; box-shadow:0 1px 3px rgba(0,0,0,0.08);">
+        <td style="padding:32px 16px; text-align:center;">
+          <table style="width:100%; max-width:560px; margin:0 auto; border-collapse:collapse; background-color:#ffffff; border-radius:12px; overflow:hidden; box-shadow:0 1px 3px rgba(0,0,0,0.08); text-align:left;">
             <tr>
               <td style="background-color:#4f46e5; padding:24px 32px;">
                 <span style="color:#ffffff; font-size:18px; font-weight:600; letter-spacing:0.2px;">Newsletter Service</span>

--- a/template.yaml
+++ b/template.yaml
@@ -3863,13 +3863,24 @@ Resources:
             - HasVerifiedFromEmail
             - !Ref VerifiedFromEmail
             - !Sub "noreply@${DomainName}"
+          # Where SES sends the browser after the verification link is clicked.
+          # Without these, SES falls back to its default (the AWS SES product page).
+          VERIFY_SUCCESS_URL: !If
+            - DeployFrontendCustomDomain
+            - !Sub "https://${FrontendCustomDomain}/verify-sender?status=success"
+            - !Sub "https://${FrontendDistribution.DomainName}/verify-sender?status=success"
+          VERIFY_FAILURE_URL: !If
+            - DeployFrontendCustomDomain
+            - !Sub "https://${FrontendCustomDomain}/verify-sender?status=failed"
+            - !Sub "https://${FrontendDistribution.DomainName}/verify-sender?status=failed"
 
   BootstrapVerificationTemplate:
     Type: AWS::CloudFormation::CustomResource
     Properties:
       ServiceToken: !GetAtt BootstrapVerificationTemplateFunction.Arn
-      # Force update on every deployment by including a timestamp-like value
-      Version: !Sub "${AWS::StackName}-${Environment}"
+      # Bump this value to force the custom resource to re-run and re-apply the
+      # SES template (content + success/failure redirect URLs) on deploy.
+      Version: !Sub "${AWS::StackName}-${Environment}-v2"
 
   CheckSenderStatusAutomaticallyFunction:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
## Summary

Fixes three issues in the **add sender → email verification** flow, plus a cleanup of the landing page.

### 1. `GET /api/senders/{id}/status` returned 405 Method Not Allowed
The dashboard's "refresh status" button (`SenderEmailList.handleRefreshStatus` → `senderService.getSenderStatus`) and the OpenAPI spec both define this endpoint as **GET**, but the Rust router only registered the route for **PUT**. Because API Gateway proxies everything to the Lambda, the GET reached the router, matched no route, and fell through to the "valid path, unsupported method → 405" arm.
- **Fix:** switch the `/senders/{id}/status` route from `PUT` to `GET` in `router.rs`.

### 2. Clicking the verification link redirected to the AWS SES product page
The verification email is an SES *custom verification email template*. SES redirects the browser to a configured success/failure URL after the link is clicked. Those come from `VERIFY_SUCCESS_URL` / `VERIFY_FAILURE_URL`, which were **never set in `template.yaml`**, so the bootstrap function fell back to its default of `https://aws.amazon.com/ses/`. Verification was succeeding — users just landed on Amazon's marketing page.
- **Fix:** set `VERIFY_SUCCESS_URL` / `VERIFY_FAILURE_URL` to `https://<frontend>/verify-sender?status=success|failed` (reusing the existing `DeployFrontendCustomDomain` `!If` pattern), and **bump the custom-resource `Version` to `-v2`** so CloudFormation re-runs the bootstrap and re-applies the template + URLs on deploy.

### 3. The verification email was unprofessional
- **Fix:** rewrote `generate_template_content()` as a clean, branded, email-safe layout (table + inline CSS, header bar, clear copy, footer).

### 4. `/verify-sender` landing page
The page expected an obsolete `token` and showed a "deprecated verification method" error. Reworked it to read the `?status=success|failed` param SES now redirects with, rendering a proper verified / failed / info state with matching toasts and a button to sender settings.

## Why a reviewer should care
- The `Version: -v2` bump is **required** — the SES template is managed by a CloudFormation custom resource that only re-runs when its properties change. Without it, the new content/redirect URLs would not deploy.
- The raw `email-verification.us-east-1.amazonaws.com/...` link in the email is **appended by SES itself** and cannot be styled into a button — that's inherent to SES custom verification templates.
- Changes take effect on the **next deploy**.

## Testing
- `cargo test --bin api-router` → 62 passed
- `cargo test --bin bootstrap-verification-template` → 10 passed (template assertions updated to match new markup)
- `npm run type-check` (dashboard-ui) → clean
- `senderService` vitest suite → 27 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)