### PR TITLE
Add send-test-email functionality to sender page

### DIFF
--- a/dashboard-ui/src/components/senders/SenderEmailList.tsx
+++ b/dashboard-ui/src/components/senders/SenderEmailList.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
 import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { Modal, ModalHeader, ModalTitle, ModalDescription, ModalContent, ModalFooter } from '@/components/ui/Modal';
 import { useConfirmationDialog } from '@/components/ui/ConfirmationDialog';
 import { useToast } from '@/components/ui/Toast';
 import { ErrorDisplay } from '@/components/ui/ErrorDisplay';
@@ -16,6 +18,7 @@ import {
   EnvelopeIcon,
   GlobeAltIcon,
   ArrowPathIcon,
+  PaperAirplaneIcon,
 } from '@heroicons/react/24/outline';
 import { StarIcon as StarIconSolid } from '@heroicons/react/24/solid';
 import { cn } from '@/utils/cn';
@@ -39,8 +42,51 @@ export const SenderEmailList: React.FC<SenderEmailListProps> = ({
   const [updatingId, setUpdatingId] = useState<string | null>(null);
   const [refreshingId, setRefreshingId] = useState<string | null>(null);
   const [operationErrors, setOperationErrors] = useState<Record<string, string>>({});
+  const [testEmailSender, setTestEmailSender] = useState<SenderEmail | null>(null);
+  const [testRecipient, setTestRecipient] = useState('');
+  const [testError, setTestError] = useState<string | null>(null);
+  const [sendingTest, setSendingTest] = useState(false);
   const { showConfirmation, ConfirmationDialog } = useConfirmationDialog();
   const { addToast } = useToast();
+
+  const openTestEmailModal = (sender: SenderEmail) => {
+    setTestEmailSender(sender);
+    setTestRecipient('');
+    setTestError(null);
+  };
+
+  const closeTestEmailModal = () => {
+    if (sendingTest) return;
+    setTestEmailSender(null);
+    setTestRecipient('');
+    setTestError(null);
+  };
+
+  const handleSendTestEmail = async () => {
+    if (!testEmailSender) return;
+
+    setTestError(null);
+    setSendingTest(true);
+    try {
+      const response = await senderService.sendTestEmail(testEmailSender.senderId, testRecipient);
+
+      if (response.success) {
+        addToast({
+          title: 'Test email sent',
+          message: `A test email from ${testEmailSender.email} is on its way to ${testRecipient.trim()}`,
+          type: 'success'
+        });
+        setTestEmailSender(null);
+        setTestRecipient('');
+      } else {
+        setTestError(getUserFriendlyErrorMessage(response, 'sender'));
+      }
+    } catch (error) {
+      setTestError(getUserFriendlyErrorMessage(error, 'sender'));
+    } finally {
+      setSendingTest(false);
+    }
+  };
 
   const getStatusIcon = (status: SenderEmail['verificationStatus']) => {
     switch (status) {
@@ -392,6 +438,18 @@ export const SenderEmailList: React.FC<SenderEmailListProps> = ({
                   </Button>
                 )}
 
+                {/* Send Test Email Button - for verified senders */}
+                {sender.verificationStatus === 'verified' && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => openTestEmailModal(sender)}
+                    title="Send a test email"
+                  >
+                    <PaperAirplaneIcon className="w-4 h-4" />
+                  </Button>
+                )}
+
                 {/* Set as Default Button */}
                 {!sender.isDefault && sender.verificationStatus === 'verified' && (
                   <Button
@@ -497,6 +555,52 @@ export const SenderEmailList: React.FC<SenderEmailListProps> = ({
       ))}
 
       <ConfirmationDialog />
+
+      {/* Send Test Email Modal */}
+      <Modal isOpen={!!testEmailSender} onClose={closeTestEmailModal} size="md">
+        <ModalHeader onClose={closeTestEmailModal}>
+          <ModalTitle>Send a test email</ModalTitle>
+          <ModalDescription>
+            {testEmailSender
+              ? `Send a test email from ${testEmailSender.email} to confirm everything is working.`
+              : ''}
+          </ModalDescription>
+        </ModalHeader>
+        <ModalContent>
+          <form
+            onSubmit={(event) => {
+              event.preventDefault();
+              handleSendTestEmail();
+            }}
+          >
+            <Input
+              type="email"
+              label="Recipient email address"
+              placeholder="you@example.com"
+              value={testRecipient}
+              onChange={(event) => {
+                setTestRecipient(event.target.value);
+                if (testError) setTestError(null);
+              }}
+              error={testError ?? undefined}
+              leftIcon={<EnvelopeIcon />}
+              disabled={sendingTest}
+            />
+          </form>
+        </ModalContent>
+        <ModalFooter>
+          <Button variant="outline" onClick={closeTestEmailModal} disabled={sendingTest}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSendTestEmail}
+            isLoading={sendingTest}
+            disabled={sendingTest || !testRecipient.trim()}
+          >
+            Send test email
+          </Button>
+        </ModalFooter>
+      </Modal>
     </div>
   );
 };

