### PR TITLE
Add template management (CRUD)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ aws-smithy-types = { workspace = true }
 aws_lambda_events = { workspace = true }
 base64 = { workspace = true }
 chrono = { workspace = true }
+handlebars = { workspace = true }
 hex = { workspace = true }
 jsonwebtoken = { workspace = true }
 lambda_http = { workspace = true }
@@ -130,3 +131,4 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 aws_lambda_events = "0.15"
 jsonwebtoken = "9"
 serial_test = "3"
+handlebars = "6"

--- a/dashboard-ui/src/App.tsx
+++ b/dashboard-ui/src/App.tsx
@@ -23,6 +23,8 @@ import {
   LazySubscribersPage,
   LazySponsorDirectoryPage,
   LazySponsorDetailPage,
+  LazyTemplatesListPage,
+  LazyTemplateFormPage,
   preloadCriticalRoutes
 } from '@/utils/lazyImports';
 import { AppShell } from '@/components/layout/AppShell';
@@ -349,6 +351,55 @@ function App() {
                             <AppShell>
                               <PageLoader>
                                 <LazyIssueFormPage />
+                              </PageLoader>
+                            </AppShell>
+                          </OnboardingGuard>
+                        </ProtectedRoute>
+                      </RouteErrorBoundary>
+                    }
+                  />
+
+                  <Route
+                    path="/templates"
+                    element={
+                      <RouteErrorBoundary routeName="Templates">
+                        <ProtectedRoute>
+                          <OnboardingGuard>
+                            <AppShell>
+                              <PageLoader>
+                                <LazyTemplatesListPage />
+                              </PageLoader>
+                            </AppShell>
+                          </OnboardingGuard>
+                        </ProtectedRoute>
+                      </RouteErrorBoundary>
+                    }
+                  />
+                  <Route
+                    path="/templates/new"
+                    element={
+                      <RouteErrorBoundary routeName="Create Template">
+                        <ProtectedRoute>
+                          <OnboardingGuard>
+                            <AppShell>
+                              <PageLoader>
+                                <LazyTemplateFormPage />
+                              </PageLoader>
+                            </AppShell>
+                          </OnboardingGuard>
+                        </ProtectedRoute>
+                      </RouteErrorBoundary>
+                    }
+                  />
+                  <Route
+                    path="/templates/:id/edit"
+                    element={
+                      <RouteErrorBoundary routeName="Edit Template">
+                        <ProtectedRoute>
+                          <OnboardingGuard>
+                            <AppShell>
+                              <PageLoader>
+                                <LazyTemplateFormPage />
                               </PageLoader>
                             </AppShell>
                           </OnboardingGuard>

--- a/dashboard-ui/src/components/layout/AppHeader.tsx
+++ b/dashboard-ui/src/components/layout/AppHeader.tsx
@@ -16,7 +16,7 @@ import {
   SunIcon,
   UserGroupIcon
 } from '@heroicons/react/24/outline';
-import { FileText } from 'lucide-react';
+import { FileText, LayoutTemplate } from 'lucide-react';
 import { useTheme } from '@/hooks/useTheme';
 import { BRAND } from '@/constants/brand';
 
@@ -27,6 +27,7 @@ export const AppHeader: React.FC = () => {
 
   const baseNavigation = [
     { name: 'Issues', href: '/issues', icon: FileText, preloadKey: 'issues' },
+    { name: 'Templates', href: '/templates', icon: LayoutTemplate, preloadKey: 'templates' },
     { name: 'Segments', href: '/segments', icon: UserGroupIcon, preloadKey: 'segments' },
     { name: 'Brand', href: '/brand', icon: BuildingOfficeIcon, preloadKey: 'brand' },
     { name: 'Profile', href: '/profile', icon: UserIcon, preloadKey: 'profile' },

--- a/dashboard-ui/src/components/layout/MobileNavigation.tsx
+++ b/dashboard-ui/src/components/layout/MobileNavigation.tsx
@@ -15,7 +15,7 @@ import {
   Bars3Icon,
   XMarkIcon
 } from '@heroicons/react/24/outline';
-import { FileText } from 'lucide-react';
+import { FileText, LayoutTemplate } from 'lucide-react';
 import { cn } from '../../utils/cn';
 
 export const MobileNavigation: React.FC = () => {
@@ -28,6 +28,7 @@ export const MobileNavigation: React.FC = () => {
 
   const baseNavigation = [
     { name: 'Issues', href: '/issues', icon: FileText, preloadKey: 'issues' },
+    { name: 'Templates', href: '/templates', icon: LayoutTemplate, preloadKey: 'templates' },
     { name: 'Brand', href: '/brand', icon: BuildingOfficeIcon, preloadKey: 'brand' },
     { name: 'Profile', href: '/profile', icon: UserIcon, preloadKey: 'profile' },
     { name: 'Sender Emails', href: '/senders', icon: EnvelopeIcon, preloadKey: 'senders' },

--- a/dashboard-ui/src/components/layout/__tests__/AppSidebar.test.tsx
+++ b/dashboard-ui/src/components/layout/__tests__/AppSidebar.test.tsx
@@ -31,17 +31,18 @@ describe('AppSidebar', () => {
   // ---- Requirement 2.2: Renders exactly 5 nav items with icons ----
 
   describe('nav items', () => {
-    it('renders exactly 6 navigation links', () => {
+    it('renders exactly 7 navigation links', () => {
       renderSidebar();
       const nav = screen.getByRole('navigation', { name: 'Main navigation' });
       const links = nav.querySelectorAll('a');
-      expect(links).toHaveLength(6);
+      expect(links).toHaveLength(7);
     });
 
     it('renders the correct nav item labels', () => {
       renderSidebar();
       expect(screen.getByText('Dashboard')).toBeInTheDocument();
       expect(screen.getByText('Issues')).toBeInTheDocument();
+      expect(screen.getByText('Templates')).toBeInTheDocument();
       expect(screen.getByText('Subscribers')).toBeInTheDocument();
       expect(screen.getByText('Sponsors')).toBeInTheDocument();
       expect(screen.getByText('Brand')).toBeInTheDocument();
@@ -52,7 +53,7 @@ describe('AppSidebar', () => {
       renderSidebar();
       const nav = screen.getByRole('navigation', { name: 'Main navigation' });
       const icons = nav.querySelectorAll('svg[aria-hidden="true"]');
-      expect(icons).toHaveLength(6);
+      expect(icons).toHaveLength(7);
     });
   });
 

--- a/dashboard-ui/src/components/layout/__tests__/MobileDrawerParity.property.test.ts
+++ b/dashboard-ui/src/components/layout/__tests__/MobileDrawerParity.property.test.ts
@@ -63,6 +63,7 @@ describe('Mobile Drawer Parity - Property-Based Tests', () => {
           expect(drawerNavNames).toEqual([
             'Dashboard',
             'Issues',
+            'Templates',
             'Subscribers',
             'Sponsors',
             'Brand',

--- a/dashboard-ui/src/components/layout/sidebarNav.ts
+++ b/dashboard-ui/src/components/layout/sidebarNav.ts
@@ -4,7 +4,7 @@ import {
   CurrencyDollarIcon,
   UserGroupIcon,
 } from '@heroicons/react/24/outline';
-import { FileText, Building2 } from 'lucide-react';
+import { FileText, Building2, LayoutTemplate } from 'lucide-react';
 
 export interface SidebarNavItem {
   name: string;
@@ -17,6 +17,7 @@ export interface SidebarNavItem {
 export const NAV_ITEMS: SidebarNavItem[] = [
   { name: 'Dashboard', href: '/', icon: HomeIcon, preloadKey: 'dashboard', matchPaths: ['/'] },
   { name: 'Issues', href: '/issues', icon: FileText, preloadKey: 'issues', matchPaths: ['/issues'] },
+  { name: 'Templates', href: '/templates', icon: LayoutTemplate, preloadKey: 'templates', matchPaths: ['/templates'] },
   { name: 'Subscribers', href: '/subscribers', icon: UserGroupIcon, preloadKey: 'subscribers', matchPaths: ['/subscribers', '/segments'] },
   { name: 'Sponsors', href: '/sponsors', icon: Building2, preloadKey: 'sponsors', matchPaths: ['/sponsors'] },
   { name: 'Brand', href: '/brand', icon: BuildingOfficeIcon, preloadKey: 'brand', matchPaths: ['/brand'] },

--- a/dashboard-ui/src/hooks/usePageMeta.ts
+++ b/dashboard-ui/src/hooks/usePageMeta.ts
@@ -13,6 +13,7 @@ export interface PageMeta {
 export const ROUTE_META: Record<string, { title: string; parent?: { label: string; href: string } }> = {
   '/': { title: 'Dashboard' },
   '/issues': { title: 'Issues' },
+  '/templates': { title: 'Templates' },
   '/subscribers': { title: 'Subscribers' },
   '/brand': { title: 'Brand' },
   '/sponsors': { title: 'Sponsors' },
@@ -67,6 +68,28 @@ export function usePageMeta(dynamicTitle?: string): PageMeta {
       breadcrumb: [
         { label: 'Issues', href: '/issues' },
         { label: title },
+      ],
+    };
+  }
+
+  // Dynamic route: /templates/new
+  if (pathname === '/templates/new') {
+    return {
+      title: 'New Template',
+      breadcrumb: [
+        { label: 'Templates', href: '/templates' },
+        { label: 'New Template' },
+      ],
+    };
+  }
+
+  // Dynamic route: /templates/:id/edit
+  if (params.id && pathname === `/templates/${params.id}/edit`) {
+    return {
+      title: 'Edit Template',
+      breadcrumb: [
+        { label: 'Templates', href: '/templates' },
+        { label: 'Edit Template' },
       ],
     };
   }

--- a/dashboard-ui/src/pages/templates/TemplateFormPage.tsx
+++ b/dashboard-ui/src/pages/templates/TemplateFormPage.tsx
@@ -1,0 +1,197 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { TextArea } from '@/components/ui/TextArea';
+import { useToast } from '@/components/ui/Toast';
+import { ErrorDisplay } from '@/components/ui/ErrorDisplay';
+import { LoadingSpinner } from '@/components/ui/LoadingStates';
+import { templateService } from '@/services/templateService';
+import { getUserFriendlyErrorMessage } from '@/utils/errorHandling';
+import type { CreateTemplateRequest } from '@/types/api';
+import { ArrowLeftIcon } from '@heroicons/react/24/outline';
+
+export function TemplateFormPage() {
+  const navigate = useNavigate();
+  const { id } = useParams<{ id: string }>();
+  const isEditMode = Boolean(id);
+  const { addToast } = useToast();
+
+  const [name, setName] = useState('');
+  const [category, setCategory] = useState('');
+  const [description, setDescription] = useState('');
+  const [content, setContent] = useState('');
+  const [sampleDataText, setSampleDataText] = useState('');
+
+  const [isLoading, setIsLoading] = useState(isEditMode);
+  const [isSaving, setIsSaving] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [fieldError, setFieldError] = useState<string | null>(null);
+
+  const loadTemplate = useCallback(async (templateId: string) => {
+    setIsLoading(true);
+    setLoadError(null);
+    const response = await templateService.getTemplate(templateId);
+    if (response.success && response.data) {
+      const t = response.data;
+      setName(t.name);
+      setCategory(t.category ?? '');
+      setDescription(t.description ?? '');
+      setContent(t.content);
+      setSampleDataText(t.sampleData ? JSON.stringify(t.sampleData, null, 2) : '');
+    } else {
+      setLoadError(getUserFriendlyErrorMessage(response, 'template'));
+    }
+    setIsLoading(false);
+  }, []);
+
+  useEffect(() => {
+    if (id) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      loadTemplate(id);
+    }
+  }, [id, loadTemplate]);
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setFieldError(null);
+
+    // Validate sample data is JSON if provided.
+    let sampleData: Record<string, unknown> | undefined;
+    if (sampleDataText.trim()) {
+      try {
+        const parsed = JSON.parse(sampleDataText);
+        if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+          setFieldError('Sample data must be a JSON object');
+          return;
+        }
+        sampleData = parsed as Record<string, unknown>;
+      } catch {
+        setFieldError('Sample data is not valid JSON');
+        return;
+      }
+    }
+
+    const payload: CreateTemplateRequest = {
+      name,
+      content,
+      ...(category.trim() && { category }),
+      ...(description.trim() && { description }),
+      ...(sampleData && { sampleData }),
+    };
+
+    setIsSaving(true);
+    const response = isEditMode && id
+      ? await templateService.updateTemplate(id, payload)
+      : await templateService.createTemplate(payload);
+    setIsSaving(false);
+
+    if (response.success) {
+      addToast({
+        type: 'success',
+        title: isEditMode ? 'Template updated' : 'Template created',
+        message: `${name.trim()} was saved successfully`,
+      });
+      navigate('/templates');
+    } else {
+      setFieldError(getUserFriendlyErrorMessage(response, 'template'));
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-background">
+      <main className="max-w-3xl mx-auto py-6 sm:px-6 lg:px-8">
+        <div className="px-4 py-6 sm:px-0">
+          <button
+            type="button"
+            onClick={() => navigate('/templates')}
+            className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground mb-4"
+          >
+            <ArrowLeftIcon className="w-4 h-4 mr-1" />
+            Back to templates
+          </button>
+
+          <h1 className="text-2xl sm:text-3xl font-bold text-foreground mb-6">
+            {isEditMode ? 'Edit template' : 'New template'}
+          </h1>
+
+          {isLoading ? (
+            <div className="flex items-center gap-3 text-muted-foreground">
+              <LoadingSpinner size="sm" />
+              <span>Loading template…</span>
+            </div>
+          ) : loadError ? (
+            <ErrorDisplay
+              title="Error loading template"
+              message={loadError}
+              severity="error"
+              retryable
+              onRetry={() => id && loadTemplate(id)}
+            />
+          ) : (
+            <form onSubmit={handleSubmit} className="space-y-5">
+              <Input
+                label="Name"
+                placeholder="Weekly newsletter"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                maxLength={100}
+                required
+              />
+
+              <Input
+                label="Category (optional)"
+                placeholder="newsletter"
+                value={category}
+                onChange={(e) => setCategory(e.target.value)}
+                maxLength={50}
+              />
+
+              <Input
+                label="Description (optional)"
+                placeholder="A short description of what this template is for"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                maxLength={500}
+              />
+
+              <TextArea
+                label="Content (Handlebars)"
+                placeholder={'<h1>{{ title }}</h1>\n{{> sponsorBlock }}'}
+                value={content}
+                onChange={(e) => setContent(e.target.value)}
+                rows={16}
+                className="font-mono text-sm"
+                helperText="Handlebars markup. Reference macros (partials) with {{> macroName }}."
+                required
+              />
+
+              <TextArea
+                label="Sample data (optional JSON)"
+                placeholder={'{\n  "title": "Hello world"\n}'}
+                value={sampleDataText}
+                onChange={(e) => setSampleDataText(e.target.value)}
+                rows={6}
+                className="font-mono text-sm"
+                helperText="Default data used to preview this template in the upcoming builder."
+              />
+
+              {fieldError && (
+                <ErrorDisplay title="Could not save template" message={fieldError} severity="error" compact />
+              )}
+
+              <div className="flex items-center justify-end gap-3 pt-2">
+                <Button type="button" variant="outline" onClick={() => navigate('/templates')} disabled={isSaving}>
+                  Cancel
+                </Button>
+                <Button type="submit" isLoading={isSaving} disabled={isSaving}>
+                  {isEditMode ? 'Save changes' : 'Create template'}
+                </Button>
+              </div>
+            </form>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/dashboard-ui/src/pages/templates/TemplatesListPage.tsx
+++ b/dashboard-ui/src/pages/templates/TemplatesListPage.tsx
@@ -1,0 +1,169 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Button } from '@/components/ui/Button';
+import { useToast } from '@/components/ui/Toast';
+import { useConfirmationDialog } from '@/components/ui/ConfirmationDialog';
+import { ErrorDisplay } from '@/components/ui/ErrorDisplay';
+import { EmptyState, SkeletonLoader } from '@/components/ui/LoadingStates';
+import { templateService } from '@/services/templateService';
+import { getUserFriendlyErrorMessage } from '@/utils/errorHandling';
+import type { TemplateSummary } from '@/types/api';
+import {
+  DocumentDuplicateIcon,
+  PlusIcon,
+  PencilSquareIcon,
+  TrashIcon,
+} from '@heroicons/react/24/outline';
+
+export function TemplatesListPage() {
+  const navigate = useNavigate();
+  const { addToast } = useToast();
+  const { showConfirmation, ConfirmationDialog } = useConfirmationDialog();
+
+  const [templates, setTemplates] = useState<TemplateSummary[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  const loadTemplates = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    const response = await templateService.listTemplates();
+    if (response.success && response.data) {
+      setTemplates(response.data.templates);
+    } else {
+      setError(getUserFriendlyErrorMessage(response, 'template'));
+    }
+    setIsLoading(false);
+  }, []);
+
+  useEffect(() => {
+    loadTemplates();
+  }, [loadTemplates]);
+
+  const handleDelete = async (template: TemplateSummary) => {
+    try {
+      await showConfirmation({
+        title: 'Delete Template',
+        description: `Are you sure you want to delete "${template.name}"? This action cannot be undone.`,
+        confirmText: 'Delete Template',
+        type: 'danger',
+        isDestructive: true,
+        onConfirm: async () => {
+          setDeletingId(template.templateId);
+          const response = await templateService.deleteTemplate(template.templateId);
+          if (response.success) {
+            addToast({ type: 'success', title: 'Template deleted', message: `${template.name} was removed` });
+            setTemplates((prev) => prev.filter((t) => t.templateId !== template.templateId));
+          } else {
+            throw new Error(getUserFriendlyErrorMessage(response, 'template'));
+          }
+        },
+      });
+    } catch (err) {
+      addToast({ type: 'error', title: 'Failed to delete template', message: getUserFriendlyErrorMessage(err, 'template') });
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-background">
+      <main className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
+        <div className="px-4 py-6 sm:px-0">
+          {/* Header */}
+          <div className="mb-6 sm:mb-8 flex items-start justify-between gap-4">
+            <div>
+              <h1 className="text-2xl sm:text-3xl font-bold text-foreground">Templates</h1>
+              <p className="text-muted-foreground mt-2 text-sm sm:text-base">
+                Create and manage reusable Handlebars templates for your emails.
+              </p>
+            </div>
+            <Button onClick={() => navigate('/templates/new')}>
+              <PlusIcon className="w-4 h-4 mr-2" />
+              New template
+            </Button>
+          </div>
+
+          {isLoading ? (
+            <SkeletonLoader count={3} />
+          ) : error ? (
+            <ErrorDisplay
+              title="Error loading templates"
+              message={error}
+              severity="error"
+              retryable
+              onRetry={loadTemplates}
+            />
+          ) : templates.length === 0 ? (
+            <EmptyState
+              title="No templates yet"
+              description="Create your first template to start building reusable emails."
+              icon={<DocumentDuplicateIcon className="w-12 h-12 text-muted-foreground" />}
+              action={{ label: 'New template', onClick: () => navigate('/templates/new') }}
+            />
+          ) : (
+            <div className="space-y-3">
+              {templates.map((template) => (
+                <div
+                  key={template.templateId}
+                  className="bg-surface border border-border rounded-lg p-4 sm:p-6 flex items-center justify-between gap-4 hover:border-primary-200 transition-colors"
+                >
+                  <button
+                    type="button"
+                    onClick={() => navigate(`/templates/${template.templateId}/edit`)}
+                    className="flex items-center gap-4 flex-1 min-w-0 text-left"
+                  >
+                    <div className="flex-shrink-0 w-10 h-10 bg-primary-100 rounded-lg flex items-center justify-center">
+                      <DocumentDuplicateIcon className="w-5 h-5 text-primary-600" />
+                    </div>
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2">
+                        <h3 className="text-base font-medium text-foreground truncate">{template.name}</h3>
+                        {template.category && (
+                          <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-muted text-muted-foreground">
+                            {template.category}
+                          </span>
+                        )}
+                      </div>
+                      {template.description && (
+                        <p className="text-sm text-muted-foreground truncate mt-0.5">{template.description}</p>
+                      )}
+                      <p className="text-xs text-muted-foreground mt-1">
+                        Updated {new Date(template.updatedAt).toLocaleDateString()} · v{template.version}
+                      </p>
+                    </div>
+                  </button>
+
+                  <div className="flex items-center gap-2 flex-shrink-0">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => navigate(`/templates/${template.templateId}/edit`)}
+                      title="Edit template"
+                    >
+                      <PencilSquareIcon className="w-4 h-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => handleDelete(template)}
+                      disabled={deletingId === template.templateId}
+                      isLoading={deletingId === template.templateId}
+                      className="text-error-600 hover:text-error-700 hover:bg-error-50"
+                      title="Delete template"
+                    >
+                      <TrashIcon className="w-4 h-4" />
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </main>
+
+      <ConfirmationDialog />
+    </div>
+  );
+}

--- a/dashboard-ui/src/pages/templates/index.ts
+++ b/dashboard-ui/src/pages/templates/index.ts
@@ -1,0 +1,2 @@
+export { TemplatesListPage } from './TemplatesListPage';
+export { TemplateFormPage } from './TemplateFormPage';

--- a/dashboard-ui/src/services/__tests__/templateService.test.ts
+++ b/dashboard-ui/src/services/__tests__/templateService.test.ts
@@ -1,0 +1,144 @@
+import { templateService } from '../templateService';
+import { apiClient } from '../api';
+import type { Template, ListTemplatesResponse } from '@/types/api';
+
+vi.mock('../api');
+
+const mockApiClient = vi.mocked(apiClient);
+
+const mockTemplate: Template = {
+  templateId: 'tmpl-123',
+  name: 'Welcome',
+  description: 'Welcome email',
+  category: 'transactional',
+  content: '<h1>{{ title }}</h1>',
+  sampleData: { title: 'Hi' },
+  version: 1,
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-01T00:00:00Z',
+};
+
+describe('TemplateService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('listTemplates', () => {
+    it('calls the templates endpoint', async () => {
+      const data: ListTemplatesResponse = { templates: [mockTemplate], total: 1 };
+      mockApiClient.get.mockResolvedValue({ success: true, data });
+
+      const result = await templateService.listTemplates();
+
+      expect(mockApiClient.get).toHaveBeenCalledWith('/templates');
+      expect(result.success).toBe(true);
+      expect(result.data?.total).toBe(1);
+    });
+  });
+
+  describe('getTemplate', () => {
+    it('calls the endpoint with the template ID', async () => {
+      mockApiClient.get.mockResolvedValue({ success: true, data: mockTemplate });
+
+      const result = await templateService.getTemplate('tmpl-123');
+
+      expect(mockApiClient.get).toHaveBeenCalledWith('/templates/tmpl-123');
+      expect(result.success).toBe(true);
+    });
+
+    it('returns an error when ID is missing', async () => {
+      const result = await templateService.getTemplate('');
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('MISSING_TEMPLATE_ID');
+      expect(mockApiClient.get).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('createTemplate', () => {
+    it('posts a normalized (trimmed) payload', async () => {
+      mockApiClient.post.mockResolvedValue({ success: true, data: mockTemplate });
+
+      const result = await templateService.createTemplate({
+        name: '  Welcome  ',
+        content: '<h1>{{ title }}</h1>',
+        category: '  transactional  ',
+      });
+
+      expect(mockApiClient.post).toHaveBeenCalledWith('/templates', {
+        name: 'Welcome',
+        content: '<h1>{{ title }}</h1>',
+        category: 'transactional',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects an empty name before calling the API', async () => {
+      const result = await templateService.createTemplate({ name: '   ', content: 'x' });
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('VALIDATION_ERROR');
+      expect(mockApiClient.post).not.toHaveBeenCalled();
+    });
+
+    it('rejects empty content before calling the API', async () => {
+      const result = await templateService.createTemplate({ name: 'Valid', content: '   ' });
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('VALIDATION_ERROR');
+      expect(mockApiClient.post).not.toHaveBeenCalled();
+    });
+
+    it('rejects names with reserved characters', async () => {
+      const result = await templateService.createTemplate({ name: 'bad/name', content: 'x' });
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('VALIDATION_ERROR');
+      expect(mockApiClient.post).not.toHaveBeenCalled();
+    });
+
+    it('allows names with spaces and hyphens', async () => {
+      mockApiClient.post.mockResolvedValue({ success: true, data: mockTemplate });
+      const result = await templateService.createTemplate({ name: 'Weekly - Digest', content: 'x' });
+      expect(result.success).toBe(true);
+      expect(mockApiClient.post).toHaveBeenCalled();
+    });
+  });
+
+  describe('updateTemplate', () => {
+    it('puts to the endpoint with the template ID', async () => {
+      mockApiClient.put.mockResolvedValue({ success: true, data: mockTemplate });
+
+      const result = await templateService.updateTemplate('tmpl-123', { name: 'Renamed' });
+
+      expect(mockApiClient.put).toHaveBeenCalledWith('/templates/tmpl-123', { name: 'Renamed' });
+      expect(result.success).toBe(true);
+    });
+
+    it('returns an error when ID is missing', async () => {
+      const result = await templateService.updateTemplate('', { name: 'x' });
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('MISSING_TEMPLATE_ID');
+      expect(mockApiClient.put).not.toHaveBeenCalled();
+    });
+
+    it('skips name/content validation when not provided', async () => {
+      mockApiClient.put.mockResolvedValue({ success: true, data: mockTemplate });
+      const result = await templateService.updateTemplate('tmpl-123', { description: 'new' });
+      expect(result.success).toBe(true);
+      expect(mockApiClient.put).toHaveBeenCalledWith('/templates/tmpl-123', { description: 'new' });
+    });
+  });
+
+  describe('deleteTemplate', () => {
+    it('calls delete with the template ID', async () => {
+      mockApiClient.delete.mockResolvedValue({ success: true });
+      const result = await templateService.deleteTemplate('tmpl-123');
+      expect(mockApiClient.delete).toHaveBeenCalledWith('/templates/tmpl-123');
+      expect(result.success).toBe(true);
+    });
+
+    it('returns an error when ID is missing', async () => {
+      const result = await templateService.deleteTemplate('');
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('MISSING_TEMPLATE_ID');
+      expect(mockApiClient.delete).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/dashboard-ui/src/services/templateService.ts
+++ b/dashboard-ui/src/services/templateService.ts
@@ -1,0 +1,124 @@
+import { apiClient } from './api';
+import type {
+  ApiResponse,
+  Template,
+  ListTemplatesResponse,
+  CreateTemplateRequest,
+  UpdateTemplateRequest,
+} from '@/types/api';
+
+/**
+ * Reserved characters that are not allowed in template names (mirrors backend
+ * validation). Spaces and hyphens are allowed; control characters are rejected
+ * separately by `hasControlCharacter`.
+ */
+const RESERVED_NAME_CHARS = /[<>:"/\\|?*]/;
+const NAME_MAX_LENGTH = 100;
+
+function hasControlCharacter(value: string): boolean {
+  for (const char of value) {
+    if (char.charCodeAt(0) < 0x20) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Template Service - CRUD operations for Handlebars email templates.
+ */
+export class TemplateService {
+  /**
+   * List all templates for the authenticated tenant (summaries, no content).
+   */
+  async listTemplates(): Promise<ApiResponse<ListTemplatesResponse>> {
+    return apiClient.get<ListTemplatesResponse>('/templates');
+  }
+
+  /**
+   * Get a single template including its content and sample data.
+   */
+  async getTemplate(templateId: string): Promise<ApiResponse<Template>> {
+    if (!templateId) {
+      return { success: false, error: 'Template ID is required', errorCode: 'MISSING_TEMPLATE_ID' };
+    }
+    return apiClient.get<Template>(`/templates/${templateId}`);
+  }
+
+  /**
+   * Create a new template.
+   */
+  async createTemplate(data: CreateTemplateRequest): Promise<ApiResponse<Template>> {
+    const validationError = this.validateTemplate(data.name, data.content);
+    if (validationError) {
+      return { success: false, error: validationError, errorCode: 'VALIDATION_ERROR' };
+    }
+    return apiClient.post<Template>('/templates', this.normalize(data));
+  }
+
+  /**
+   * Update an existing template.
+   */
+  async updateTemplate(templateId: string, data: UpdateTemplateRequest): Promise<ApiResponse<Template>> {
+    if (!templateId) {
+      return { success: false, error: 'Template ID is required', errorCode: 'MISSING_TEMPLATE_ID' };
+    }
+
+    const validationError = this.validateTemplate(data.name, data.content);
+    if (validationError) {
+      return { success: false, error: validationError, errorCode: 'VALIDATION_ERROR' };
+    }
+
+    return apiClient.put<Template>(`/templates/${templateId}`, this.normalize(data));
+  }
+
+  /**
+   * Delete a template.
+   */
+  async deleteTemplate(templateId: string): Promise<ApiResponse<void>> {
+    if (!templateId) {
+      return { success: false, error: 'Template ID is required', errorCode: 'MISSING_TEMPLATE_ID' };
+    }
+    return apiClient.delete<void>(`/templates/${templateId}`);
+  }
+
+  /**
+   * Validate a template name and content. Returns an error message or null.
+   * `name` and `content` may be undefined on partial updates, in which case
+   * the corresponding check is skipped.
+   */
+  validateTemplate(name?: string, content?: string): string | null {
+    if (name !== undefined) {
+      const trimmed = name.trim();
+      if (!trimmed) {
+        return 'Template name is required';
+      }
+      if (trimmed.length > NAME_MAX_LENGTH) {
+        return `Template name must be ${NAME_MAX_LENGTH} characters or less`;
+      }
+      if (RESERVED_NAME_CHARS.test(trimmed) || hasControlCharacter(trimmed)) {
+        return 'Template name contains invalid characters';
+      }
+    }
+
+    if (content !== undefined && !content.trim()) {
+      return 'Template content is required';
+    }
+
+    return null;
+  }
+
+  /**
+   * Trim string fields so what we send matches what the backend stores.
+   */
+  private normalize<T extends UpdateTemplateRequest>(data: T): T {
+    return {
+      ...data,
+      ...(data.name !== undefined && { name: data.name.trim() }),
+      ...(data.description !== undefined && { description: data.description.trim() }),
+      ...(data.category !== undefined && { category: data.category.trim() }),
+    };
+  }
+}
+
+export const templateService = new TemplateService();

--- a/dashboard-ui/src/types/api.ts
+++ b/dashboard-ui/src/types/api.ts
@@ -226,6 +226,43 @@ export interface SendTestEmailRequest {
   recipientEmail: string;
 }
 
+// Template Types
+export interface TemplateSummary {
+  templateId: string;
+  name: string;
+  description?: string;
+  category?: string;
+  version: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Template extends TemplateSummary {
+  content: string;
+  sampleData?: Record<string, unknown>;
+}
+
+export interface ListTemplatesResponse {
+  templates: TemplateSummary[];
+  total: number;
+}
+
+export interface CreateTemplateRequest {
+  name: string;
+  description?: string;
+  category?: string;
+  content: string;
+  sampleData?: Record<string, unknown>;
+}
+
+export interface UpdateTemplateRequest {
+  name?: string;
+  description?: string;
+  category?: string;
+  content?: string;
+  sampleData?: Record<string, unknown>;
+}
+
 export interface SendTestEmailResponse {
   messageId: string;
   recipientEmail: string;

--- a/dashboard-ui/src/utils/lazyImports.ts
+++ b/dashboard-ui/src/utils/lazyImports.ts
@@ -137,6 +137,22 @@ export const LazySponsorDetailPage = lazy(() =>
     })
 );
 
+export const LazyTemplatesListPage = lazy(() =>
+  import('@/pages/templates').then(module => ({ default: module.TemplatesListPage }))
+    .catch(error => {
+      console.error('Failed to load TemplatesListPage:', error);
+      throw error;
+    })
+);
+
+export const LazyTemplateFormPage = lazy(() =>
+  import('@/pages/templates').then(module => ({ default: module.TemplateFormPage }))
+    .catch(error => {
+      console.error('Failed to load TemplateFormPage:', error);
+      throw error;
+    })
+);
+
 // Preload critical routes
 export const preloadCriticalRoutes = () => {
   // Preload dashboard since it's the default route
@@ -189,6 +205,9 @@ export const preloadRoute = (routeName: string) => {
     case 'sponsors':
       import('@/pages/sponsors/SponsorDirectoryPage');
       import('@/pages/sponsors/SponsorDetailPage');
+      break;
+    case 'templates':
+      import('@/pages/templates');
       break;
     case 'login':
       import('@/pages/auth/LoginPage');

--- a/functions/src/api/controllers/mod.rs
+++ b/functions/src/api/controllers/mod.rs
@@ -8,3 +8,4 @@ pub mod segments;
 pub mod senders;
 pub mod sponsors;
 pub mod subscribers;
+pub mod templates;

--- a/functions/src/api/controllers/senders.rs
+++ b/functions/src/api/controllers/senders.rs
@@ -973,12 +973,15 @@ async fn send_test_email_via_ses(
 
     let message = Message::builder()
         .subject(subject)
-        .body(SesBody::builder().html(html_content).text(text_content).build())
+        .body(
+            SesBody::builder()
+                .html(html_content)
+                .text(text_content)
+                .build(),
+        )
         .build();
 
-    let destination = Destination::builder()
-        .to_addresses(recipient_email)
-        .build();
+    let destination = Destination::builder().to_addresses(recipient_email).build();
 
     let mut send_command = ses
         .send_email()
@@ -992,9 +995,10 @@ async fn send_test_email_via_ses(
         }
     }
 
-    let result = send_command.send().await.map_err(|e| {
-        AppError::AwsError(format!("SES send test email failed: {}", e))
-    })?;
+    let result = send_command
+        .send()
+        .await
+        .map_err(|e| AppError::AwsError(format!("SES send test email failed: {}", e)))?;
 
     Ok(result.message_id().unwrap_or_default().to_string())
 }

--- a/functions/src/api/controllers/templates.rs
+++ b/functions/src/api/controllers/templates.rs
@@ -1,0 +1,719 @@
+use aws_sdk_dynamodb::types::AttributeValue;
+use lambda_http::{Body, Error, Request, Response};
+use newsletter::admin::{auth, aws_clients, error::AppError, response};
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use serde_dynamo::from_item;
+use serde_json::{json, Value};
+use std::env;
+use std::sync::OnceLock;
+use uuid::Uuid;
+
+// ── Constants ──────────────────────────────────────────────────────────
+
+const TEMPLATE_SK_PREFIX: &str = "template#";
+const TEMPLATE_GSI1PK_PREFIX: &str = "template#";
+
+const NAME_MAX_LEN: usize = 100;
+const DESCRIPTION_MAX_LEN: usize = 500;
+const CATEGORY_MAX_LEN: usize = 50;
+/// Template content is stored inline in the DynamoDB item. DynamoDB items are
+/// capped at 400KB, so we cap content well below that to leave room for the
+/// rest of the record. Realistic email templates are well under this.
+const CONTENT_MAX_LEN: usize = 256 * 1024;
+const SAMPLE_DATA_MAX_LEN: usize = 64 * 1024;
+
+static INVALID_NAME_CHARS: OnceLock<Regex> = OnceLock::new();
+
+fn invalid_name_regex() -> &'static Regex {
+    INVALID_NAME_CHARS.get_or_init(|| {
+        Regex::new(r#"[<>:"/\\|?*\x00-\x1f]"#).expect("Failed to compile template name regex")
+    })
+}
+
+// ── Key patterns ───────────────────────────────────────────────────────
+
+fn template_sk(template_id: &str) -> String {
+    format!("{}{}", TEMPLATE_SK_PREFIX, template_id)
+}
+
+fn template_gsi1pk(tenant_id: &str) -> String {
+    format!("{}{}", TEMPLATE_GSI1PK_PREFIX, tenant_id)
+}
+
+/// Normalize a template name for case-insensitive uniqueness and sorting.
+fn normalize_name(name: &str) -> String {
+    name.trim().to_lowercase()
+}
+
+// ── Data types ─────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct TemplateRecord {
+    pub pk: String,
+    pub sk: String,
+    #[serde(rename = "GSI1PK")]
+    pub gsi1pk: String,
+    #[serde(rename = "GSI1SK")]
+    pub gsi1sk: String,
+    #[serde(rename = "templateId")]
+    pub template_id: String,
+    #[serde(rename = "tenantId")]
+    pub tenant_id: String,
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub category: Option<String>,
+    pub content: String,
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "sampleData")]
+    pub sample_data: Option<String>,
+    pub version: u64,
+    #[serde(rename = "createdAt")]
+    pub created_at: String,
+    #[serde(rename = "updatedAt")]
+    pub updated_at: String,
+}
+
+#[derive(Debug, Serialize)]
+struct TemplateSummary {
+    #[serde(rename = "templateId")]
+    template_id: String,
+    name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    category: Option<String>,
+    version: u64,
+    #[serde(rename = "createdAt")]
+    created_at: String,
+    #[serde(rename = "updatedAt")]
+    updated_at: String,
+}
+
+impl From<TemplateRecord> for TemplateSummary {
+    fn from(t: TemplateRecord) -> Self {
+        TemplateSummary {
+            template_id: t.template_id,
+            name: t.name,
+            description: t.description,
+            category: t.category,
+            version: t.version,
+            created_at: t.created_at,
+            updated_at: t.updated_at,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct TemplateDetail {
+    #[serde(rename = "templateId")]
+    template_id: String,
+    name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    category: Option<String>,
+    content: String,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "sampleData")]
+    sample_data: Option<Value>,
+    version: u64,
+    #[serde(rename = "createdAt")]
+    created_at: String,
+    #[serde(rename = "updatedAt")]
+    updated_at: String,
+}
+
+impl From<TemplateRecord> for TemplateDetail {
+    fn from(t: TemplateRecord) -> Self {
+        let sample_data = t
+            .sample_data
+            .as_deref()
+            .and_then(|s| serde_json::from_str::<Value>(s).ok());
+
+        TemplateDetail {
+            template_id: t.template_id,
+            name: t.name,
+            description: t.description,
+            category: t.category,
+            content: t.content,
+            sample_data,
+            version: t.version,
+            created_at: t.created_at,
+            updated_at: t.updated_at,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct ListTemplatesResponse {
+    templates: Vec<TemplateSummary>,
+    total: usize,
+}
+
+#[derive(Deserialize)]
+struct CreateTemplateRequest {
+    name: Option<String>,
+    description: Option<String>,
+    category: Option<String>,
+    content: Option<String>,
+    #[serde(rename = "sampleData")]
+    sample_data: Option<Value>,
+}
+
+#[derive(Deserialize)]
+struct UpdateTemplateRequest {
+    name: Option<String>,
+    description: Option<String>,
+    category: Option<String>,
+    content: Option<String>,
+    #[serde(rename = "sampleData")]
+    sample_data: Option<Value>,
+}
+
+// ── Validation ─────────────────────────────────────────────────────────
+
+fn validate_name(name: &str) -> Result<String, AppError> {
+    let trimmed = name.trim();
+
+    if trimmed.is_empty() {
+        return Err(AppError::BadRequest("Template name is required".to_string()));
+    }
+
+    if trimmed.chars().count() > NAME_MAX_LEN {
+        return Err(AppError::BadRequest(format!(
+            "Template name must be {} characters or less",
+            NAME_MAX_LEN
+        )));
+    }
+
+    if invalid_name_regex().is_match(trimmed) {
+        return Err(AppError::BadRequest(
+            "Template name contains invalid characters".to_string(),
+        ));
+    }
+
+    Ok(trimmed.to_string())
+}
+
+fn validate_description(description: &str) -> Result<(), AppError> {
+    if description.chars().count() > DESCRIPTION_MAX_LEN {
+        return Err(AppError::BadRequest(format!(
+            "Description must be {} characters or less",
+            DESCRIPTION_MAX_LEN
+        )));
+    }
+    Ok(())
+}
+
+fn validate_category(category: &str) -> Result<(), AppError> {
+    if category.chars().count() > CATEGORY_MAX_LEN {
+        return Err(AppError::BadRequest(format!(
+            "Category must be {} characters or less",
+            CATEGORY_MAX_LEN
+        )));
+    }
+    Ok(())
+}
+
+fn validate_content(content: &str) -> Result<(), AppError> {
+    if content.trim().is_empty() {
+        return Err(AppError::BadRequest(
+            "Template content is required".to_string(),
+        ));
+    }
+
+    if content.len() > CONTENT_MAX_LEN {
+        return Err(AppError::BadRequest(format!(
+            "Template content must be {}KB or less",
+            CONTENT_MAX_LEN / 1024
+        )));
+    }
+
+    // Compile the content as Handlebars to surface syntax errors early.
+    // Unknown partials (i.e. macros that aren't managed yet) are resolved at
+    // render time, not registration, so they do not fail this check.
+    let mut hb = handlebars::Handlebars::new();
+    hb.register_template_string("__validate__", content)
+        .map_err(|e| {
+            AppError::BadRequest(format!("Template content is not valid Handlebars: {}", e))
+        })?;
+
+    Ok(())
+}
+
+/// Validate and serialize optional sample data to a JSON string for storage.
+fn serialize_sample_data(sample_data: Option<&Value>) -> Result<Option<String>, AppError> {
+    match sample_data {
+        None | Some(Value::Null) => Ok(None),
+        Some(value) => {
+            let serialized = serde_json::to_string(value).map_err(|e| {
+                AppError::BadRequest(format!("Sample data must be valid JSON: {}", e))
+            })?;
+            if serialized.len() > SAMPLE_DATA_MAX_LEN {
+                return Err(AppError::BadRequest(format!(
+                    "Sample data must be {}KB or less",
+                    SAMPLE_DATA_MAX_LEN / 1024
+                )));
+            }
+            Ok(Some(serialized))
+        }
+    }
+}
+
+// ── Handlers ───────────────────────────────────────────────────────────
+
+pub async fn list_templates(event: Request) -> Result<Response<Body>, Error> {
+    match handle_list_templates(event).await {
+        Ok(response) => Ok(response),
+        Err(e) => Ok(response::format_error_response(&e)),
+    }
+}
+
+async fn handle_list_templates(event: Request) -> Result<Response<Body>, AppError> {
+    let tenant_id = require_tenant(&event)?;
+    let templates = query_templates_by_tenant(&tenant_id).await?;
+
+    let summaries: Vec<TemplateSummary> = templates.into_iter().map(TemplateSummary::from).collect();
+
+    response::format_response(
+        200,
+        ListTemplatesResponse {
+            total: summaries.len(),
+            templates: summaries,
+        },
+    )
+}
+
+pub async fn create_template(event: Request) -> Result<Response<Body>, Error> {
+    match handle_create_template(event).await {
+        Ok(response) => Ok(response),
+        Err(e) => Ok(response::format_error_response(&e)),
+    }
+}
+
+async fn handle_create_template(event: Request) -> Result<Response<Body>, AppError> {
+    let tenant_id = require_tenant(&event)?;
+
+    let body: CreateTemplateRequest = serde_json::from_slice(event.body())
+        .map_err(|e| AppError::BadRequest(format!("Invalid JSON: {}", e)))?;
+
+    let name = validate_name(body.name.as_deref().unwrap_or_default())?;
+    let content = body.content.unwrap_or_default();
+    validate_content(&content)?;
+
+    if let Some(ref description) = body.description {
+        validate_description(description)?;
+    }
+    if let Some(ref category) = body.category {
+        validate_category(category)?;
+    }
+    let sample_data = serialize_sample_data(body.sample_data.as_ref())?;
+
+    if template_name_exists(&tenant_id, &name, None).await? {
+        return Err(AppError::Conflict(format!(
+            "A template with the name \"{}\" already exists",
+            name
+        )));
+    }
+
+    let template_id = Uuid::new_v4().to_string();
+    let now = chrono::Utc::now().to_rfc3339();
+
+    let record = TemplateRecord {
+        pk: tenant_id.clone(),
+        sk: template_sk(&template_id),
+        gsi1pk: template_gsi1pk(&tenant_id),
+        gsi1sk: normalize_name(&name),
+        template_id,
+        tenant_id,
+        name,
+        description: body.description.map(|d| d.trim().to_string()),
+        category: body.category.map(|c| c.trim().to_string()),
+        content,
+        sample_data,
+        version: 1,
+        created_at: now.clone(),
+        updated_at: now,
+    };
+
+    put_template(&record, true).await?;
+
+    response::format_response(201, TemplateDetail::from(record))
+}
+
+pub async fn get_template(
+    event: Request,
+    template_id: Option<String>,
+) -> Result<Response<Body>, Error> {
+    match handle_get_template(event, template_id).await {
+        Ok(response) => Ok(response),
+        Err(e) => Ok(response::format_error_response(&e)),
+    }
+}
+
+async fn handle_get_template(
+    event: Request,
+    template_id: Option<String>,
+) -> Result<Response<Body>, AppError> {
+    let tenant_id = require_tenant(&event)?;
+    let template_id =
+        template_id.ok_or_else(|| AppError::BadRequest("Template ID is required".to_string()))?;
+
+    let record = get_template_record(&tenant_id, &template_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound("Template not found".to_string()))?;
+
+    response::format_response(200, TemplateDetail::from(record))
+}
+
+pub async fn update_template(
+    event: Request,
+    template_id: Option<String>,
+) -> Result<Response<Body>, Error> {
+    match handle_update_template(event, template_id).await {
+        Ok(response) => Ok(response),
+        Err(e) => Ok(response::format_error_response(&e)),
+    }
+}
+
+async fn handle_update_template(
+    event: Request,
+    template_id: Option<String>,
+) -> Result<Response<Body>, AppError> {
+    let tenant_id = require_tenant(&event)?;
+    let template_id =
+        template_id.ok_or_else(|| AppError::BadRequest("Template ID is required".to_string()))?;
+
+    let body: UpdateTemplateRequest = serde_json::from_slice(event.body())
+        .map_err(|e| AppError::BadRequest(format!("Invalid JSON: {}", e)))?;
+
+    if body.name.is_none()
+        && body.description.is_none()
+        && body.category.is_none()
+        && body.content.is_none()
+        && body.sample_data.is_none()
+    {
+        return Err(AppError::BadRequest(
+            "At least one field must be provided for update".to_string(),
+        ));
+    }
+
+    let mut record = get_template_record(&tenant_id, &template_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound("Template not found".to_string()))?;
+
+    if let Some(name) = body.name {
+        let validated = validate_name(&name)?;
+        if normalize_name(&validated) != record.gsi1sk
+            && template_name_exists(&tenant_id, &validated, Some(&template_id)).await?
+        {
+            return Err(AppError::Conflict(format!(
+                "A template with the name \"{}\" already exists",
+                validated
+            )));
+        }
+        record.gsi1sk = normalize_name(&validated);
+        record.name = validated;
+    }
+
+    if let Some(description) = body.description {
+        validate_description(&description)?;
+        record.description = Some(description.trim().to_string());
+    }
+
+    if let Some(category) = body.category {
+        validate_category(&category)?;
+        record.category = Some(category.trim().to_string());
+    }
+
+    if let Some(content) = body.content {
+        validate_content(&content)?;
+        record.content = content;
+    }
+
+    if let Some(ref sample_data) = body.sample_data {
+        record.sample_data = serialize_sample_data(Some(sample_data))?;
+    }
+
+    record.version += 1;
+    record.updated_at = chrono::Utc::now().to_rfc3339();
+
+    put_template(&record, false).await?;
+
+    response::format_response(200, TemplateDetail::from(record))
+}
+
+pub async fn delete_template(
+    event: Request,
+    template_id: Option<String>,
+) -> Result<Response<Body>, Error> {
+    match handle_delete_template(event, template_id).await {
+        Ok(response) => Ok(response),
+        Err(e) => Ok(response::format_error_response(&e)),
+    }
+}
+
+async fn handle_delete_template(
+    event: Request,
+    template_id: Option<String>,
+) -> Result<Response<Body>, AppError> {
+    let tenant_id = require_tenant(&event)?;
+    let template_id =
+        template_id.ok_or_else(|| AppError::BadRequest("Template ID is required".to_string()))?;
+
+    let client = aws_clients::get_dynamodb_client().await;
+    let table_name = table_name()?;
+
+    client
+        .delete_item()
+        .table_name(table_name)
+        .key("pk", AttributeValue::S(tenant_id))
+        .key("sk", AttributeValue::S(template_sk(&template_id)))
+        .condition_expression("attribute_exists(pk) AND attribute_exists(sk)")
+        .send()
+        .await
+        .map_err(|e| {
+            if e.to_string().contains("ConditionalCheckFailed") {
+                AppError::NotFound("Template not found".to_string())
+            } else {
+                AppError::AwsError(format!("DynamoDB delete failed: {}", e))
+            }
+        })?;
+
+    response::format_response(200, json!({ "message": "Template deleted" }))
+}
+
+// ── Persistence helpers ────────────────────────────────────────────────
+
+fn require_tenant(event: &Request) -> Result<String, AppError> {
+    let user_context = auth::get_user_context(event)?;
+    user_context
+        .tenant_id
+        .ok_or_else(|| AppError::Unauthorized("Tenant access required".to_string()))
+}
+
+fn table_name() -> Result<String, AppError> {
+    env::var("TABLE_NAME")
+        .map_err(|_| AppError::InternalError("TABLE_NAME not configured".to_string()))
+}
+
+async fn query_templates_by_tenant(tenant_id: &str) -> Result<Vec<TemplateRecord>, AppError> {
+    let client = aws_clients::get_dynamodb_client().await;
+    let table_name = table_name()?;
+
+    let result = client
+        .query()
+        .table_name(table_name)
+        .index_name("GSI1")
+        .key_condition_expression("GSI1PK = :gsi1pk")
+        .expression_attribute_values(":gsi1pk", AttributeValue::S(template_gsi1pk(tenant_id)))
+        .send()
+        .await
+        .map_err(|e| AppError::AwsError(format!("Failed to query templates: {}", e)))?;
+
+    let templates = result
+        .items()
+        .iter()
+        .filter_map(|item| {
+            from_item::<_, TemplateRecord>(item.clone())
+                .map_err(|e| tracing::error!("Failed to deserialize template: {}", e))
+                .ok()
+        })
+        .collect();
+
+    Ok(templates)
+}
+
+async fn get_template_record(
+    tenant_id: &str,
+    template_id: &str,
+) -> Result<Option<TemplateRecord>, AppError> {
+    let client = aws_clients::get_dynamodb_client().await;
+    let table_name = table_name()?;
+
+    let result = client
+        .get_item()
+        .table_name(table_name)
+        .key("pk", AttributeValue::S(tenant_id.to_string()))
+        .key("sk", AttributeValue::S(template_sk(template_id)))
+        .send()
+        .await
+        .map_err(|e| AppError::AwsError(format!("Failed to get template: {}", e)))?;
+
+    match result.item {
+        Some(item) => {
+            let record: TemplateRecord = from_item(item).map_err(|e| {
+                AppError::InternalError(format!("Failed to deserialize template: {}", e))
+            })?;
+            Ok(Some(record))
+        }
+        None => Ok(None),
+    }
+}
+
+/// Returns true if a template with the given (case-insensitive) name already
+/// exists for the tenant, optionally excluding a specific template id.
+async fn template_name_exists(
+    tenant_id: &str,
+    name: &str,
+    exclude_template_id: Option<&str>,
+) -> Result<bool, AppError> {
+    let client = aws_clients::get_dynamodb_client().await;
+    let table_name = table_name()?;
+
+    let result = client
+        .query()
+        .table_name(table_name)
+        .index_name("GSI1")
+        .key_condition_expression("GSI1PK = :gsi1pk AND GSI1SK = :name")
+        .expression_attribute_values(":gsi1pk", AttributeValue::S(template_gsi1pk(tenant_id)))
+        .expression_attribute_values(":name", AttributeValue::S(normalize_name(name)))
+        .send()
+        .await
+        .map_err(|e| AppError::AwsError(format!("Failed to check template name: {}", e)))?;
+
+    let exists = result.items().iter().any(|item| {
+        let item_id = item.get("templateId").and_then(|v| v.as_s().ok());
+        match (item_id, exclude_template_id) {
+            (Some(id), Some(exclude)) => id != exclude,
+            (Some(_), None) => true,
+            _ => false,
+        }
+    });
+
+    Ok(exists)
+}
+
+async fn put_template(record: &TemplateRecord, ensure_new: bool) -> Result<(), AppError> {
+    let client = aws_clients::get_dynamodb_client().await;
+    let table_name = table_name()?;
+
+    let item = serde_dynamo::to_item(record)
+        .map_err(|e| AppError::InternalError(format!("Failed to serialize template: {}", e)))?;
+
+    let mut request = client.put_item().table_name(table_name).set_item(Some(item));
+
+    if ensure_new {
+        request = request.condition_expression("attribute_not_exists(pk) AND attribute_not_exists(sk)");
+    } else {
+        request = request.condition_expression("attribute_exists(pk) AND attribute_exists(sk)");
+    }
+
+    request.send().await.map_err(|e| {
+        if e.to_string().contains("ConditionalCheckFailed") {
+            if ensure_new {
+                AppError::Conflict("Template already exists".to_string())
+            } else {
+                AppError::NotFound("Template not found".to_string())
+            }
+        } else {
+            AppError::AwsError(format!("DynamoDB put failed: {}", e))
+        }
+    })?;
+
+    Ok(())
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_template_sk() {
+        assert_eq!(template_sk("abc-123"), "template#abc-123");
+    }
+
+    #[test]
+    fn test_template_gsi1pk() {
+        assert_eq!(template_gsi1pk("tenant-1"), "template#tenant-1");
+    }
+
+    #[test]
+    fn test_normalize_name() {
+        assert_eq!(normalize_name("  Welcome Email  "), "welcome email");
+    }
+
+    #[test]
+    fn test_validate_name_ok() {
+        assert_eq!(validate_name("  My Template  ").unwrap(), "My Template");
+    }
+
+    #[test]
+    fn test_validate_name_empty() {
+        assert!(validate_name("   ").is_err());
+    }
+
+    #[test]
+    fn test_validate_name_too_long() {
+        let long = "a".repeat(NAME_MAX_LEN + 1);
+        assert!(validate_name(&long).is_err());
+    }
+
+    #[test]
+    fn test_validate_name_invalid_chars() {
+        assert!(validate_name("bad/name").is_err());
+        assert!(validate_name("bad<name>").is_err());
+    }
+
+    #[test]
+    fn test_validate_content_empty() {
+        assert!(validate_content("   ").is_err());
+    }
+
+    #[test]
+    fn test_validate_content_valid_handlebars() {
+        assert!(validate_content("<h1>{{ title }}</h1>{{#each items}}{{this}}{{/each}}").is_ok());
+    }
+
+    #[test]
+    fn test_validate_content_unknown_partial_is_allowed() {
+        // Partials (macros) are resolved at render time, so referencing one that
+        // isn't registered should still validate successfully.
+        assert!(validate_content("<div>{{> sponsorBlock }}</div>").is_ok());
+    }
+
+    #[test]
+    fn test_validate_content_invalid_handlebars() {
+        // Unclosed block helper should fail to compile.
+        assert!(validate_content("{{#if foo}}no close").is_err());
+    }
+
+    #[test]
+    fn test_serialize_sample_data_none() {
+        assert_eq!(serialize_sample_data(None).unwrap(), None);
+        assert_eq!(serialize_sample_data(Some(&Value::Null)).unwrap(), None);
+    }
+
+    #[test]
+    fn test_serialize_sample_data_object() {
+        let value = json!({ "title": "Hi", "count": 3 });
+        let serialized = serialize_sample_data(Some(&value)).unwrap().unwrap();
+        let parsed: Value = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(parsed, value);
+    }
+
+    #[test]
+    fn test_detail_parses_sample_data() {
+        let record = TemplateRecord {
+            pk: "tenant".to_string(),
+            sk: template_sk("t1"),
+            gsi1pk: template_gsi1pk("tenant"),
+            gsi1sk: "welcome".to_string(),
+            template_id: "t1".to_string(),
+            tenant_id: "tenant".to_string(),
+            name: "Welcome".to_string(),
+            description: None,
+            category: None,
+            content: "<h1>{{title}}</h1>".to_string(),
+            sample_data: Some("{\"title\":\"Hi\"}".to_string()),
+            version: 1,
+            created_at: "now".to_string(),
+            updated_at: "now".to_string(),
+        };
+        let detail = TemplateDetail::from(record);
+        assert_eq!(detail.sample_data, Some(json!({ "title": "Hi" })));
+    }
+}

--- a/functions/src/api/controllers/templates.rs
+++ b/functions/src/api/controllers/templates.rs
@@ -66,7 +66,11 @@ struct TemplateRecord {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub category: Option<String>,
     pub content: String,
-    #[serde(default, skip_serializing_if = "Option::is_none", rename = "sampleData")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "sampleData"
+    )]
     pub sample_data: Option<String>,
     pub version: u64,
     #[serde(rename = "createdAt")]
@@ -177,7 +181,9 @@ fn validate_name(name: &str) -> Result<String, AppError> {
     let trimmed = name.trim();
 
     if trimmed.is_empty() {
-        return Err(AppError::BadRequest("Template name is required".to_string()));
+        return Err(AppError::BadRequest(
+            "Template name is required".to_string(),
+        ));
     }
 
     if trimmed.chars().count() > NAME_MAX_LEN {
@@ -274,7 +280,8 @@ async fn handle_list_templates(event: Request) -> Result<Response<Body>, AppErro
     let tenant_id = require_tenant(&event)?;
     let templates = query_templates_by_tenant(&tenant_id).await?;
 
-    let summaries: Vec<TemplateSummary> = templates.into_iter().map(TemplateSummary::from).collect();
+    let summaries: Vec<TemplateSummary> =
+        templates.into_iter().map(TemplateSummary::from).collect();
 
     response::format_response(
         200,
@@ -592,10 +599,14 @@ async fn put_template(record: &TemplateRecord, ensure_new: bool) -> Result<(), A
     let item = serde_dynamo::to_item(record)
         .map_err(|e| AppError::InternalError(format!("Failed to serialize template: {}", e)))?;
 
-    let mut request = client.put_item().table_name(table_name).set_item(Some(item));
+    let mut request = client
+        .put_item()
+        .table_name(table_name)
+        .set_item(Some(item));
 
     if ensure_new {
-        request = request.condition_expression("attribute_not_exists(pk) AND attribute_not_exists(sk)");
+        request =
+            request.condition_expression("attribute_not_exists(pk) AND attribute_not_exists(sk)");
     } else {
         request = request.condition_expression("attribute_exists(pk) AND attribute_exists(sk)");
     }

--- a/functions/src/api/router.rs
+++ b/functions/src/api/router.rs
@@ -3,6 +3,7 @@ use serde_json::json;
 
 use crate::controllers::{
     api_keys, brand, domain, issues, pricing, profile, segments, senders, sponsors, subscribers,
+    templates,
 };
 
 pub async fn route_request(event: Request) -> Result<Response<Body>, Error> {
@@ -296,6 +297,22 @@ pub async fn route_request(event: Request) -> Result<Response<Body>, Error> {
             }
         }
 
+        // Templates endpoints
+        (&Method::GET, "/templates") => templates::list_templates(event).await,
+        (&Method::POST, "/templates") => templates::create_template(event).await,
+        (&Method::GET, path) if path.starts_with("/templates/") => {
+            let template_id = extract_path_param(path, "/templates/");
+            templates::get_template(event, template_id).await
+        }
+        (&Method::PUT, path) if path.starts_with("/templates/") => {
+            let template_id = extract_path_param(path, "/templates/");
+            templates::update_template(event, template_id).await
+        }
+        (&Method::DELETE, path) if path.starts_with("/templates/") => {
+            let template_id = extract_path_param(path, "/templates/");
+            templates::delete_template(event, template_id).await
+        }
+
         // Method not allowed for valid paths
         (_, path) if is_valid_api_path(path) => Ok(format_method_not_allowed()),
 
@@ -349,6 +366,9 @@ fn is_valid_api_path(path: &str) -> bool {
         // Sponsors paths
         || path == "/sponsors"
         || path.starts_with("/sponsors/")
+        // Templates paths
+        || path == "/templates"
+        || path.starts_with("/templates/")
 }
 
 fn extract_path_param(path: &str, prefix: &str) -> Option<String> {
@@ -845,6 +865,21 @@ mod tests {
         ));
         assert!(is_valid_api_path("/sponsors/sp-123/outreach"));
         assert!(is_valid_api_path("/sponsors/sp-123/outreach/jobs/job-789"));
+    }
+
+    #[test]
+    fn test_is_valid_api_path_templates() {
+        assert!(is_valid_api_path("/templates"));
+        assert!(is_valid_api_path("/templates/abc-123"));
+    }
+
+    #[test]
+    fn test_extract_template_id_from_path() {
+        let result = extract_path_param("/templates/tmpl-123", "/templates/");
+        assert_eq!(result, Some("tmpl-123".to_string()));
+
+        let result = extract_path_param("/templates/", "/templates/");
+        assert_eq!(result, None);
     }
 
     #[test]

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1130,6 +1130,123 @@ paths:
         "500":
           $ref: "#/components/responses/UnknownError"
 
+  /templates:
+    get:
+      summary: List templates
+      description: Returns all Handlebars templates for the authenticated tenant (summaries without content).
+      tags:
+        - Templates
+      responses:
+        "200":
+          description: A list of templates
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  templates:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/TemplateSummary"
+                  total:
+                    type: integer
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/UnknownError"
+    post:
+      summary: Create a template
+      tags:
+        - Templates
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateTemplateRequest"
+      responses:
+        "201":
+          description: Template created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Template"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          description: A template with the same name already exists
+        "500":
+          $ref: "#/components/responses/UnknownError"
+
+  /templates/{templateId}:
+    parameters:
+      - name: templateId
+        in: path
+        required: true
+        schema:
+          type: string
+        description: The template ID
+    get:
+      summary: Get a template
+      description: Returns a single template including its content and sample data.
+      tags:
+        - Templates
+      responses:
+        "200":
+          description: The template
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Template"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/UnknownError"
+    put:
+      summary: Update a template
+      tags:
+        - Templates
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateTemplateRequest"
+      responses:
+        "200":
+          description: Template updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Template"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: A template with the same name already exists
+        "500":
+          $ref: "#/components/responses/UnknownError"
+    delete:
+      summary: Delete a template
+      tags:
+        - Templates
+      responses:
+        "200":
+          description: Template deleted
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/UnknownError"
+
   /issues:
     get:
       summary: List all issues
@@ -2368,6 +2485,83 @@ components:
         domain:
           type: string
           description: Domain name to verify
+
+    TemplateSummary:
+      type: object
+      properties:
+        templateId:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        category:
+          type: string
+          nullable: true
+        version:
+          type: integer
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
+    Template:
+      allOf:
+        - $ref: "#/components/schemas/TemplateSummary"
+        - type: object
+          properties:
+            content:
+              type: string
+              description: The Handlebars template source
+            sampleData:
+              type: object
+              additionalProperties: true
+              nullable: true
+              description: Default data used to preview the template
+
+    CreateTemplateRequest:
+      type: object
+      required:
+        - name
+        - content
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        description:
+          type: string
+          maxLength: 500
+        category:
+          type: string
+          maxLength: 50
+        content:
+          type: string
+          description: The Handlebars template source
+        sampleData:
+          type: object
+          additionalProperties: true
+          description: Default data used to preview the template
+
+    UpdateTemplateRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        description:
+          type: string
+          maxLength: 500
+        category:
+          type: string
+          maxLength: 50
+        content:
+          type: string
+        sampleData:
+          type: object
+          additionalProperties: true
 
     ListIssuesResponse:
       type: object


### PR DESCRIPTION
Introduces tenant-scoped Handlebars **template management** — the first step toward an interactive template builder. This PR is CRUD only; snippets (macros), the builder UX, and send integration are tracked as follow-ups (see below).

## What's included

**Backend (Rust `api-router`)** — `functions/src/api/controllers/templates.rs`
- `GET/POST /templates`, `GET/PUT/DELETE /templates/{templateId}`, wired into `router.rs` + `is_valid_api_path`
- Stored per-tenant in the existing `NewsletterTable` (`pk={tenant}`, `sk=template#{id}`, `GSI1` for listing and case-insensitive name uniqueness) — **no new infra/SAM changes**
- Content is validated by **compiling it with the `handlebars` crate** (new dependency). Unknown partials (the "macros"/snippets, managed later) are allowed because they resolve at render time, not registration
- Name / description / category / `sampleData` validation with size caps; content stored inline, capped well under the DynamoDB 400KB item limit
- Unit tests for validation + key patterns; OpenAPI docs for both paths and schemas

**Frontend (React)**
- `templateService` with client-side validation mirroring the backend
- Templates **list page** (view/create/delete) and a **create/edit form** (name, category, description, Handlebars content, optional JSON sample data)
- Routing, lazy-load/preload, page-meta titles, and a **Templates** nav item across sidebar, header, and mobile drawer
- Service unit tests; updated navigation parity tests

## Design notes
- **Storage:** The abandoned `feat/templating` branch stored template content in **S3** (with S3 versioning for history). Since real templates are 8–35KB, this PR keeps content **inline in DynamoDB** for simplicity and consistency with senders/sponsors. If version history is wanted later, S3-backed content is the clean path.
- **Salvaged from `feat/templating`:** the API/data-model contract and name-validation rules (the over-built drag-drop builder UI was intentionally not carried over).

## Verification
- Rust: `cargo check` + `cargo test` (16 template/router tests pass)
- UI: `tsc --noEmit`, `eslint --max-warnings 0`, and `vitest` (128 tests pass)

## Follow-up work
- #265 — Snippets (Handlebars partials/macros): CRUD backend + UI
- #266 — Interactive template builder: delightful editing + **server-side** live preview
- #267 — Send issues with a selected template (optional `templateId`, missing snippet **renders empty**)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KcoMVe13jS15kdPyU6rcNY)_