### PR TITLE
Snippets (Handlebars partials/macros) — CRUD backend + UI

### DIFF
--- a/dashboard-ui/src/App.tsx
+++ b/dashboard-ui/src/App.tsx
@@ -25,6 +25,8 @@ import {
   LazySponsorDetailPage,
   LazyTemplatesListPage,
   LazyTemplateFormPage,
+  LazySnippetsListPage,
+  LazySnippetFormPage,
   preloadCriticalRoutes
 } from '@/utils/lazyImports';
 import { AppShell } from '@/components/layout/AppShell';
@@ -400,6 +402,55 @@ function App() {
                             <AppShell>
                               <PageLoader>
                                 <LazyTemplateFormPage />
+                              </PageLoader>
+                            </AppShell>
+                          </OnboardingGuard>
+                        </ProtectedRoute>
+                      </RouteErrorBoundary>
+                    }
+                  />
+
+                  <Route
+                    path="/snippets"
+                    element={
+                      <RouteErrorBoundary routeName="Snippets">
+                        <ProtectedRoute>
+                          <OnboardingGuard>
+                            <AppShell>
+                              <PageLoader>
+                                <LazySnippetsListPage />
+                              </PageLoader>
+                            </AppShell>
+                          </OnboardingGuard>
+                        </ProtectedRoute>
+                      </RouteErrorBoundary>
+                    }
+                  />
+                  <Route
+                    path="/snippets/new"
+                    element={
+                      <RouteErrorBoundary routeName="Create Snippet">
+                        <ProtectedRoute>
+                          <OnboardingGuard>
+                            <AppShell>
+                              <PageLoader>
+                                <LazySnippetFormPage />
+                              </PageLoader>
+                            </AppShell>
+                          </OnboardingGuard>
+                        </ProtectedRoute>
+                      </RouteErrorBoundary>
+                    }
+                  />
+                  <Route
+                    path="/snippets/:id/edit"
+                    element={
+                      <RouteErrorBoundary routeName="Edit Snippet">
+                        <ProtectedRoute>
+                          <OnboardingGuard>
+                            <AppShell>
+                              <PageLoader>
+                                <LazySnippetFormPage />
                               </PageLoader>
                             </AppShell>
                           </OnboardingGuard>

--- a/dashboard-ui/src/components/layout/AppHeader.tsx
+++ b/dashboard-ui/src/components/layout/AppHeader.tsx
@@ -16,7 +16,7 @@ import {
   SunIcon,
   UserGroupIcon
 } from '@heroicons/react/24/outline';
-import { FileText, LayoutTemplate } from 'lucide-react';
+import { FileText, LayoutTemplate, Puzzle } from 'lucide-react';
 import { useTheme } from '@/hooks/useTheme';
 import { BRAND } from '@/constants/brand';
 
@@ -28,6 +28,7 @@ export const AppHeader: React.FC = () => {
   const baseNavigation = [
     { name: 'Issues', href: '/issues', icon: FileText, preloadKey: 'issues' },
     { name: 'Templates', href: '/templates', icon: LayoutTemplate, preloadKey: 'templates' },
+    { name: 'Snippets', href: '/snippets', icon: Puzzle, preloadKey: 'snippets' },
     { name: 'Segments', href: '/segments', icon: UserGroupIcon, preloadKey: 'segments' },
     { name: 'Brand', href: '/brand', icon: BuildingOfficeIcon, preloadKey: 'brand' },
     { name: 'Profile', href: '/profile', icon: UserIcon, preloadKey: 'profile' },

--- a/dashboard-ui/src/components/layout/MobileNavigation.tsx
+++ b/dashboard-ui/src/components/layout/MobileNavigation.tsx
@@ -15,7 +15,7 @@ import {
   Bars3Icon,
   XMarkIcon
 } from '@heroicons/react/24/outline';
-import { FileText, LayoutTemplate } from 'lucide-react';
+import { FileText, LayoutTemplate, Puzzle } from 'lucide-react';
 import { cn } from '../../utils/cn';
 
 export const MobileNavigation: React.FC = () => {
@@ -29,6 +29,7 @@ export const MobileNavigation: React.FC = () => {
   const baseNavigation = [
     { name: 'Issues', href: '/issues', icon: FileText, preloadKey: 'issues' },
     { name: 'Templates', href: '/templates', icon: LayoutTemplate, preloadKey: 'templates' },
+    { name: 'Snippets', href: '/snippets', icon: Puzzle, preloadKey: 'snippets' },
     { name: 'Brand', href: '/brand', icon: BuildingOfficeIcon, preloadKey: 'brand' },
     { name: 'Profile', href: '/profile', icon: UserIcon, preloadKey: 'profile' },
     { name: 'Sender Emails', href: '/senders', icon: EnvelopeIcon, preloadKey: 'senders' },

--- a/dashboard-ui/src/components/layout/__tests__/AppSidebar.test.tsx
+++ b/dashboard-ui/src/components/layout/__tests__/AppSidebar.test.tsx
@@ -31,11 +31,11 @@ describe('AppSidebar', () => {
   // ---- Requirement 2.2: Renders exactly 5 nav items with icons ----
 
   describe('nav items', () => {
-    it('renders exactly 7 navigation links', () => {
+    it('renders exactly 8 navigation links', () => {
       renderSidebar();
       const nav = screen.getByRole('navigation', { name: 'Main navigation' });
       const links = nav.querySelectorAll('a');
-      expect(links).toHaveLength(7);
+      expect(links).toHaveLength(8);
     });
 
     it('renders the correct nav item labels', () => {
@@ -43,6 +43,7 @@ describe('AppSidebar', () => {
       expect(screen.getByText('Dashboard')).toBeInTheDocument();
       expect(screen.getByText('Issues')).toBeInTheDocument();
       expect(screen.getByText('Templates')).toBeInTheDocument();
+      expect(screen.getByText('Snippets')).toBeInTheDocument();
       expect(screen.getByText('Subscribers')).toBeInTheDocument();
       expect(screen.getByText('Sponsors')).toBeInTheDocument();
       expect(screen.getByText('Brand')).toBeInTheDocument();
@@ -53,7 +54,7 @@ describe('AppSidebar', () => {
       renderSidebar();
       const nav = screen.getByRole('navigation', { name: 'Main navigation' });
       const icons = nav.querySelectorAll('svg[aria-hidden="true"]');
-      expect(icons).toHaveLength(7);
+      expect(icons).toHaveLength(8);
     });
   });
 

--- a/dashboard-ui/src/components/layout/__tests__/MobileDrawerParity.property.test.ts
+++ b/dashboard-ui/src/components/layout/__tests__/MobileDrawerParity.property.test.ts
@@ -64,6 +64,7 @@ describe('Mobile Drawer Parity - Property-Based Tests', () => {
             'Dashboard',
             'Issues',
             'Templates',
+            'Snippets',
             'Subscribers',
             'Sponsors',
             'Brand',

--- a/dashboard-ui/src/components/layout/sidebarNav.ts
+++ b/dashboard-ui/src/components/layout/sidebarNav.ts
@@ -4,7 +4,7 @@ import {
   CurrencyDollarIcon,
   UserGroupIcon,
 } from '@heroicons/react/24/outline';
-import { FileText, Building2, LayoutTemplate } from 'lucide-react';
+import { FileText, Building2, LayoutTemplate, Puzzle } from 'lucide-react';
 
 export interface SidebarNavItem {
   name: string;
@@ -18,6 +18,7 @@ export const NAV_ITEMS: SidebarNavItem[] = [
   { name: 'Dashboard', href: '/', icon: HomeIcon, preloadKey: 'dashboard', matchPaths: ['/'] },
   { name: 'Issues', href: '/issues', icon: FileText, preloadKey: 'issues', matchPaths: ['/issues'] },
   { name: 'Templates', href: '/templates', icon: LayoutTemplate, preloadKey: 'templates', matchPaths: ['/templates'] },
+  { name: 'Snippets', href: '/snippets', icon: Puzzle, preloadKey: 'snippets', matchPaths: ['/snippets'] },
   { name: 'Subscribers', href: '/subscribers', icon: UserGroupIcon, preloadKey: 'subscribers', matchPaths: ['/subscribers', '/segments'] },
   { name: 'Sponsors', href: '/sponsors', icon: Building2, preloadKey: 'sponsors', matchPaths: ['/sponsors'] },
   { name: 'Brand', href: '/brand', icon: BuildingOfficeIcon, preloadKey: 'brand', matchPaths: ['/brand'] },

--- a/dashboard-ui/src/hooks/usePageMeta.ts
+++ b/dashboard-ui/src/hooks/usePageMeta.ts
@@ -14,6 +14,7 @@ export const ROUTE_META: Record<string, { title: string; parent?: { label: strin
   '/': { title: 'Dashboard' },
   '/issues': { title: 'Issues' },
   '/templates': { title: 'Templates' },
+  '/snippets': { title: 'Snippets' },
   '/subscribers': { title: 'Subscribers' },
   '/brand': { title: 'Brand' },
   '/sponsors': { title: 'Sponsors' },
@@ -90,6 +91,28 @@ export function usePageMeta(dynamicTitle?: string): PageMeta {
       breadcrumb: [
         { label: 'Templates', href: '/templates' },
         { label: 'Edit Template' },
+      ],
+    };
+  }
+
+  // Dynamic route: /snippets/new
+  if (pathname === '/snippets/new') {
+    return {
+      title: 'New Snippet',
+      breadcrumb: [
+        { label: 'Snippets', href: '/snippets' },
+        { label: 'New Snippet' },
+      ],
+    };
+  }
+
+  // Dynamic route: /snippets/:id/edit
+  if (params.id && pathname === `/snippets/${params.id}/edit`) {
+    return {
+      title: 'Edit Snippet',
+      breadcrumb: [
+        { label: 'Snippets', href: '/snippets' },
+        { label: 'Edit Snippet' },
       ],
     };
   }

--- a/dashboard-ui/src/pages/snippets/SnippetFormPage.tsx
+++ b/dashboard-ui/src/pages/snippets/SnippetFormPage.tsx
@@ -1,0 +1,340 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { TextArea } from '@/components/ui/TextArea';
+import { Select } from '@/components/ui/Select';
+import { useToast } from '@/components/ui/Toast';
+import { ErrorDisplay } from '@/components/ui/ErrorDisplay';
+import { LoadingSpinner } from '@/components/ui/LoadingStates';
+import { snippetService } from '@/services/snippetService';
+import { getUserFriendlyErrorMessage } from '@/utils/errorHandling';
+import type { CreateSnippetRequest, SnippetParameter, SnippetParameterType } from '@/types/api';
+import { ArrowLeftIcon, PlusIcon, TrashIcon } from '@heroicons/react/24/outline';
+
+const PARAMETER_TYPES: SnippetParameterType[] = [
+  'string',
+  'number',
+  'boolean',
+  'select',
+  'textarea',
+  'url',
+];
+
+const PARAMETER_TYPE_OPTIONS = PARAMETER_TYPES.map((type) => ({ value: type, label: type }));
+
+/** Local editor row state. `optionsText` is the raw textarea value for select options. */
+interface ParameterRow {
+  name: string;
+  type: SnippetParameterType;
+  required: boolean;
+  defaultValue: string;
+  description: string;
+  optionsText: string;
+}
+
+function emptyRow(): ParameterRow {
+  return { name: '', type: 'string', required: false, defaultValue: '', description: '', optionsText: '' };
+}
+
+function toRow(parameter: SnippetParameter): ParameterRow {
+  return {
+    name: parameter.name,
+    type: parameter.type,
+    required: parameter.required,
+    defaultValue:
+      parameter.defaultValue === undefined || parameter.defaultValue === null
+        ? ''
+        : String(parameter.defaultValue),
+    description: parameter.description ?? '',
+    optionsText: (parameter.options ?? []).join('\n'),
+  };
+}
+
+function toParameter(row: ParameterRow): SnippetParameter {
+  const parameter: SnippetParameter = {
+    name: row.name.trim(),
+    type: row.type,
+    required: row.required,
+  };
+  if (row.defaultValue.trim()) {
+    parameter.defaultValue = row.defaultValue.trim();
+  }
+  if (row.description.trim()) {
+    parameter.description = row.description.trim();
+  }
+  if (row.type === 'select') {
+    parameter.options = row.optionsText
+      .split('\n')
+      .map((option) => option.trim())
+      .filter((option) => option.length > 0);
+  }
+  return parameter;
+}
+
+export function SnippetFormPage() {
+  const navigate = useNavigate();
+  const { id } = useParams<{ id: string }>();
+  const isEditMode = Boolean(id);
+  const { addToast } = useToast();
+
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [content, setContent] = useState('');
+  const [parameters, setParameters] = useState<ParameterRow[]>([]);
+
+  const [isLoading, setIsLoading] = useState(isEditMode);
+  const [isSaving, setIsSaving] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [fieldError, setFieldError] = useState<string | null>(null);
+
+  const loadSnippet = useCallback(async (snippetId: string) => {
+    setIsLoading(true);
+    setLoadError(null);
+    const response = await snippetService.getSnippet(snippetId);
+    if (response.success && response.data) {
+      const s = response.data;
+      setName(s.name);
+      setDescription(s.description ?? '');
+      setContent(s.content);
+      setParameters((s.parameters ?? []).map(toRow));
+    } else {
+      setLoadError(getUserFriendlyErrorMessage(response, 'snippet'));
+    }
+    setIsLoading(false);
+  }, []);
+
+  useEffect(() => {
+    if (id) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      loadSnippet(id);
+    }
+  }, [id, loadSnippet]);
+
+  const addParameter = () => setParameters((prev) => [...prev, emptyRow()]);
+  const removeParameter = (index: number) =>
+    setParameters((prev) => prev.filter((_, i) => i !== index));
+  const updateParameter = (index: number, changes: Partial<ParameterRow>) =>
+    setParameters((prev) => prev.map((row, i) => (i === index ? { ...row, ...changes } : row)));
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setFieldError(null);
+
+    // Build and validate parameters client-side before submitting.
+    const builtParameters: SnippetParameter[] = [];
+    for (const row of parameters) {
+      if (!row.name.trim()) {
+        setFieldError('Each parameter must have a name');
+        return;
+      }
+      const parameter = toParameter(row);
+      if (parameter.type === 'select' && (!parameter.options || parameter.options.length === 0)) {
+        setFieldError(`Parameter "${parameter.name}" of type select must include at least one option`);
+        return;
+      }
+      builtParameters.push(parameter);
+    }
+
+    const payload: CreateSnippetRequest = {
+      name,
+      content,
+      ...(description.trim() && { description }),
+      ...(builtParameters.length > 0 && { parameters: builtParameters }),
+    };
+
+    setIsSaving(true);
+    const response = isEditMode && id
+      ? await snippetService.updateSnippet(id, payload)
+      : await snippetService.createSnippet(payload);
+    setIsSaving(false);
+
+    if (response.success) {
+      addToast({
+        type: 'success',
+        title: isEditMode ? 'Snippet updated' : 'Snippet created',
+        message: `${name.trim()} was saved successfully`,
+      });
+      navigate('/snippets');
+    } else {
+      setFieldError(getUserFriendlyErrorMessage(response, 'snippet'));
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-background">
+      <main className="max-w-3xl mx-auto py-6 sm:px-6 lg:px-8">
+        <div className="px-4 py-6 sm:px-0">
+          <button
+            type="button"
+            onClick={() => navigate('/snippets')}
+            className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground mb-4"
+          >
+            <ArrowLeftIcon className="w-4 h-4 mr-1" />
+            Back to snippets
+          </button>
+
+          <h1 className="text-2xl sm:text-3xl font-bold text-foreground mb-6">
+            {isEditMode ? 'Edit snippet' : 'New snippet'}
+          </h1>
+
+          {isLoading ? (
+            <div className="flex items-center gap-3 text-muted-foreground">
+              <LoadingSpinner size="sm" />
+              <span>Loading snippet…</span>
+            </div>
+          ) : loadError ? (
+            <ErrorDisplay
+              title="Error loading snippet"
+              message={loadError}
+              severity="error"
+              retryable
+              onRetry={() => id && loadSnippet(id)}
+            />
+          ) : (
+            <form onSubmit={handleSubmit} className="space-y-5">
+              <Input
+                label="Name"
+                placeholder="sponsorBlock"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                maxLength={100}
+                helperText="Referenced in templates as {{> name }}. Letters, numbers, underscores, and hyphens only (no spaces)."
+                required
+              />
+
+              <Input
+                label="Description (optional)"
+                placeholder="A short description of what this snippet is for"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                maxLength={500}
+              />
+
+              <TextArea
+                label="Content (Handlebars)"
+                placeholder={'<div class="sponsor">\n  <h2>{{ title }}</h2>\n</div>'}
+                value={content}
+                onChange={(e) => setContent(e.target.value)}
+                rows={16}
+                className="font-mono text-sm"
+                helperText="Handlebars markup. Reference other snippets with {{> otherSnippet }}."
+                required
+              />
+
+              {/* Parameters editor */}
+              <div className="space-y-3">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <h2 className="text-sm font-medium text-foreground">Parameters (optional)</h2>
+                    <p className="text-xs text-muted-foreground mt-0.5">
+                      Declare the inputs this snippet expects.
+                    </p>
+                  </div>
+                  <Button type="button" variant="outline" size="sm" onClick={addParameter}>
+                    <PlusIcon className="w-4 h-4 mr-1" />
+                    Add parameter
+                  </Button>
+                </div>
+
+                {parameters.length === 0 ? (
+                  <p className="text-sm text-muted-foreground border border-dashed border-border rounded-lg p-4 text-center">
+                    No parameters yet.
+                  </p>
+                ) : (
+                  <div className="space-y-4">
+                    {parameters.map((row, index) => (
+                      <div key={index} className="border border-border rounded-lg p-4 space-y-3 bg-surface">
+                        <div className="flex items-start justify-between gap-3">
+                          <h3 className="text-sm font-medium text-muted-foreground">Parameter {index + 1}</h3>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => removeParameter(index)}
+                            className="text-error-600 hover:text-error-700 hover:bg-error-50"
+                            title="Remove parameter"
+                          >
+                            <TrashIcon className="w-4 h-4" />
+                          </Button>
+                        </div>
+
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                          <Input
+                            label="Name"
+                            placeholder="title"
+                            value={row.name}
+                            onChange={(e) => updateParameter(index, { name: e.target.value })}
+                            maxLength={100}
+                          />
+                          <Select
+                            label="Type"
+                            value={row.type}
+                            options={PARAMETER_TYPE_OPTIONS}
+                            onChange={(e) =>
+                              updateParameter(index, { type: e.target.value as SnippetParameterType })
+                            }
+                          />
+                        </div>
+
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                          <Input
+                            label="Default value (optional)"
+                            placeholder="Default"
+                            value={row.defaultValue}
+                            onChange={(e) => updateParameter(index, { defaultValue: e.target.value })}
+                          />
+                          <Input
+                            label="Description (optional)"
+                            placeholder="What this parameter controls"
+                            value={row.description}
+                            onChange={(e) => updateParameter(index, { description: e.target.value })}
+                            maxLength={500}
+                          />
+                        </div>
+
+                        {row.type === 'select' && (
+                          <TextArea
+                            label="Options (one per line)"
+                            placeholder={'formal\ncasual'}
+                            value={row.optionsText}
+                            onChange={(e) => updateParameter(index, { optionsText: e.target.value })}
+                            rows={3}
+                            helperText="Required for select parameters. Enter one option per line."
+                          />
+                        )}
+
+                        <label className="inline-flex items-center gap-2 text-sm text-muted-foreground">
+                          <input
+                            type="checkbox"
+                            checked={row.required}
+                            onChange={(e) => updateParameter(index, { required: e.target.checked })}
+                            className="rounded border-border text-primary-600 focus:ring-ring"
+                          />
+                          Required
+                        </label>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              {fieldError && (
+                <ErrorDisplay title="Could not save snippet" message={fieldError} severity="error" compact />
+              )}
+
+              <div className="flex items-center justify-end gap-3 pt-2">
+                <Button type="button" variant="outline" onClick={() => navigate('/snippets')} disabled={isSaving}>
+                  Cancel
+                </Button>
+                <Button type="submit" isLoading={isSaving} disabled={isSaving}>
+                  {isEditMode ? 'Save changes' : 'Create snippet'}
+                </Button>
+              </div>
+            </form>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/dashboard-ui/src/pages/snippets/SnippetsListPage.tsx
+++ b/dashboard-ui/src/pages/snippets/SnippetsListPage.tsx
@@ -1,0 +1,164 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Button } from '@/components/ui/Button';
+import { useToast } from '@/components/ui/Toast';
+import { useConfirmationDialog } from '@/components/ui/ConfirmationDialog';
+import { ErrorDisplay } from '@/components/ui/ErrorDisplay';
+import { EmptyState, SkeletonLoader } from '@/components/ui/LoadingStates';
+import { snippetService } from '@/services/snippetService';
+import { getUserFriendlyErrorMessage } from '@/utils/errorHandling';
+import type { SnippetSummary } from '@/types/api';
+import {
+  PuzzlePieceIcon,
+  PlusIcon,
+  PencilSquareIcon,
+  TrashIcon,
+} from '@heroicons/react/24/outline';
+
+export function SnippetsListPage() {
+  const navigate = useNavigate();
+  const { addToast } = useToast();
+  const { showConfirmation, ConfirmationDialog } = useConfirmationDialog();
+
+  const [snippets, setSnippets] = useState<SnippetSummary[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  const loadSnippets = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    const response = await snippetService.listSnippets();
+    if (response.success && response.data) {
+      setSnippets(response.data.snippets);
+    } else {
+      setError(getUserFriendlyErrorMessage(response, 'snippet'));
+    }
+    setIsLoading(false);
+  }, []);
+
+  useEffect(() => {
+    loadSnippets();
+  }, [loadSnippets]);
+
+  const handleDelete = async (snippet: SnippetSummary) => {
+    try {
+      await showConfirmation({
+        title: 'Delete Snippet',
+        description: `Are you sure you want to delete "${snippet.name}"? This action cannot be undone.`,
+        confirmText: 'Delete Snippet',
+        type: 'danger',
+        isDestructive: true,
+        onConfirm: async () => {
+          setDeletingId(snippet.snippetId);
+          const response = await snippetService.deleteSnippet(snippet.snippetId);
+          if (response.success) {
+            addToast({ type: 'success', title: 'Snippet deleted', message: `${snippet.name} was removed` });
+            setSnippets((prev) => prev.filter((s) => s.snippetId !== snippet.snippetId));
+          } else {
+            throw new Error(getUserFriendlyErrorMessage(response, 'snippet'));
+          }
+        },
+      });
+    } catch (err) {
+      addToast({ type: 'error', title: 'Failed to delete snippet', message: getUserFriendlyErrorMessage(err, 'snippet') });
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-background">
+      <main className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
+        <div className="px-4 py-6 sm:px-0">
+          {/* Header */}
+          <div className="mb-6 sm:mb-8 flex items-start justify-between gap-4">
+            <div>
+              <h1 className="text-2xl sm:text-3xl font-bold text-foreground">Snippets</h1>
+              <p className="text-muted-foreground mt-2 text-sm sm:text-base">
+                Create and manage reusable Handlebars partials referenced in templates as {'{{> name }}'}.
+              </p>
+            </div>
+            <Button onClick={() => navigate('/snippets/new')}>
+              <PlusIcon className="w-4 h-4 mr-2" />
+              New snippet
+            </Button>
+          </div>
+
+          {isLoading ? (
+            <SkeletonLoader count={3} />
+          ) : error ? (
+            <ErrorDisplay
+              title="Error loading snippets"
+              message={error}
+              severity="error"
+              retryable
+              onRetry={loadSnippets}
+            />
+          ) : snippets.length === 0 ? (
+            <EmptyState
+              title="No snippets yet"
+              description="Create your first snippet to start building reusable partials."
+              icon={<PuzzlePieceIcon className="w-12 h-12 text-muted-foreground" />}
+              action={{ label: 'New snippet', onClick: () => navigate('/snippets/new') }}
+            />
+          ) : (
+            <div className="space-y-3">
+              {snippets.map((snippet) => (
+                <div
+                  key={snippet.snippetId}
+                  className="bg-surface border border-border rounded-lg p-4 sm:p-6 flex items-center justify-between gap-4 hover:border-primary-200 transition-colors"
+                >
+                  <button
+                    type="button"
+                    onClick={() => navigate(`/snippets/${snippet.snippetId}/edit`)}
+                    className="flex items-center gap-4 flex-1 min-w-0 text-left"
+                  >
+                    <div className="flex-shrink-0 w-10 h-10 bg-primary-100 rounded-lg flex items-center justify-center">
+                      <PuzzlePieceIcon className="w-5 h-5 text-primary-600" />
+                    </div>
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2">
+                        <h3 className="text-base font-medium text-foreground truncate">{snippet.name}</h3>
+                      </div>
+                      {snippet.description && (
+                        <p className="text-sm text-muted-foreground truncate mt-0.5">{snippet.description}</p>
+                      )}
+                      <p className="text-xs text-muted-foreground mt-1">
+                        Updated {new Date(snippet.updatedAt).toLocaleDateString()} · v{snippet.version}
+                      </p>
+                    </div>
+                  </button>
+
+                  <div className="flex items-center gap-2 flex-shrink-0">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => navigate(`/snippets/${snippet.snippetId}/edit`)}
+                      title="Edit snippet"
+                    >
+                      <PencilSquareIcon className="w-4 h-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => handleDelete(snippet)}
+                      disabled={deletingId === snippet.snippetId}
+                      isLoading={deletingId === snippet.snippetId}
+                      className="text-error-600 hover:text-error-700 hover:bg-error-50"
+                      title="Delete snippet"
+                    >
+                      <TrashIcon className="w-4 h-4" />
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </main>
+
+      <ConfirmationDialog />
+    </div>
+  );
+}

--- a/dashboard-ui/src/pages/snippets/index.ts
+++ b/dashboard-ui/src/pages/snippets/index.ts
@@ -1,0 +1,2 @@
+export { SnippetsListPage } from './SnippetsListPage';
+export { SnippetFormPage } from './SnippetFormPage';

--- a/dashboard-ui/src/services/__tests__/snippetService.test.ts
+++ b/dashboard-ui/src/services/__tests__/snippetService.test.ts
@@ -1,0 +1,164 @@
+import { snippetService } from '../snippetService';
+import { apiClient } from '../api';
+import type { Snippet, ListSnippetsResponse } from '@/types/api';
+
+vi.mock('../api');
+
+const mockApiClient = vi.mocked(apiClient);
+
+const mockSnippet: Snippet = {
+  snippetId: 'snip-123',
+  name: 'sponsorBlock',
+  description: 'Reusable sponsor block',
+  content: '<div>{{ title }}</div>',
+  parameters: [
+    { name: 'title', type: 'string', required: true },
+  ],
+  version: 1,
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-01T00:00:00Z',
+};
+
+describe('SnippetService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('listSnippets', () => {
+    it('calls the snippets endpoint', async () => {
+      const data: ListSnippetsResponse = { snippets: [mockSnippet], total: 1 };
+      mockApiClient.get.mockResolvedValue({ success: true, data });
+
+      const result = await snippetService.listSnippets();
+
+      expect(mockApiClient.get).toHaveBeenCalledWith('/snippets');
+      expect(result.success).toBe(true);
+      expect(result.data?.total).toBe(1);
+    });
+  });
+
+  describe('getSnippet', () => {
+    it('calls the endpoint with the snippet ID', async () => {
+      mockApiClient.get.mockResolvedValue({ success: true, data: mockSnippet });
+
+      const result = await snippetService.getSnippet('snip-123');
+
+      expect(mockApiClient.get).toHaveBeenCalledWith('/snippets/snip-123');
+      expect(result.success).toBe(true);
+    });
+
+    it('returns an error when ID is missing', async () => {
+      const result = await snippetService.getSnippet('');
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('MISSING_SNIPPET_ID');
+      expect(mockApiClient.get).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('createSnippet', () => {
+    it('posts a normalized (trimmed) payload', async () => {
+      mockApiClient.post.mockResolvedValue({ success: true, data: mockSnippet });
+
+      const result = await snippetService.createSnippet({
+        name: '  sponsorBlock  ',
+        content: '<div>{{ title }}</div>',
+        description: '  Reusable sponsor block  ',
+      });
+
+      expect(mockApiClient.post).toHaveBeenCalledWith('/snippets', {
+        name: 'sponsorBlock',
+        content: '<div>{{ title }}</div>',
+        description: 'Reusable sponsor block',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects an empty name before calling the API', async () => {
+      const result = await snippetService.createSnippet({ name: '   ', content: 'x' });
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('VALIDATION_ERROR');
+      expect(mockApiClient.post).not.toHaveBeenCalled();
+    });
+
+    it('rejects empty content before calling the API', async () => {
+      const result = await snippetService.createSnippet({ name: 'valid', content: '   ' });
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('VALIDATION_ERROR');
+      expect(mockApiClient.post).not.toHaveBeenCalled();
+    });
+
+    it('rejects names with spaces', async () => {
+      const result = await snippetService.createSnippet({ name: 'bad name', content: 'x' });
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('VALIDATION_ERROR');
+      expect(mockApiClient.post).not.toHaveBeenCalled();
+    });
+
+    it('rejects names that do not start with a letter', async () => {
+      const result = await snippetService.createSnippet({ name: '1abc', content: 'x' });
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('VALIDATION_ERROR');
+      expect(mockApiClient.post).not.toHaveBeenCalled();
+    });
+
+    it('allows names with underscores and hyphens', async () => {
+      mockApiClient.post.mockResolvedValue({ success: true, data: mockSnippet });
+      const result = await snippetService.createSnippet({ name: 'footer_block-1', content: 'x' });
+      expect(result.success).toBe(true);
+      expect(mockApiClient.post).toHaveBeenCalled();
+    });
+
+    it('forwards parameters in the payload', async () => {
+      mockApiClient.post.mockResolvedValue({ success: true, data: mockSnippet });
+      await snippetService.createSnippet({
+        name: 'sponsorBlock',
+        content: 'x',
+        parameters: [{ name: 'tone', type: 'select', required: false, options: ['formal'] }],
+      });
+      expect(mockApiClient.post).toHaveBeenCalledWith('/snippets', expect.objectContaining({
+        parameters: [{ name: 'tone', type: 'select', required: false, options: ['formal'] }],
+      }));
+    });
+  });
+
+  describe('updateSnippet', () => {
+    it('puts to the endpoint with the snippet ID', async () => {
+      mockApiClient.put.mockResolvedValue({ success: true, data: mockSnippet });
+
+      const result = await snippetService.updateSnippet('snip-123', { name: 'renamed' });
+
+      expect(mockApiClient.put).toHaveBeenCalledWith('/snippets/snip-123', { name: 'renamed' });
+      expect(result.success).toBe(true);
+    });
+
+    it('returns an error when ID is missing', async () => {
+      const result = await snippetService.updateSnippet('', { name: 'x' });
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('MISSING_SNIPPET_ID');
+      expect(mockApiClient.put).not.toHaveBeenCalled();
+    });
+
+    it('skips name/content validation when not provided', async () => {
+      mockApiClient.put.mockResolvedValue({ success: true, data: mockSnippet });
+      const result = await snippetService.updateSnippet('snip-123', { description: 'new' });
+      expect(result.success).toBe(true);
+      expect(mockApiClient.put).toHaveBeenCalledWith('/snippets/snip-123', { description: 'new' });
+    });
+  });
+
+  describe('deleteSnippet', () => {
+    it('calls delete with the snippet ID', async () => {
+      mockApiClient.delete.mockResolvedValue({ success: true });
+      const result = await snippetService.deleteSnippet('snip-123');
+      expect(mockApiClient.delete).toHaveBeenCalledWith('/snippets/snip-123');
+      expect(result.success).toBe(true);
+    });
+
+    it('returns an error when ID is missing', async () => {
+      const result = await snippetService.deleteSnippet('');
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('MISSING_SNIPPET_ID');
+      expect(mockApiClient.delete).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/dashboard-ui/src/services/snippetService.ts
+++ b/dashboard-ui/src/services/snippetService.ts
@@ -1,0 +1,115 @@
+import { apiClient } from './api';
+import type {
+  ApiResponse,
+  Snippet,
+  ListSnippetsResponse,
+  CreateSnippetRequest,
+  UpdateSnippetRequest,
+} from '@/types/api';
+
+/**
+ * Snippet names are referenced inside templates as `{{> name }}`, so they must
+ * be a valid Handlebars partial identifier (mirrors backend validation):
+ * start with a letter and contain only letters, numbers, underscores, and
+ * hyphens. No spaces are allowed.
+ */
+const SNIPPET_NAME_PATTERN = /^[a-zA-Z][a-zA-Z0-9_-]*$/;
+const NAME_MAX_LENGTH = 100;
+
+/**
+ * Snippet Service - CRUD operations for reusable Handlebars snippets (partials).
+ */
+export class SnippetService {
+  /**
+   * List all snippets for the authenticated tenant (summaries, no content).
+   */
+  async listSnippets(): Promise<ApiResponse<ListSnippetsResponse>> {
+    return apiClient.get<ListSnippetsResponse>('/snippets');
+  }
+
+  /**
+   * Get a single snippet including its content and parameters.
+   */
+  async getSnippet(snippetId: string): Promise<ApiResponse<Snippet>> {
+    if (!snippetId) {
+      return { success: false, error: 'Snippet ID is required', errorCode: 'MISSING_SNIPPET_ID' };
+    }
+    return apiClient.get<Snippet>(`/snippets/${snippetId}`);
+  }
+
+  /**
+   * Create a new snippet.
+   */
+  async createSnippet(data: CreateSnippetRequest): Promise<ApiResponse<Snippet>> {
+    const validationError = this.validateSnippet(data.name, data.content);
+    if (validationError) {
+      return { success: false, error: validationError, errorCode: 'VALIDATION_ERROR' };
+    }
+    return apiClient.post<Snippet>('/snippets', this.normalize(data));
+  }
+
+  /**
+   * Update an existing snippet.
+   */
+  async updateSnippet(snippetId: string, data: UpdateSnippetRequest): Promise<ApiResponse<Snippet>> {
+    if (!snippetId) {
+      return { success: false, error: 'Snippet ID is required', errorCode: 'MISSING_SNIPPET_ID' };
+    }
+
+    const validationError = this.validateSnippet(data.name, data.content);
+    if (validationError) {
+      return { success: false, error: validationError, errorCode: 'VALIDATION_ERROR' };
+    }
+
+    return apiClient.put<Snippet>(`/snippets/${snippetId}`, this.normalize(data));
+  }
+
+  /**
+   * Delete a snippet.
+   */
+  async deleteSnippet(snippetId: string): Promise<ApiResponse<void>> {
+    if (!snippetId) {
+      return { success: false, error: 'Snippet ID is required', errorCode: 'MISSING_SNIPPET_ID' };
+    }
+    return apiClient.delete<void>(`/snippets/${snippetId}`);
+  }
+
+  /**
+   * Validate a snippet name and content. Returns an error message or null.
+   * `name` and `content` may be undefined on partial updates, in which case
+   * the corresponding check is skipped.
+   */
+  validateSnippet(name?: string, content?: string): string | null {
+    if (name !== undefined) {
+      const trimmed = name.trim();
+      if (!trimmed) {
+        return 'Snippet name is required';
+      }
+      if (trimmed.length > NAME_MAX_LENGTH) {
+        return `Snippet name must be ${NAME_MAX_LENGTH} characters or less`;
+      }
+      if (!SNIPPET_NAME_PATTERN.test(trimmed)) {
+        return 'Snippet name must start with a letter and contain only letters, numbers, underscores, and hyphens (no spaces)';
+      }
+    }
+
+    if (content !== undefined && !content.trim()) {
+      return 'Snippet content is required';
+    }
+
+    return null;
+  }
+
+  /**
+   * Trim string fields so what we send matches what the backend stores.
+   */
+  private normalize<T extends UpdateSnippetRequest>(data: T): T {
+    return {
+      ...data,
+      ...(data.name !== undefined && { name: data.name.trim() }),
+      ...(data.description !== undefined && { description: data.description.trim() }),
+    };
+  }
+}
+
+export const snippetService = new SnippetService();

--- a/dashboard-ui/src/types/api.ts
+++ b/dashboard-ui/src/types/api.ts
@@ -263,6 +263,51 @@ export interface UpdateTemplateRequest {
   sampleData?: Record<string, unknown>;
 }
 
+// Snippet Types
+export type SnippetParameterType = 'string' | 'number' | 'boolean' | 'select' | 'textarea' | 'url';
+
+export interface SnippetParameter {
+  name: string;
+  type: SnippetParameterType;
+  required: boolean;
+  defaultValue?: unknown;
+  description?: string;
+  options?: string[];
+}
+
+export interface SnippetSummary {
+  snippetId: string;
+  name: string;
+  description?: string;
+  version: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Snippet extends SnippetSummary {
+  content: string;
+  parameters?: SnippetParameter[];
+}
+
+export interface ListSnippetsResponse {
+  snippets: SnippetSummary[];
+  total: number;
+}
+
+export interface CreateSnippetRequest {
+  name: string;
+  description?: string;
+  content: string;
+  parameters?: SnippetParameter[];
+}
+
+export interface UpdateSnippetRequest {
+  name?: string;
+  description?: string;
+  content?: string;
+  parameters?: SnippetParameter[];
+}
+
 export interface SendTestEmailResponse {
   messageId: string;
   recipientEmail: string;

--- a/dashboard-ui/src/utils/lazyImports.ts
+++ b/dashboard-ui/src/utils/lazyImports.ts
@@ -153,6 +153,22 @@ export const LazyTemplateFormPage = lazy(() =>
     })
 );
 
+export const LazySnippetsListPage = lazy(() =>
+  import('@/pages/snippets').then(module => ({ default: module.SnippetsListPage }))
+    .catch(error => {
+      console.error('Failed to load SnippetsListPage:', error);
+      throw error;
+    })
+);
+
+export const LazySnippetFormPage = lazy(() =>
+  import('@/pages/snippets').then(module => ({ default: module.SnippetFormPage }))
+    .catch(error => {
+      console.error('Failed to load SnippetFormPage:', error);
+      throw error;
+    })
+);
+
 // Preload critical routes
 export const preloadCriticalRoutes = () => {
   // Preload dashboard since it's the default route
@@ -208,6 +224,9 @@ export const preloadRoute = (routeName: string) => {
       break;
     case 'templates':
       import('@/pages/templates');
+      break;
+    case 'snippets':
+      import('@/pages/snippets');
       break;
     case 'login':
       import('@/pages/auth/LoginPage');

--- a/functions/src/api/controllers/mod.rs
+++ b/functions/src/api/controllers/mod.rs
@@ -6,6 +6,7 @@ pub mod pricing;
 pub mod profile;
 pub mod segments;
 pub mod senders;
+pub mod snippets;
 pub mod sponsors;
 pub mod subscribers;
 pub mod templates;

--- a/functions/src/api/controllers/snippets.rs
+++ b/functions/src/api/controllers/snippets.rs
@@ -1,0 +1,842 @@
+use aws_sdk_dynamodb::types::AttributeValue;
+use lambda_http::{Body, Error, Request, Response};
+use newsletter::admin::{auth, aws_clients, error::AppError, response};
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use serde_dynamo::from_item;
+use serde_json::{json, Value};
+use std::env;
+use std::sync::OnceLock;
+use uuid::Uuid;
+
+// ── Constants ──────────────────────────────────────────────────────────
+
+const SNIPPET_SK_PREFIX: &str = "snippet#";
+const SNIPPET_GSI1PK_PREFIX: &str = "snippet#";
+
+const NAME_MAX_LEN: usize = 100;
+const DESCRIPTION_MAX_LEN: usize = 500;
+/// Snippet content is stored inline in the DynamoDB item. DynamoDB items are
+/// capped at 400KB, so we cap content well below that to leave room for the
+/// rest of the record. Realistic Handlebars partials are well under this.
+const CONTENT_MAX_LEN: usize = 256 * 1024;
+
+const PARAMETER_NAME_MAX_LEN: usize = 100;
+const ALLOWED_PARAMETER_TYPES: [&str; 6] =
+    ["string", "number", "boolean", "select", "textarea", "url"];
+
+static SNIPPET_NAME_RE: OnceLock<Regex> = OnceLock::new();
+
+/// Snippet names are referenced inside Handlebars templates as `{{> name }}`,
+/// so they must be a valid partial identifier: start with a letter and contain
+/// only letters, digits, underscores, and hyphens (no spaces).
+fn snippet_name_regex() -> &'static Regex {
+    SNIPPET_NAME_RE.get_or_init(|| {
+        Regex::new(r"^[a-zA-Z][a-zA-Z0-9_-]*$").expect("Failed to compile snippet name regex")
+    })
+}
+
+// ── Key patterns ───────────────────────────────────────────────────────
+
+fn snippet_sk(snippet_id: &str) -> String {
+    format!("{}{}", SNIPPET_SK_PREFIX, snippet_id)
+}
+
+fn snippet_gsi1pk(tenant_id: &str) -> String {
+    format!("{}{}", SNIPPET_GSI1PK_PREFIX, tenant_id)
+}
+
+/// Normalize a snippet name for case-insensitive uniqueness and sorting.
+fn normalize_name(name: &str) -> String {
+    name.trim().to_lowercase()
+}
+
+// ── Data types ─────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SnippetParameter {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub param_type: String,
+    pub required: bool,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "defaultValue"
+    )]
+    pub default_value: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub options: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SnippetRecord {
+    pub pk: String,
+    pub sk: String,
+    #[serde(rename = "GSI1PK")]
+    pub gsi1pk: String,
+    #[serde(rename = "GSI1SK")]
+    pub gsi1sk: String,
+    #[serde(rename = "snippetId")]
+    pub snippet_id: String,
+    #[serde(rename = "tenantId")]
+    pub tenant_id: String,
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub content: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parameters: Option<Vec<SnippetParameter>>,
+    pub version: u64,
+    #[serde(rename = "createdAt")]
+    pub created_at: String,
+    #[serde(rename = "updatedAt")]
+    pub updated_at: String,
+}
+
+#[derive(Debug, Serialize)]
+struct SnippetSummary {
+    #[serde(rename = "snippetId")]
+    snippet_id: String,
+    name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    version: u64,
+    #[serde(rename = "createdAt")]
+    created_at: String,
+    #[serde(rename = "updatedAt")]
+    updated_at: String,
+}
+
+impl From<SnippetRecord> for SnippetSummary {
+    fn from(s: SnippetRecord) -> Self {
+        SnippetSummary {
+            snippet_id: s.snippet_id,
+            name: s.name,
+            description: s.description,
+            version: s.version,
+            created_at: s.created_at,
+            updated_at: s.updated_at,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct SnippetDetail {
+    #[serde(rename = "snippetId")]
+    snippet_id: String,
+    name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    content: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    parameters: Option<Vec<SnippetParameter>>,
+    version: u64,
+    #[serde(rename = "createdAt")]
+    created_at: String,
+    #[serde(rename = "updatedAt")]
+    updated_at: String,
+}
+
+impl From<SnippetRecord> for SnippetDetail {
+    fn from(s: SnippetRecord) -> Self {
+        SnippetDetail {
+            snippet_id: s.snippet_id,
+            name: s.name,
+            description: s.description,
+            content: s.content,
+            parameters: s.parameters,
+            version: s.version,
+            created_at: s.created_at,
+            updated_at: s.updated_at,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct ListSnippetsResponse {
+    snippets: Vec<SnippetSummary>,
+    total: usize,
+}
+
+#[derive(Deserialize)]
+struct CreateSnippetRequest {
+    name: Option<String>,
+    description: Option<String>,
+    content: Option<String>,
+    parameters: Option<Vec<SnippetParameter>>,
+}
+
+#[derive(Deserialize)]
+struct UpdateSnippetRequest {
+    name: Option<String>,
+    description: Option<String>,
+    content: Option<String>,
+    parameters: Option<Vec<SnippetParameter>>,
+}
+
+// ── Validation ─────────────────────────────────────────────────────────
+
+fn validate_name(name: &str) -> Result<String, AppError> {
+    let trimmed = name.trim();
+
+    if trimmed.is_empty() {
+        return Err(AppError::BadRequest("Snippet name is required".to_string()));
+    }
+
+    if trimmed.chars().count() > NAME_MAX_LEN {
+        return Err(AppError::BadRequest(format!(
+            "Snippet name must be {} characters or less",
+            NAME_MAX_LEN
+        )));
+    }
+
+    if !snippet_name_regex().is_match(trimmed) {
+        return Err(AppError::BadRequest(
+            "Snippet name must start with a letter and contain only letters, numbers, underscores, and hyphens (no spaces)"
+                .to_string(),
+        ));
+    }
+
+    Ok(trimmed.to_string())
+}
+
+fn validate_description(description: &str) -> Result<(), AppError> {
+    if description.chars().count() > DESCRIPTION_MAX_LEN {
+        return Err(AppError::BadRequest(format!(
+            "Description must be {} characters or less",
+            DESCRIPTION_MAX_LEN
+        )));
+    }
+    Ok(())
+}
+
+fn validate_content(content: &str) -> Result<(), AppError> {
+    if content.trim().is_empty() {
+        return Err(AppError::BadRequest(
+            "Snippet content is required".to_string(),
+        ));
+    }
+
+    if content.len() > CONTENT_MAX_LEN {
+        return Err(AppError::BadRequest(format!(
+            "Snippet content must be {}KB or less",
+            CONTENT_MAX_LEN / 1024
+        )));
+    }
+
+    // Compile the content as Handlebars to surface syntax errors early.
+    // Unknown partials (i.e. other snippets that aren't managed yet) are
+    // resolved at render time, not registration, so they do not fail this check.
+    let mut hb = handlebars::Handlebars::new();
+    hb.register_template_string("__validate__", content)
+        .map_err(|e| {
+            AppError::BadRequest(format!("Snippet content is not valid Handlebars: {}", e))
+        })?;
+
+    Ok(())
+}
+
+/// Validate the optional parameter schema. Each parameter must have a non-empty
+/// name, a recognized type, and `options` are only meaningful for `select`.
+fn validate_parameters(parameters: &[SnippetParameter]) -> Result<(), AppError> {
+    for parameter in parameters {
+        let name = parameter.name.trim();
+        if name.is_empty() {
+            return Err(AppError::BadRequest(
+                "Each parameter must have a name".to_string(),
+            ));
+        }
+        if name.chars().count() > PARAMETER_NAME_MAX_LEN {
+            return Err(AppError::BadRequest(format!(
+                "Parameter name must be {} characters or less",
+                PARAMETER_NAME_MAX_LEN
+            )));
+        }
+        if !ALLOWED_PARAMETER_TYPES.contains(&parameter.param_type.as_str()) {
+            return Err(AppError::BadRequest(format!(
+                "Parameter \"{}\" has an unsupported type \"{}\"",
+                name, parameter.param_type
+            )));
+        }
+        if let Some(ref description) = parameter.description {
+            validate_description(description)?;
+        }
+        if parameter.param_type == "select" {
+            match &parameter.options {
+                Some(options) if !options.is_empty() => {}
+                _ => {
+                    return Err(AppError::BadRequest(format!(
+                        "Parameter \"{}\" of type select must include at least one option",
+                        name
+                    )));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Normalize parameters for storage (trim names/descriptions).
+fn normalize_parameters(parameters: Vec<SnippetParameter>) -> Vec<SnippetParameter> {
+    parameters
+        .into_iter()
+        .map(|p| SnippetParameter {
+            name: p.name.trim().to_string(),
+            param_type: p.param_type,
+            required: p.required,
+            default_value: p.default_value,
+            description: p.description.map(|d| d.trim().to_string()),
+            options: p.options,
+        })
+        .collect()
+}
+
+// ── Handlers ───────────────────────────────────────────────────────────
+
+pub async fn list_snippets(event: Request) -> Result<Response<Body>, Error> {
+    match handle_list_snippets(event).await {
+        Ok(response) => Ok(response),
+        Err(e) => Ok(response::format_error_response(&e)),
+    }
+}
+
+async fn handle_list_snippets(event: Request) -> Result<Response<Body>, AppError> {
+    let tenant_id = require_tenant(&event)?;
+    let snippets = query_snippets_by_tenant(&tenant_id).await?;
+
+    let summaries: Vec<SnippetSummary> = snippets.into_iter().map(SnippetSummary::from).collect();
+
+    response::format_response(
+        200,
+        ListSnippetsResponse {
+            total: summaries.len(),
+            snippets: summaries,
+        },
+    )
+}
+
+pub async fn create_snippet(event: Request) -> Result<Response<Body>, Error> {
+    match handle_create_snippet(event).await {
+        Ok(response) => Ok(response),
+        Err(e) => Ok(response::format_error_response(&e)),
+    }
+}
+
+async fn handle_create_snippet(event: Request) -> Result<Response<Body>, AppError> {
+    let tenant_id = require_tenant(&event)?;
+
+    let body: CreateSnippetRequest = serde_json::from_slice(event.body())
+        .map_err(|e| AppError::BadRequest(format!("Invalid JSON: {}", e)))?;
+
+    let name = validate_name(body.name.as_deref().unwrap_or_default())?;
+    let content = body.content.unwrap_or_default();
+    validate_content(&content)?;
+
+    if let Some(ref description) = body.description {
+        validate_description(description)?;
+    }
+
+    let parameters = match body.parameters {
+        Some(parameters) => {
+            validate_parameters(&parameters)?;
+            Some(normalize_parameters(parameters))
+        }
+        None => None,
+    };
+
+    if snippet_name_exists(&tenant_id, &name, None).await? {
+        return Err(AppError::Conflict(format!(
+            "A snippet with the name \"{}\" already exists",
+            name
+        )));
+    }
+
+    let snippet_id = Uuid::new_v4().to_string();
+    let now = chrono::Utc::now().to_rfc3339();
+
+    let record = SnippetRecord {
+        pk: tenant_id.clone(),
+        sk: snippet_sk(&snippet_id),
+        gsi1pk: snippet_gsi1pk(&tenant_id),
+        gsi1sk: normalize_name(&name),
+        snippet_id,
+        tenant_id,
+        name,
+        description: body.description.map(|d| d.trim().to_string()),
+        content,
+        parameters,
+        version: 1,
+        created_at: now.clone(),
+        updated_at: now,
+    };
+
+    put_snippet(&record, true).await?;
+
+    response::format_response(201, SnippetDetail::from(record))
+}
+
+pub async fn get_snippet(
+    event: Request,
+    snippet_id: Option<String>,
+) -> Result<Response<Body>, Error> {
+    match handle_get_snippet(event, snippet_id).await {
+        Ok(response) => Ok(response),
+        Err(e) => Ok(response::format_error_response(&e)),
+    }
+}
+
+async fn handle_get_snippet(
+    event: Request,
+    snippet_id: Option<String>,
+) -> Result<Response<Body>, AppError> {
+    let tenant_id = require_tenant(&event)?;
+    let snippet_id =
+        snippet_id.ok_or_else(|| AppError::BadRequest("Snippet ID is required".to_string()))?;
+
+    let record = get_snippet_record(&tenant_id, &snippet_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound("Snippet not found".to_string()))?;
+
+    response::format_response(200, SnippetDetail::from(record))
+}
+
+pub async fn update_snippet(
+    event: Request,
+    snippet_id: Option<String>,
+) -> Result<Response<Body>, Error> {
+    match handle_update_snippet(event, snippet_id).await {
+        Ok(response) => Ok(response),
+        Err(e) => Ok(response::format_error_response(&e)),
+    }
+}
+
+async fn handle_update_snippet(
+    event: Request,
+    snippet_id: Option<String>,
+) -> Result<Response<Body>, AppError> {
+    let tenant_id = require_tenant(&event)?;
+    let snippet_id =
+        snippet_id.ok_or_else(|| AppError::BadRequest("Snippet ID is required".to_string()))?;
+
+    let body: UpdateSnippetRequest = serde_json::from_slice(event.body())
+        .map_err(|e| AppError::BadRequest(format!("Invalid JSON: {}", e)))?;
+
+    if body.name.is_none()
+        && body.description.is_none()
+        && body.content.is_none()
+        && body.parameters.is_none()
+    {
+        return Err(AppError::BadRequest(
+            "At least one field must be provided for update".to_string(),
+        ));
+    }
+
+    let mut record = get_snippet_record(&tenant_id, &snippet_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound("Snippet not found".to_string()))?;
+
+    if let Some(name) = body.name {
+        let validated = validate_name(&name)?;
+        if normalize_name(&validated) != record.gsi1sk
+            && snippet_name_exists(&tenant_id, &validated, Some(&snippet_id)).await?
+        {
+            return Err(AppError::Conflict(format!(
+                "A snippet with the name \"{}\" already exists",
+                validated
+            )));
+        }
+        record.gsi1sk = normalize_name(&validated);
+        record.name = validated;
+    }
+
+    if let Some(description) = body.description {
+        validate_description(&description)?;
+        record.description = Some(description.trim().to_string());
+    }
+
+    if let Some(content) = body.content {
+        validate_content(&content)?;
+        record.content = content;
+    }
+
+    if let Some(parameters) = body.parameters {
+        validate_parameters(&parameters)?;
+        record.parameters = Some(normalize_parameters(parameters));
+    }
+
+    record.version += 1;
+    record.updated_at = chrono::Utc::now().to_rfc3339();
+
+    put_snippet(&record, false).await?;
+
+    response::format_response(200, SnippetDetail::from(record))
+}
+
+pub async fn delete_snippet(
+    event: Request,
+    snippet_id: Option<String>,
+) -> Result<Response<Body>, Error> {
+    match handle_delete_snippet(event, snippet_id).await {
+        Ok(response) => Ok(response),
+        Err(e) => Ok(response::format_error_response(&e)),
+    }
+}
+
+async fn handle_delete_snippet(
+    event: Request,
+    snippet_id: Option<String>,
+) -> Result<Response<Body>, AppError> {
+    let tenant_id = require_tenant(&event)?;
+    let snippet_id =
+        snippet_id.ok_or_else(|| AppError::BadRequest("Snippet ID is required".to_string()))?;
+
+    let client = aws_clients::get_dynamodb_client().await;
+    let table_name = table_name()?;
+
+    client
+        .delete_item()
+        .table_name(table_name)
+        .key("pk", AttributeValue::S(tenant_id))
+        .key("sk", AttributeValue::S(snippet_sk(&snippet_id)))
+        .condition_expression("attribute_exists(pk) AND attribute_exists(sk)")
+        .send()
+        .await
+        .map_err(|e| {
+            if e.to_string().contains("ConditionalCheckFailed") {
+                AppError::NotFound("Snippet not found".to_string())
+            } else {
+                AppError::AwsError(format!("DynamoDB delete failed: {}", e))
+            }
+        })?;
+
+    response::format_response(200, json!({ "message": "Snippet deleted" }))
+}
+
+// ── Persistence helpers ────────────────────────────────────────────────
+
+fn require_tenant(event: &Request) -> Result<String, AppError> {
+    let user_context = auth::get_user_context(event)?;
+    user_context
+        .tenant_id
+        .ok_or_else(|| AppError::Unauthorized("Tenant access required".to_string()))
+}
+
+fn table_name() -> Result<String, AppError> {
+    env::var("TABLE_NAME")
+        .map_err(|_| AppError::InternalError("TABLE_NAME not configured".to_string()))
+}
+
+async fn query_snippets_by_tenant(tenant_id: &str) -> Result<Vec<SnippetRecord>, AppError> {
+    let client = aws_clients::get_dynamodb_client().await;
+    let table_name = table_name()?;
+
+    let result = client
+        .query()
+        .table_name(table_name)
+        .index_name("GSI1")
+        .key_condition_expression("GSI1PK = :gsi1pk")
+        .expression_attribute_values(":gsi1pk", AttributeValue::S(snippet_gsi1pk(tenant_id)))
+        .send()
+        .await
+        .map_err(|e| AppError::AwsError(format!("Failed to query snippets: {}", e)))?;
+
+    let snippets = result
+        .items()
+        .iter()
+        .filter_map(|item| {
+            from_item::<_, SnippetRecord>(item.clone())
+                .map_err(|e| tracing::error!("Failed to deserialize snippet: {}", e))
+                .ok()
+        })
+        .collect();
+
+    Ok(snippets)
+}
+
+async fn get_snippet_record(
+    tenant_id: &str,
+    snippet_id: &str,
+) -> Result<Option<SnippetRecord>, AppError> {
+    let client = aws_clients::get_dynamodb_client().await;
+    let table_name = table_name()?;
+
+    let result = client
+        .get_item()
+        .table_name(table_name)
+        .key("pk", AttributeValue::S(tenant_id.to_string()))
+        .key("sk", AttributeValue::S(snippet_sk(snippet_id)))
+        .send()
+        .await
+        .map_err(|e| AppError::AwsError(format!("Failed to get snippet: {}", e)))?;
+
+    match result.item {
+        Some(item) => {
+            let record: SnippetRecord = from_item(item).map_err(|e| {
+                AppError::InternalError(format!("Failed to deserialize snippet: {}", e))
+            })?;
+            Ok(Some(record))
+        }
+        None => Ok(None),
+    }
+}
+
+/// Returns true if a snippet with the given (case-insensitive) name already
+/// exists for the tenant, optionally excluding a specific snippet id.
+async fn snippet_name_exists(
+    tenant_id: &str,
+    name: &str,
+    exclude_snippet_id: Option<&str>,
+) -> Result<bool, AppError> {
+    let client = aws_clients::get_dynamodb_client().await;
+    let table_name = table_name()?;
+
+    let result = client
+        .query()
+        .table_name(table_name)
+        .index_name("GSI1")
+        .key_condition_expression("GSI1PK = :gsi1pk AND GSI1SK = :name")
+        .expression_attribute_values(":gsi1pk", AttributeValue::S(snippet_gsi1pk(tenant_id)))
+        .expression_attribute_values(":name", AttributeValue::S(normalize_name(name)))
+        .send()
+        .await
+        .map_err(|e| AppError::AwsError(format!("Failed to check snippet name: {}", e)))?;
+
+    let exists = result.items().iter().any(|item| {
+        let item_id = item.get("snippetId").and_then(|v| v.as_s().ok());
+        match (item_id, exclude_snippet_id) {
+            (Some(id), Some(exclude)) => id != exclude,
+            (Some(_), None) => true,
+            _ => false,
+        }
+    });
+
+    Ok(exists)
+}
+
+async fn put_snippet(record: &SnippetRecord, ensure_new: bool) -> Result<(), AppError> {
+    let client = aws_clients::get_dynamodb_client().await;
+    let table_name = table_name()?;
+
+    let item = serde_dynamo::to_item(record)
+        .map_err(|e| AppError::InternalError(format!("Failed to serialize snippet: {}", e)))?;
+
+    let mut request = client
+        .put_item()
+        .table_name(table_name)
+        .set_item(Some(item));
+
+    if ensure_new {
+        request =
+            request.condition_expression("attribute_not_exists(pk) AND attribute_not_exists(sk)");
+    } else {
+        request = request.condition_expression("attribute_exists(pk) AND attribute_exists(sk)");
+    }
+
+    request.send().await.map_err(|e| {
+        if e.to_string().contains("ConditionalCheckFailed") {
+            if ensure_new {
+                AppError::Conflict("Snippet already exists".to_string())
+            } else {
+                AppError::NotFound("Snippet not found".to_string())
+            }
+        } else {
+            AppError::AwsError(format!("DynamoDB put failed: {}", e))
+        }
+    })?;
+
+    Ok(())
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_snippet_sk() {
+        assert_eq!(snippet_sk("abc-123"), "snippet#abc-123");
+    }
+
+    #[test]
+    fn test_snippet_gsi1pk() {
+        assert_eq!(snippet_gsi1pk("tenant-1"), "snippet#tenant-1");
+    }
+
+    #[test]
+    fn test_normalize_name() {
+        assert_eq!(normalize_name("  Sponsor_Block  "), "sponsor_block");
+    }
+
+    #[test]
+    fn test_validate_name_ok() {
+        assert_eq!(validate_name("  sponsorBlock  ").unwrap(), "sponsorBlock");
+        assert_eq!(validate_name("Footer-1").unwrap(), "Footer-1");
+        assert_eq!(validate_name("a_b_c").unwrap(), "a_b_c");
+    }
+
+    #[test]
+    fn test_validate_name_empty() {
+        assert!(validate_name("   ").is_err());
+    }
+
+    #[test]
+    fn test_validate_name_too_long() {
+        let long = "a".repeat(NAME_MAX_LEN + 1);
+        assert!(validate_name(&long).is_err());
+    }
+
+    #[test]
+    fn test_validate_name_invalid_chars() {
+        // Spaces are not allowed because the name is a partial identifier.
+        assert!(validate_name("bad name").is_err());
+        assert!(validate_name("bad/name").is_err());
+        assert!(validate_name("bad<name>").is_err());
+        // Must start with a letter.
+        assert!(validate_name("1abc").is_err());
+        assert!(validate_name("-abc").is_err());
+        assert!(validate_name("_abc").is_err());
+    }
+
+    #[test]
+    fn test_validate_content_empty() {
+        assert!(validate_content("   ").is_err());
+    }
+
+    #[test]
+    fn test_validate_content_valid_handlebars() {
+        assert!(validate_content("<div>{{ title }}</div>{{#each items}}{{this}}{{/each}}").is_ok());
+    }
+
+    #[test]
+    fn test_validate_content_unknown_partial_is_allowed() {
+        // Partials (other snippets) are resolved at render time, so referencing
+        // one that isn't registered should still validate successfully.
+        assert!(validate_content("<div>{{> otherSnippet }}</div>").is_ok());
+    }
+
+    #[test]
+    fn test_validate_content_invalid_handlebars() {
+        // Unclosed block helper should fail to compile.
+        assert!(validate_content("{{#if foo}}no close").is_err());
+    }
+
+    #[test]
+    fn test_validate_parameters_ok() {
+        let parameters = vec![
+            SnippetParameter {
+                name: "title".to_string(),
+                param_type: "string".to_string(),
+                required: true,
+                default_value: None,
+                description: Some("The title".to_string()),
+                options: None,
+            },
+            SnippetParameter {
+                name: "tone".to_string(),
+                param_type: "select".to_string(),
+                required: false,
+                default_value: Some(json!("formal")),
+                description: None,
+                options: Some(vec!["formal".to_string(), "casual".to_string()]),
+            },
+        ];
+        assert!(validate_parameters(&parameters).is_ok());
+    }
+
+    #[test]
+    fn test_validate_parameters_empty_name() {
+        let parameters = vec![SnippetParameter {
+            name: "  ".to_string(),
+            param_type: "string".to_string(),
+            required: false,
+            default_value: None,
+            description: None,
+            options: None,
+        }];
+        assert!(validate_parameters(&parameters).is_err());
+    }
+
+    #[test]
+    fn test_validate_parameters_unknown_type() {
+        let parameters = vec![SnippetParameter {
+            name: "x".to_string(),
+            param_type: "datetime".to_string(),
+            required: false,
+            default_value: None,
+            description: None,
+            options: None,
+        }];
+        assert!(validate_parameters(&parameters).is_err());
+    }
+
+    #[test]
+    fn test_validate_parameters_select_requires_options() {
+        let parameters = vec![SnippetParameter {
+            name: "tone".to_string(),
+            param_type: "select".to_string(),
+            required: false,
+            default_value: None,
+            description: None,
+            options: None,
+        }];
+        assert!(validate_parameters(&parameters).is_err());
+
+        let empty_options = vec![SnippetParameter {
+            name: "tone".to_string(),
+            param_type: "select".to_string(),
+            required: false,
+            default_value: None,
+            description: None,
+            options: Some(vec![]),
+        }];
+        assert!(validate_parameters(&empty_options).is_err());
+    }
+
+    #[test]
+    fn test_normalize_parameters_trims() {
+        let parameters = vec![SnippetParameter {
+            name: "  title  ".to_string(),
+            param_type: "string".to_string(),
+            required: true,
+            default_value: None,
+            description: Some("  desc  ".to_string()),
+            options: None,
+        }];
+        let normalized = normalize_parameters(parameters);
+        assert_eq!(normalized[0].name, "title");
+        assert_eq!(normalized[0].description, Some("desc".to_string()));
+    }
+
+    #[test]
+    fn test_detail_round_trips_parameters() {
+        let record = SnippetRecord {
+            pk: "tenant".to_string(),
+            sk: snippet_sk("s1"),
+            gsi1pk: snippet_gsi1pk("tenant"),
+            gsi1sk: "sponsorblock".to_string(),
+            snippet_id: "s1".to_string(),
+            tenant_id: "tenant".to_string(),
+            name: "sponsorBlock".to_string(),
+            description: None,
+            content: "<div>{{ title }}</div>".to_string(),
+            parameters: Some(vec![SnippetParameter {
+                name: "title".to_string(),
+                param_type: "string".to_string(),
+                required: true,
+                default_value: None,
+                description: None,
+                options: None,
+            }]),
+            version: 1,
+            created_at: "now".to_string(),
+            updated_at: "now".to_string(),
+        };
+        let detail = SnippetDetail::from(record);
+        assert_eq!(detail.parameters.as_ref().unwrap().len(), 1);
+        assert_eq!(detail.parameters.unwrap()[0].name, "title");
+    }
+}

--- a/functions/src/api/router.rs
+++ b/functions/src/api/router.rs
@@ -2,8 +2,8 @@ use lambda_http::{http::Method, Body, Error, Request, Response};
 use serde_json::json;
 
 use crate::controllers::{
-    api_keys, brand, domain, issues, pricing, profile, segments, senders, sponsors, subscribers,
-    templates,
+    api_keys, brand, domain, issues, pricing, profile, segments, senders, snippets, sponsors,
+    subscribers, templates,
 };
 
 pub async fn route_request(event: Request) -> Result<Response<Body>, Error> {
@@ -313,6 +313,22 @@ pub async fn route_request(event: Request) -> Result<Response<Body>, Error> {
             templates::delete_template(event, template_id).await
         }
 
+        // Snippets endpoints
+        (&Method::GET, "/snippets") => snippets::list_snippets(event).await,
+        (&Method::POST, "/snippets") => snippets::create_snippet(event).await,
+        (&Method::GET, path) if path.starts_with("/snippets/") => {
+            let snippet_id = extract_path_param(path, "/snippets/");
+            snippets::get_snippet(event, snippet_id).await
+        }
+        (&Method::PUT, path) if path.starts_with("/snippets/") => {
+            let snippet_id = extract_path_param(path, "/snippets/");
+            snippets::update_snippet(event, snippet_id).await
+        }
+        (&Method::DELETE, path) if path.starts_with("/snippets/") => {
+            let snippet_id = extract_path_param(path, "/snippets/");
+            snippets::delete_snippet(event, snippet_id).await
+        }
+
         // Method not allowed for valid paths
         (_, path) if is_valid_api_path(path) => Ok(format_method_not_allowed()),
 
@@ -369,6 +385,9 @@ fn is_valid_api_path(path: &str) -> bool {
         // Templates paths
         || path == "/templates"
         || path.starts_with("/templates/")
+        // Snippets paths
+        || path == "/snippets"
+        || path.starts_with("/snippets/")
 }
 
 fn extract_path_param(path: &str, prefix: &str) -> Option<String> {
@@ -879,6 +898,21 @@ mod tests {
         assert_eq!(result, Some("tmpl-123".to_string()));
 
         let result = extract_path_param("/templates/", "/templates/");
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_is_valid_api_path_snippets() {
+        assert!(is_valid_api_path("/snippets"));
+        assert!(is_valid_api_path("/snippets/abc-123"));
+    }
+
+    #[test]
+    fn test_extract_snippet_id_from_path() {
+        let result = extract_path_param("/snippets/snip-123", "/snippets/");
+        assert_eq!(result, Some("snip-123".to_string()));
+
+        let result = extract_path_param("/snippets/", "/snippets/");
         assert_eq!(result, None);
     }
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1247,6 +1247,123 @@ paths:
         "500":
           $ref: "#/components/responses/UnknownError"
 
+  /snippets:
+    get:
+      summary: List snippets
+      description: Returns all reusable Handlebars snippets (partials) for the authenticated tenant (summaries without content).
+      tags:
+        - Snippets
+      responses:
+        "200":
+          description: A list of snippets
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  snippets:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/SnippetSummary"
+                  total:
+                    type: integer
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/UnknownError"
+    post:
+      summary: Create a snippet
+      tags:
+        - Snippets
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateSnippetRequest"
+      responses:
+        "201":
+          description: Snippet created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Snippet"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          description: A snippet with the same name already exists
+        "500":
+          $ref: "#/components/responses/UnknownError"
+
+  /snippets/{snippetId}:
+    parameters:
+      - name: snippetId
+        in: path
+        required: true
+        schema:
+          type: string
+        description: The snippet ID
+    get:
+      summary: Get a snippet
+      description: Returns a single snippet including its content and parameters.
+      tags:
+        - Snippets
+      responses:
+        "200":
+          description: The snippet
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Snippet"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/UnknownError"
+    put:
+      summary: Update a snippet
+      tags:
+        - Snippets
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateSnippetRequest"
+      responses:
+        "200":
+          description: Snippet updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Snippet"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: A snippet with the same name already exists
+        "500":
+          $ref: "#/components/responses/UnknownError"
+    delete:
+      summary: Delete a snippet
+      tags:
+        - Snippets
+      responses:
+        "200":
+          description: Snippet deleted
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/UnknownError"
+
   /issues:
     get:
       summary: List all issues
@@ -2562,6 +2679,109 @@ components:
         sampleData:
           type: object
           additionalProperties: true
+
+    SnippetParameter:
+      type: object
+      required:
+        - name
+        - type
+        - required
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        type:
+          type: string
+          enum:
+            - string
+            - number
+            - boolean
+            - select
+            - textarea
+            - url
+        required:
+          type: boolean
+        defaultValue:
+          nullable: true
+          description: Default value for the parameter (any JSON type)
+        description:
+          type: string
+          maxLength: 500
+        options:
+          type: array
+          items:
+            type: string
+          description: Allowed values, required when type is "select"
+
+    SnippetSummary:
+      type: object
+      properties:
+        snippetId:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        version:
+          type: integer
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
+    Snippet:
+      allOf:
+        - $ref: "#/components/schemas/SnippetSummary"
+        - type: object
+          properties:
+            content:
+              type: string
+              description: The Handlebars partial source
+            parameters:
+              type: array
+              nullable: true
+              items:
+                $ref: "#/components/schemas/SnippetParameter"
+
+    CreateSnippetRequest:
+      type: object
+      required:
+        - name
+        - content
+      properties:
+        name:
+          type: string
+          maxLength: 100
+          description: Partial identifier; must start with a letter and contain only letters, numbers, underscores, and hyphens
+        description:
+          type: string
+          maxLength: 500
+        content:
+          type: string
+          description: The Handlebars partial source
+        parameters:
+          type: array
+          items:
+            $ref: "#/components/schemas/SnippetParameter"
+
+    UpdateSnippetRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        description:
+          type: string
+          maxLength: 500
+        content:
+          type: string
+        parameters:
+          type: array
+          items:
+            $ref: "#/components/schemas/SnippetParameter"
 
     ListIssuesResponse:
       type: object


### PR DESCRIPTION
Closes #265.

Adds management for reusable Handlebars partials ("macros"/snippets) referenced in templates as `{{> name }}`. This is the **foundation** for #266 (builder) and #267 (sends) — please **merge this first**.

## What's included
**Backend (Rust api-router)** — `functions/src/api/controllers/snippets.rs`
- `GET/POST /snippets`, `GET/PUT/DELETE /snippets/{snippetId}`, tenant-scoped in `NewsletterTable` (`sk=snippet#{id}`, `GSI1` for listing + case-insensitive name uniqueness), mirroring the templates controller.
- Validation: name must be a valid partial identifier `^[a-zA-Z][a-zA-Z0-9_-]*$`; content compiled with the `handlebars` crate (unknown partials allowed — they resolve at render time); parameter schema (typed params; `select` requires options); size caps.
- Router wiring + `is_valid_api_path` + unit tests; OpenAPI for both paths and schemas.

**Frontend**
- `snippetService` (+ tests), types in `types/api.ts`, list + create/edit pages with a full **parameters editor** (add/remove rows; name/type/required/default/description, plus an options editor for `select`).
- Routes, lazy-load/preload, page-meta, and a **Snippets** nav item across sidebar/header/mobile; nav parity tests updated.

## Verification (all green)
`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --bin api-router` (373 passed); `tsc`, `eslint --max-warnings 0`, `vitest` (37 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KcoMVe13jS15kdPyU6rcNY)_