--- a/dashboard-ui/src/services/__tests__/senderService.test.ts
+++ b/dashboard-ui/src/services/__tests__/senderService.test.ts
@@ -149,6 +149,46 @@ describe('SenderService', () => {
     });
   });
 
+  describe('sendTestEmail', () => {
+    it('calls API client with sender ID and trimmed recipient', async () => {
+      mockApiClient.post.mockResolvedValue({
+        success: true,
+        data: { messageId: 'msg-1', recipientEmail: 'to@example.com', message: 'Test email sent successfully' }
+      });
+
+      const result = await senderService.sendTestEmail('sender-123', '  to@example.com  ');
+
+      expect(mockApiClient.post).toHaveBeenCalledWith('/senders/sender-123/test', {
+        recipientEmail: 'to@example.com'
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('returns error when sender ID is missing', async () => {
+      const result = await senderService.sendTestEmail('', 'to@example.com');
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('MISSING_SENDER_ID');
+      expect(mockApiClient.post).not.toHaveBeenCalled();
+    });
+
+    it('returns error when recipient is empty', async () => {
+      const result = await senderService.sendTestEmail('sender-123', '   ');
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('MISSING_RECIPIENT');
+      expect(mockApiClient.post).not.toHaveBeenCalled();
+    });
+
+    it('returns error for invalid recipient email', async () => {
+      const result = await senderService.sendTestEmail('sender-123', 'not-an-email');
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('INVALID_EMAIL');
+      expect(mockApiClient.post).not.toHaveBeenCalled();
+    });
+  });
+
   describe('verifyDomain', () => {
     it('calls API client with domain data', async () => {
       const domainData = { domain: 'example.com' };

--- a/dashboard-ui/src/services/senderService.ts
+++ b/dashboard-ui/src/services/senderService.ts
@@ -9,6 +9,7 @@ import type {
   UpdateSenderRequest,
   VerifyDomainRequest,
   GetSendersResponse,
+  SendTestEmailResponse,
 } from '@/types/api';
 
 /**
@@ -64,6 +65,42 @@ export class SenderService {
    */
   async getSenderStatus(senderId: string): Promise<ApiResponse<SenderEmail>> {
     return apiClient.get<SenderEmail>(`/senders/${senderId}/status`);
+  }
+
+  /**
+   * Send a test email from a verified sender to an address of the user's choosing
+   * @param senderId - The sender ID to send the test email from
+   * @param recipientEmail - The email address to send the test email to
+   */
+  async sendTestEmail(senderId: string, recipientEmail: string): Promise<ApiResponse<SendTestEmailResponse>> {
+    if (!senderId) {
+      return {
+        success: false,
+        error: 'Sender ID is required',
+        errorCode: 'MISSING_SENDER_ID'
+      };
+    }
+
+    const trimmedRecipient = recipientEmail.trim();
+    if (!trimmedRecipient) {
+      return {
+        success: false,
+        error: 'Recipient email address is required',
+        errorCode: 'MISSING_RECIPIENT'
+      };
+    }
+
+    if (!this.validateEmail(trimmedRecipient)) {
+      return {
+        success: false,
+        error: 'Please enter a valid email address',
+        errorCode: 'INVALID_EMAIL'
+      };
+    }
+
+    return apiClient.post<SendTestEmailResponse>(`/senders/${senderId}/test`, {
+      recipientEmail: trimmedRecipient
+    });
   }
 
   /**

--- a/dashboard-ui/src/types/api.ts
+++ b/dashboard-ui/src/types/api.ts
@@ -222,6 +222,16 @@ export interface VerifyDomainRequest {
   domain: string;
 }
 
+export interface SendTestEmailRequest {
+  recipientEmail: string;
+}
+
+export interface SendTestEmailResponse {
+  messageId: string;
+  recipientEmail: string;
+  message: string;
+}
+
 export interface GetSendersResponse {
   senders: SenderEmail[];
   tierLimits: TierLimits;

--- a/functions/src/api/controllers/senders.rs
+++ b/functions/src/api/controllers/senders.rs
@@ -131,6 +131,21 @@ struct UpdateSenderResponse {
     failure_reason: Option<String>,
 }
 
+#[derive(Deserialize)]
+struct SendTestEmailRequest {
+    #[serde(rename = "recipientEmail")]
+    recipient_email: String,
+}
+
+#[derive(Serialize)]
+struct SendTestEmailResponse {
+    #[serde(rename = "messageId")]
+    message_id: String,
+    #[serde(rename = "recipientEmail")]
+    recipient_email: String,
+    message: String,
+}
+
 #[derive(Debug, Serialize)]
 struct GetSenderStatusResponse {
     #[serde(rename = "senderId")]
@@ -843,6 +858,145 @@ async fn update_sender_in_db(
         .map_err(|e| AppError::InternalError(format!("Failed to deserialize sender: {}", e)))?;
 
     Ok(updated_sender)
+}
+
+pub async fn send_test_email(
+    event: Request,
+    sender_id: Option<String>,
+) -> Result<Response<Body>, Error> {
+    match handle_send_test_email(event, sender_id).await {
+        Ok(response) => Ok(response),
+        Err(e) => Ok(response::format_error_response(&e)),
+    }
+}
+
+async fn handle_send_test_email(
+    event: Request,
+    sender_id: Option<String>,
+) -> Result<Response<Body>, AppError> {
+    let user_context = auth::get_user_context(&event)?;
+    let tenant_id = user_context
+        .tenant_id
+        .ok_or_else(|| AppError::Unauthorized("Tenant access required".to_string()))?;
+
+    let sender_id =
+        sender_id.ok_or_else(|| AppError::BadRequest("Sender ID is required".to_string()))?;
+
+    let body: SendTestEmailRequest = serde_json::from_slice(event.body())
+        .map_err(|e| AppError::BadRequest(format!("Invalid JSON: {}", e)))?;
+
+    let recipient_email = body.recipient_email.trim().to_string();
+    validation::validate_email(&recipient_email)?;
+
+    let sender = get_sender_by_id(&tenant_id, &sender_id).await?;
+
+    if sender.verification_status != VerificationStatus::Verified {
+        return Err(AppError::BadRequest(
+            "Sender email must be verified before sending a test email".to_string(),
+        ));
+    }
+
+    let message_id = send_test_email_via_ses(&sender, &recipient_email).await?;
+
+    tracing::info!(
+        tenant_id = %tenant_id,
+        sender_id = %sender.sender_id,
+        recipient = %recipient_email,
+        message_id = %message_id,
+        "Test email sent"
+    );
+
+    response::format_response(
+        200,
+        SendTestEmailResponse {
+            message_id,
+            recipient_email,
+            message: "Test email sent successfully".to_string(),
+        },
+    )
+}
+
+async fn send_test_email_via_ses(
+    sender: &SenderRecord,
+    recipient_email: &str,
+) -> Result<String, AppError> {
+    use aws_sdk_sesv2::types::{Body as SesBody, Content, Destination, EmailContent, Message};
+
+    let ses = aws_clients::get_ses_client().await;
+
+    let from_address = match &sender.name {
+        Some(name) if !name.trim().is_empty() => format!("{} <{}>", name.trim(), sender.email),
+        _ => sender.email.clone(),
+    };
+
+    let sender_label = sender.name.clone().unwrap_or_else(|| sender.email.clone());
+
+    let html_body = format!(
+        "<html><body style=\"font-family: Arial, sans-serif; color: #1f2937;\">\
+         <h2>It works! 🎉</h2>\
+         <p>This is a test email sent from your verified sender address \
+         <strong>{email}</strong>.</p>\
+         <p>If you received this message, your sender is configured correctly and \
+         ready to send newsletters.</p>\
+         <hr style=\"border: none; border-top: 1px solid #e5e7eb; margin: 24px 0;\" />\
+         <p style=\"font-size: 12px; color: #6b7280;\">Sent by {label} via your newsletter service.</p>\
+         </body></html>",
+        email = sender.email,
+        label = sender_label
+    );
+
+    let text_body = format!(
+        "It works!\n\nThis is a test email sent from your verified sender address {email}.\n\n\
+         If you received this message, your sender is configured correctly and ready to send newsletters.\n\n\
+         Sent by {label} via your newsletter service.",
+        email = sender.email,
+        label = sender_label
+    );
+
+    let subject = Content::builder()
+        .data("Test email from your newsletter sender")
+        .charset("UTF-8")
+        .build()
+        .map_err(|e| AppError::InternalError(format!("Failed to build subject: {}", e)))?;
+
+    let html_content = Content::builder()
+        .data(html_body)
+        .charset("UTF-8")
+        .build()
+        .map_err(|e| AppError::InternalError(format!("Failed to build HTML body: {}", e)))?;
+
+    let text_content = Content::builder()
+        .data(text_body)
+        .charset("UTF-8")
+        .build()
+        .map_err(|e| AppError::InternalError(format!("Failed to build text body: {}", e)))?;
+
+    let message = Message::builder()
+        .subject(subject)
+        .body(SesBody::builder().html(html_content).text(text_content).build())
+        .build();
+
+    let destination = Destination::builder()
+        .to_addresses(recipient_email)
+        .build();
+
+    let mut send_command = ses
+        .send_email()
+        .from_email_address(from_address)
+        .destination(destination)
+        .content(EmailContent::builder().simple(message).build());
+
+    if let Ok(config_set) = std::env::var("SES_CONFIGURATION_SET") {
+        if !config_set.is_empty() {
+            send_command = send_command.configuration_set_name(config_set);
+        }
+    }
+
+    let result = send_command.send().await.map_err(|e| {
+        AppError::AwsError(format!("SES send test email failed: {}", e))
+    })?;
+
+    Ok(result.message_id().unwrap_or_default().to_string())
 }
 
 pub async fn delete_sender(

--- a/functions/src/api/router.rs
+++ b/functions/src/api/router.rs
@@ -52,6 +52,10 @@ pub async fn route_request(event: Request) -> Result<Response<Body>, Error> {
         // Senders endpoints
         (&Method::GET, "/senders") => senders::list_senders(event).await,
         (&Method::POST, "/senders") => senders::create_sender(event).await,
+        (&Method::POST, path) if path.starts_with("/senders/") && path.ends_with("/test") => {
+            let sender_id = extract_sender_id_before(path, "/test");
+            senders::send_test_email(event, sender_id).await
+        }
         (&Method::GET, path) if path.starts_with("/senders/") && path.ends_with("/status") => {
             let sender_id = extract_sender_id(path);
             senders::get_sender_status(event, sender_id).await
@@ -360,6 +364,13 @@ fn extract_sender_id(path: &str) -> Option<String> {
         .map(|s| s.to_string())
 }
 
+fn extract_sender_id_before(path: &str, suffix: &str) -> Option<String> {
+    path.strip_prefix("/senders/")
+        .and_then(|s| s.strip_suffix(suffix))
+        .filter(|s| !s.is_empty() && *s != "domain")
+        .map(|s| s.to_string())
+}
+
 fn extract_domain(path: &str) -> Option<String> {
     path.strip_prefix("/senders/domain/")
         .filter(|s| !s.is_empty())
@@ -475,6 +486,24 @@ mod tests {
     #[test]
     fn test_extract_sender_id_domain_path() {
         let result = extract_sender_id("/senders/domain");
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_extract_sender_id_before_test_suffix() {
+        let result = extract_sender_id_before("/senders/abc-123/test", "/test");
+        assert_eq!(result, Some("abc-123".to_string()));
+    }
+
+    #[test]
+    fn test_extract_sender_id_before_test_empty() {
+        let result = extract_sender_id_before("/senders//test", "/test");
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_extract_sender_id_before_test_rejects_domain() {
+        let result = extract_sender_id_before("/senders/domain/test", "/test");
         assert_eq!(result, None);
     }
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1028,6 +1028,55 @@ paths:
         "500":
           $ref: "#/components/responses/UnknownError"
 
+  /senders/{senderId}/test:
+    parameters:
+      - name: senderId
+        in: path
+        required: true
+        schema:
+          type: string
+        description: The sender ID
+    post:
+      summary: Send a test email
+      description: Sends a test email from a verified sender address to a recipient of the user's choosing
+      tags:
+        - Senders
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - recipientEmail
+              properties:
+                recipientEmail:
+                  type: string
+                  format: email
+                  description: The email address to send the test email to
+      responses:
+        "200":
+          description: Test email sent successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  messageId:
+                    type: string
+                  recipientEmail:
+                    type: string
+                  message:
+                    type: string
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/UnknownError"
+
   /senders/verify-domain:
     post:
       summary: Initiate domain verification


### PR DESCRIPTION
Lets users send a test email from a verified sender address to a
recipient of their choosing, directly from the Sender Email Setup page.

Backend:
- POST /senders/{senderId}/test endpoint that validates the recipient,
  requires the sender to be verified, and sends a test email via SESv2
  (honoring SES_CONFIGURATION_SET when configured)
- Router wiring + helper and unit tests
- OpenAPI documentation for the new endpoint

Frontend:
- senderService.sendTestEmail() with client-side validation
- "Send test email" action on verified senders that opens a modal to
  enter the recipient address, with success/error toasts
- Types and unit tests