### PR TITLE
fix(senders): domain verification DNS records + hide upgrade card on Pro

### DIFF
--- a/dashboard-ui/src/pages/senders/SenderEmailSetupPage.tsx
+++ b/dashboard-ui/src/pages/senders/SenderEmailSetupPage.tsx
@@ -145,6 +145,21 @@ export function SenderEmailSetupPage() {
       operationInProgress: { type: null }
     }));
 
+    // For domain senders, surface the DNS-records guide immediately. The guide
+    // loads the actual records itself from GET /senders/domain-verification/{domain}.
+    if (sender.verificationType === 'domain' && sender.domain) {
+      setState(prev => ({
+        ...prev,
+        showDomainGuide: true,
+        domainVerification: {
+          domain: sender.domain!,
+          verificationStatus: 'pending',
+          dnsRecords: [],
+          instructions: []
+        }
+      }));
+    }
+
     // Add to polling statuses for UI feedback
     setState(prev => ({
       ...prev,
@@ -317,7 +332,7 @@ export function SenderEmailSetupPage() {
                   />
                 ) : (
                   /* Show balanced tier info when user can still add senders */
-                  <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+                  <div className={`grid grid-cols-1 gap-6 ${state.tierLimits.tier !== 'pro-tier' ? 'lg:grid-cols-2' : ''}`}>
                     {/* Current Plan Info */}
                     <div className="bg-primary-50 border border-primary-200 rounded-lg p-4">
                       <div className="flex items-center space-x-3 mb-3">
@@ -373,7 +388,8 @@ export function SenderEmailSetupPage() {
                       </div>
                     </div>
 
-                    {/* Upgrade Preview */}
+                    {/* Upgrade Preview - hidden on the top (Pro) tier, which has nothing to upgrade to */}
+                    {state.tierLimits.tier !== 'pro-tier' && (
                     <div className="bg-gradient-to-r from-primary-50 to-background border border-primary-200 rounded-lg p-4">
                       <div className="flex items-center space-x-3 mb-3">
                         <div className="w-10 h-10 bg-primary-100 rounded-full flex items-center justify-center">
@@ -415,6 +431,7 @@ export function SenderEmailSetupPage() {
                         View Upgrade Options
                       </button>
                     </div>
+                    )}
                   </div>
                 )}
               </div>

--- a/functions/src/api/controllers/senders.rs
+++ b/functions/src/api/controllers/senders.rs
@@ -39,6 +39,8 @@ struct CreateSenderResponse {
     created_at: String,
     #[serde(rename = "updatedAt")]
     updated_at: String,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "dnsRecords")]
+    dns_records: Option<Vec<DnsRecord>>,
     message: String,
 }
 
@@ -327,7 +329,7 @@ async fn handle_create_sender(event: Request) -> Result<Response<Body>, AppError
         None
     };
 
-    let mut sender_record = SenderRecord {
+    let sender_record = SenderRecord {
         pk: tenant_id.clone(),
         sk: KeyPatterns::sender(&sender_id),
         gsi1pk: KeyPatterns::sender_gsi1pk(&tenant_id),
@@ -350,10 +352,19 @@ async fn handle_create_sender(event: Request) -> Result<Response<Body>, AppError
         last_sent_at: None,
     };
 
+    let mut dns_records_response: Option<Vec<DnsRecord>> = None;
     if body.verification_type == "domain" {
-        match initiate_email_verification(&body.email, &body.verification_type, &tenant_id).await {
-            Ok(identity_arn) => {
-                sender_record.ses_identity_arn = Some(identity_arn);
+        let domain_name = domain.clone().ok_or_else(|| {
+            AppError::InternalError("Domain missing for domain sender".to_string())
+        })?;
+        match create_domain_identity_and_records(&domain_name, &tenant_id).await {
+            Ok(dns_records) => {
+                // Persist a domain verification record so the dashboard guide
+                // (GET /senders/domain-verification/{domain}) can immediately
+                // surface the DNS records the user needs to add.
+                save_domain_verification_record(&tenant_id, &domain_name, &dns_records, &now)
+                    .await?;
+                dns_records_response = Some(dns_records);
             }
             Err(e) => {
                 tracing::error!("SES domain verification initiation failed: {:?}", e);
@@ -417,6 +428,7 @@ async fn handle_create_sender(event: Request) -> Result<Response<Body>, AppError
             domain,
             created_at: now.clone(),
             updated_at: now,
+            dns_records: dns_records_response,
             message: message.to_string(),
         },
     )
@@ -530,6 +542,108 @@ async fn initiate_email_verification(
         .identity_type()
         .map(|t| t.as_str().to_string())
         .unwrap_or_default())
+}
+
+/// Creates the SES domain identity and returns the DKIM DNS records the user
+/// must add. Mirrors the standalone `/senders/verify-domain` flow so that
+/// adding a domain sender is a single step that yields the records directly.
+async fn create_domain_identity_and_records(
+    domain: &str,
+    tenant_id: &str,
+) -> Result<Vec<DnsRecord>, AppError> {
+    let ses = aws_clients::get_ses_client().await;
+    let config_set = std::env::var("SES_CONFIGURATION_SET").ok();
+
+    let mut create_command = ses.create_email_identity().email_identity(domain);
+    if let Some(config) = config_set {
+        create_command = create_command.configuration_set_name(config);
+    }
+
+    create_command
+        .send()
+        .await
+        .map_err(|e| AppError::AwsError(format!("SES create domain identity failed: {}", e)))?;
+
+    let resource_arn_prefix = std::env::var("RESOURCE_ARN_PREFIX")
+        .unwrap_or_else(|_| "arn:aws:ses:us-east-1:123456789012:identity/".to_string());
+    let resource_arn = format!("{}{}", resource_arn_prefix, domain);
+
+    if let Err(e) = ses
+        .create_tenant_resource_association()
+        .tenant_name(tenant_id)
+        .resource_arn(&resource_arn)
+        .send()
+        .await
+    {
+        tracing::warn!(
+            error = ?e,
+            domain = %domain,
+            tenant_id = %tenant_id,
+            "Failed to create tenant resource association (non-fatal)"
+        );
+    }
+
+    let identity_info = ses
+        .get_email_identity()
+        .email_identity(domain)
+        .send()
+        .await
+        .map_err(|e| AppError::AwsError(format!("SES get email identity failed: {}", e)))?;
+
+    let mut dns_records = Vec::new();
+    if let Some(dkim_attributes) = identity_info.dkim_attributes() {
+        for (i, token) in dkim_attributes.tokens().iter().enumerate() {
+            dns_records.push(DnsRecord {
+                name: format!("{}._domainkey.{}", token, domain),
+                record_type: "CNAME".to_string(),
+                value: format!("{}.dkim.amazonses.com", token),
+                description: format!("DKIM token {} for email authentication", i + 1),
+            });
+        }
+    }
+
+    Ok(dns_records)
+}
+
+/// Persists (or refreshes) the domain verification record so the dashboard's
+/// `GET /senders/domain-verification/{domain}` can return the DNS records and
+/// track status. Uses an unconditional put so re-adding a domain refreshes it.
+async fn save_domain_verification_record(
+    tenant_id: &str,
+    domain: &str,
+    dns_records: &[DnsRecord],
+    now: &str,
+) -> Result<(), AppError> {
+    let ddb = aws_clients::get_dynamodb_client().await;
+    let table_name = std::env::var("TABLE_NAME")
+        .map_err(|_| AppError::InternalError("TABLE_NAME not set".to_string()))?;
+
+    let domain_record = DomainVerificationRecord {
+        pk: tenant_id.to_string(),
+        sk: KeyPatterns::domain(domain),
+        domain: domain.to_string(),
+        tenant_id: tenant_id.to_string(),
+        verification_status: VerificationStatus::Pending,
+        dns_records: dns_records.to_vec(),
+        ses_identity_arn: None,
+        created_at: now.to_string(),
+        updated_at: now.to_string(),
+        verified_at: None,
+    };
+
+    let item: std::collections::HashMap<String, AttributeValue> =
+        serde_dynamo::to_item(&domain_record).map_err(|e| {
+            AppError::InternalError(format!("Failed to serialize domain record: {}", e))
+        })?;
+
+    ddb.put_item()
+        .table_name(table_name)
+        .set_item(Some(item))
+        .send()
+        .await
+        .map_err(|e| AppError::AwsError(format!("DynamoDB put failed: {}", e)))?;
+
+    Ok(())
 }
 
 async fn send_custom_verification_email(email: &str, tenant_id: &str) -> Result<(), AppError> {

--- a/functions/src/api/router.rs
+++ b/functions/src/api/router.rs
@@ -71,8 +71,8 @@ pub async fn route_request(event: Request) -> Result<Response<Body>, Error> {
         }
 
         // Domain verification endpoints
-        (&Method::POST, "/senders/domain") => domain::verify_domain(event).await,
-        (&Method::GET, path) if path.starts_with("/senders/domain/") => {
+        (&Method::POST, "/senders/verify-domain") => domain::verify_domain(event).await,
+        (&Method::GET, path) if path.starts_with("/senders/domain-verification/") => {
             let domain_param = extract_domain(path);
             domain::get_domain_verification(event, domain_param).await
         }
@@ -341,8 +341,8 @@ fn is_valid_api_path(path: &str) -> bool {
         // Senders paths
         || path == "/senders"
         || path.starts_with("/senders/")
-        || path == "/senders/domain"
-        || path.starts_with("/senders/domain/")
+        || path == "/senders/verify-domain"
+        || path.starts_with("/senders/domain-verification/")
         // Issues paths
         || path == "/issues"
         || path == "/issues/trends"
@@ -392,7 +392,7 @@ fn extract_sender_id_before(path: &str, suffix: &str) -> Option<String> {
 }
 
 fn extract_domain(path: &str) -> Option<String> {
-    path.strip_prefix("/senders/domain/")
+    path.strip_prefix("/senders/domain-verification/")
         .filter(|s| !s.is_empty())
         .map(|s| s.to_string())
 }
@@ -529,19 +529,19 @@ mod tests {
 
     #[test]
     fn test_extract_domain_valid() {
-        let result = extract_domain("/senders/domain/example.com");
+        let result = extract_domain("/senders/domain-verification/example.com");
         assert_eq!(result, Some("example.com".to_string()));
     }
 
     #[test]
     fn test_extract_domain_with_subdomain() {
-        let result = extract_domain("/senders/domain/mail.example.com");
+        let result = extract_domain("/senders/domain-verification/mail.example.com");
         assert_eq!(result, Some("mail.example.com".to_string()));
     }
 
     #[test]
     fn test_extract_domain_empty() {
-        let result = extract_domain("/senders/domain/");
+        let result = extract_domain("/senders/domain-verification/");
         assert_eq!(result, None);
     }
 
@@ -727,9 +727,9 @@ mod tests {
 
     #[test]
     fn test_method_validation_domain_endpoints() {
-        // Domain: POST verify, GET status
-        assert!(is_valid_api_path("/senders/domain"));
-        assert!(is_valid_api_path("/senders/domain/example.com"));
+        // Domain: POST verify-domain, GET domain-verification/{domain}
+        assert!(is_valid_api_path("/senders/verify-domain"));
+        assert!(is_valid_api_path("/senders/domain-verification/example.com"));
     }
 
     #[test]

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2375,6 +2375,13 @@ components:
           type: string
           format: date-time
           description: When the verification expires (24 hours after initiation)
+        dnsRecords:
+          type: array
+          description: >-
+            DNS records to add for domain verification. Only present in the
+            response when creating a sender with domain verification.
+          items:
+            $ref: "#/components/schemas/DnsRecord"
 
     TierLimits:
       type: object


### PR DESCRIPTION
## Summary

Fixes two issues on the **/senders** page.

### 1. Domain verification never returned the DNS records to add
Two causes:
- **Path mismatch (405):** the router registered `/senders/domain` + `/senders/domain/{domain}`, but the frontend and OpenAPI spec use `/senders/verify-domain` + `/senders/domain-verification/{domain}`. The calls 405'd, so no records ever came back. Aligned the router to the spec.
- **Flow gap:** even with routing fixed, adding a domain sender went through `createSender` (POST `/senders`), which created the SES identity but never produced or displayed DNS records — the `showDomainGuide` flag was dead code (only ever set to `false`). Wired the **one-step** flow:
  - **Backend** (`senders.rs`): creating a domain sender now generates the DKIM records, **persists a domain-verification record** (so the dashboard guide's `GET /senders/domain-verification/{domain}` succeeds), and returns `dnsRecords` in the create response. Reuses one `CreateEmailIdentity` call (no double-create conflict with the standalone verify-domain endpoint).
  - **Frontend** (`SenderEmailSetupPage.tsx`): adding a domain sender now opens the DNS-records guide, which loads the records for that domain.
  - **Spec** (`openapi.yaml`): documented the new optional `dnsRecords` field on the create-sender response.

### 2. "Unlock More Features" card shown to Pro users
The upgrade-preview column on the senders page was rendered for **every** tier and hardcoded to advertise Pro features ("Up to 5 sender emails", "Domain verification") — confusing for users already on Pro. Gated it to hide on `pro-tier` (the top tier) and made the Current Plan card span full width when hidden.

## Notes for reviewer
- Both the create-sender domain path and the standalone `/senders/verify-domain` endpoint create the SES identity; this PR keeps the create path doing it once and storing the records. Adding a second sender under the same already-registered domain would still error on `CreateEmailIdentity` (pre-existing behavior, out of scope).
- Rebased onto current `main` (which added template CRUD + send-test-email); the router now carries both the new send-test route and the corrected domain/status routes.

## Testing
- `cargo build` + `cargo clippy` (api-router) — clean, no warnings
- `cargo test --bin api-router` — 67 router tests pass
- `npm run type-check` — clean
- Frontend senders suites — 113 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)