### PR TITLE
De-dup Rust snippet read + render conformance test (#273, #274)

### DIFF
--- a/__tests__/fixtures/render-conformance.json
+++ b/__tests__/fixtures/render-conformance.json
@@ -1,0 +1,75 @@
+[
+  {
+    "name": "variable interpolation (incl. nested path)",
+    "template": "<h1>{{ title }}</h1><p>by {{ author.name }}</p>",
+    "data": { "title": "Hello", "author": { "name": "Ada" } },
+    "snippets": [],
+    "expected": "<h1>Hello</h1><p>by Ada</p>"
+  },
+  {
+    "name": "missing variable renders empty",
+    "template": "<p>{{ present }}{{ missing }}</p>",
+    "data": { "present": "x" },
+    "snippets": [],
+    "expected": "<p>x</p>"
+  },
+  {
+    "name": "no HTML escaping (authored HTML and & pass through)",
+    "template": "{{ body }}",
+    "data": { "body": "<b>bold</b> & <i>it</i>" },
+    "snippets": [],
+    "expected": "<b>bold</b> & <i>it</i>"
+  },
+  {
+    "name": "each block over array",
+    "template": "<ul>{{#each items}}<li>{{ this }}</li>{{/each}}</ul>",
+    "data": { "items": ["a", "b", "c"] },
+    "snippets": [],
+    "expected": "<ul><li>a</li><li>b</li><li>c</li></ul>"
+  },
+  {
+    "name": "if/else block - truthy branch",
+    "template": "{{#if showCta}}<a>Buy</a>{{else}}<span>No CTA</span>{{/if}}",
+    "data": { "showCta": true },
+    "snippets": [],
+    "expected": "<a>Buy</a>"
+  },
+  {
+    "name": "if/else block - falsy branch",
+    "template": "{{#if showCta}}<a>Buy</a>{{else}}<span>No CTA</span>{{/if}}",
+    "data": { "showCta": false },
+    "snippets": [],
+    "expected": "<span>No CTA</span>"
+  },
+  {
+    "name": "registered snippet partial",
+    "template": "<div>{{> footer }}</div>",
+    "data": { "company": "Acme" },
+    "snippets": [{ "name": "footer", "content": "<footer>{{ company }}</footer>" }],
+    "expected": "<div><footer>Acme</footer></div>"
+  },
+  {
+    "name": "missing partial renders empty (no error)",
+    "template": "<p>Hi</p>{{> doesNotExist }}<p>Bye</p>",
+    "data": {},
+    "snippets": [],
+    "expected": "<p>Hi</p><p>Bye</p>"
+  },
+  {
+    "name": "missing partial referenced inside a snippet body renders empty",
+    "template": "{{> layout }}",
+    "data": {},
+    "snippets": [{ "name": "layout", "content": "<section>{{> innerMissing }}</section>" }],
+    "expected": "<section></section>"
+  },
+  {
+    "name": "realistic combo: snippet + each + interpolation",
+    "template": "{{> header }}<main>{{#each posts}}<article>{{ title }}</article>{{/each}}</main>",
+    "data": {
+      "newsletterName": "Weekly",
+      "posts": [{ "title": "P1" }, { "title": "P2" }]
+    },
+    "snippets": [{ "name": "header", "content": "<header>{{ newsletterName }}</header>" }],
+    "expected": "<header>Weekly</header><main><article>P1</article><article>P2</article></main>"
+  }
+]

--- a/__tests__/render-conformance.test.mjs
+++ b/__tests__/render-conformance.test.mjs
@@ -1,0 +1,24 @@
+import { describe, it, expect } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { renderWithSnippets } from '../functions/utils/render-template.mjs';
+
+// Shared fixtures consumed by BOTH this JS send-path test and the Rust preview
+// test (`template_render::tests::render_conformance_fixtures`). Each case pins
+// the exact HTML both renderers must produce, so if either engine drifts on a
+// shared fixture its test fails — guaranteeing preview == delivered output.
+const fixturesPath = fileURLToPath(new URL('./fixtures/render-conformance.json', import.meta.url));
+const cases = JSON.parse(readFileSync(fixturesPath, 'utf8'));
+
+describe('render conformance (JS send path)', () => {
+  it('has shared fixtures to check', () => {
+    expect(cases.length).toBeGreaterThan(0);
+  });
+
+  for (const testCase of cases) {
+    it(`renders "${testCase.name}" to the shared expected HTML`, () => {
+      const out = renderWithSnippets(testCase.template, testCase.data, testCase.snippets ?? []);
+      expect(out).toBe(testCase.expected);
+    });
+  }
+});

--- a/functions/publish-issue.mjs
+++ b/functions/publish-issue.mjs
@@ -5,6 +5,7 @@ import { DynamoDBClient, PutItemCommand, GetItemCommand, QueryCommand } from '@a
 import { getTenant } from './utils/helpers.mjs';
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
 import { publishIssueEvent, EVENT_TYPES } from './utils/event-publisher.mjs';
+import { renderWithSnippets } from './utils/render-template.mjs';
 
 const eventBridge = new EventBridgeClient();
 const ddb = new DynamoDBClient();
@@ -82,50 +83,11 @@ const renderTemplate = async (data, tenantId, templateId) => {
     return Handlebars.compile(defaultTemplate)(data);
   }
 
-  const hbs = Handlebars.create();
   const snippets = await getSnippets(tenantId);
-  // Register each snippet as a partial. Compile with noEscape so partials match
-  // the no-escape rendering used everywhere else (see compile call below and the
-  // Rust preview renderer in template_render.rs), keeping preview == delivery.
-  for (const snippet of snippets) {
-    if (snippet.name) {
-      hbs.registerPartial(snippet.name, hbs.compile(snippet.content ?? '', { noEscape: true }));
-    }
-  }
-
-  // Register any partial referenced by the template OR by a snippet body that is
-  // not itself a known snippet as an empty partial, so a missing partial renders
-  // empty instead of throwing during rendering.
-  registerMissingPartialsAsEmpty(hbs, templateContent);
-  for (const snippet of snippets) {
-    if (snippet.content) {
-      registerMissingPartialsAsEmpty(hbs, snippet.content);
-    }
-  }
-
-  // noEscape mirrors the preview renderer (handlebars::no_escape) so authored
-  // HTML fields render identically in preview and in the delivered email.
-  return hbs.compile(templateContent, { noEscape: true })(data);
-};
-
-/**
- * Scans the template source for partial references (`{{> name }}`) and registers
- * any that are not already registered as an empty-string partial. This guarantees
- * a missing snippet renders as empty rather than throwing during compilation.
- *
- * @param {Object} hbs - Handlebars instance.
- * @param {string} source - Template source to scan.
- */
-const registerMissingPartialsAsEmpty = (hbs, source) => {
-  const partialRegex = /\{\{\s*>\s*([\w./-]+)/g;
-  let match;
-  while ((match = partialRegex.exec(source)) !== null) {
-    const name = match[1];
-    if (!hbs.partials[name]) {
-      console.warn(`Partial '${name}' not found, registering as empty`);
-      hbs.registerPartial(name, '');
-    }
-  }
+  // Delegate to the shared renderer so the send path and the conformance test
+  // exercise identical logic (snippets as partials, missing partial -> empty,
+  // noEscape to mirror the Rust preview renderer in template_render.rs).
+  return renderWithSnippets(templateContent, data, snippets);
 };
 
 /**

--- a/functions/src/api/controllers/snippets.rs
+++ b/functions/src/api/controllers/snippets.rs
@@ -54,7 +54,7 @@ fn normalize_name(name: &str) -> String {
 // ── Data types ─────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-struct SnippetParameter {
+pub(crate) struct SnippetParameter {
     pub name: String,
     #[serde(rename = "type")]
     pub param_type: String,
@@ -72,7 +72,7 @@ struct SnippetParameter {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-struct SnippetRecord {
+pub(crate) struct SnippetRecord {
     pub pk: String,
     pub sk: String,
     #[serde(rename = "GSI1PK")]
@@ -529,7 +529,12 @@ fn table_name() -> Result<String, AppError> {
         .map_err(|_| AppError::InternalError("TABLE_NAME not configured".to_string()))
 }
 
-async fn query_snippets_by_tenant(tenant_id: &str) -> Result<Vec<SnippetRecord>, AppError> {
+/// Canonical snippet-by-tenant read shared by the snippets CRUD handlers and
+/// the template preview/send renderer ([`super::template_render`]). Queries GSI1
+/// on `snippet#{tenantId}` and returns every snippet record for the tenant.
+pub(crate) async fn query_snippets_by_tenant(
+    tenant_id: &str,
+) -> Result<Vec<SnippetRecord>, AppError> {
     let client = aws_clients::get_dynamodb_client().await;
     let table_name = table_name()?;
 

--- a/functions/src/api/controllers/template_render.rs
+++ b/functions/src/api/controllers/template_render.rs
@@ -8,23 +8,15 @@
 //! renders as an EMPTY string instead of failing — both for snippets that do
 //! not exist yet and for arbitrary unknown partials.
 //!
-//! NOTE (de-dup at merge): issue #265 owns the full snippets module. The
-//! `Snippet` read helper here (`query_snippets_by_tenant`) is a small,
-//! intentionally duplicated GSI1 read so this branch can render previews
-//! before #265 lands. When the branches merge, this read should be replaced
-//! with the canonical snippets read.
+//! Snippets are loaded through the canonical reader in the [`snippets`]
+//! controller ([`super::snippets::query_snippets_by_tenant`]); this module only
+//! maps those records into the minimal [`Snippet`] shape the renderer needs.
 
-use aws_sdk_dynamodb::types::AttributeValue;
-use newsletter::admin::{aws_clients, error::AppError};
+use newsletter::admin::error::AppError;
 use regex::Regex;
-use serde::Deserialize;
-use serde_dynamo::from_item;
 use serde_json::Value;
 use std::collections::HashSet;
-use std::env;
 use std::sync::OnceLock;
-
-const SNIPPET_GSI1PK_PREFIX: &str = "snippet#";
 
 static PARTIAL_REF: OnceLock<Regex> = OnceLock::new();
 
@@ -37,51 +29,21 @@ fn partial_ref_regex() -> &'static Regex {
     })
 }
 
-/// Minimal snippet record read from DynamoDB. Mirrors the snippet data model
-/// from issue #265 (only the fields preview rendering needs).
-#[derive(Debug, Clone, Deserialize)]
+/// Minimal snippet shape the renderer needs: a partial `name` and its Handlebars
+/// `content`. Produced from the canonical [`super::snippets::SnippetRecord`].
+#[derive(Debug, Clone)]
 pub struct Snippet {
     pub name: String,
     pub content: String,
 }
 
-fn table_name() -> Result<String, AppError> {
-    env::var("TABLE_NAME")
-        .map_err(|_| AppError::InternalError("TABLE_NAME not configured".to_string()))
-}
-
-fn snippet_gsi1pk(tenant_id: &str) -> String {
-    format!("{}{}", SNIPPET_GSI1PK_PREFIX, tenant_id)
-}
-
-/// Load all snippets for a tenant by querying GSI1 on `snippet#{tenantId}`.
-///
-/// Duplicated, minimal read — see module note about de-duplication with #265.
-pub async fn query_snippets_by_tenant(tenant_id: &str) -> Result<Vec<Snippet>, AppError> {
-    let client = aws_clients::get_dynamodb_client().await;
-    let table_name = table_name()?;
-
-    let result = client
-        .query()
-        .table_name(table_name)
-        .index_name("GSI1")
-        .key_condition_expression("GSI1PK = :gsi1pk")
-        .expression_attribute_values(":gsi1pk", AttributeValue::S(snippet_gsi1pk(tenant_id)))
-        .send()
-        .await
-        .map_err(|e| AppError::AwsError(format!("Failed to query snippets: {}", e)))?;
-
-    let snippets = result
-        .items()
-        .iter()
-        .filter_map(|item| {
-            from_item::<_, Snippet>(item.clone())
-                .map_err(|e| tracing::warn!("Failed to deserialize snippet: {}", e))
-                .ok()
-        })
-        .collect();
-
-    Ok(snippets)
+impl From<super::snippets::SnippetRecord> for Snippet {
+    fn from(record: super::snippets::SnippetRecord) -> Self {
+        Snippet {
+            name: record.name,
+            content: record.content,
+        }
+    }
 }
 
 /// Collect the set of partial names referenced by a template source.
@@ -235,5 +197,57 @@ mod tests {
         let snippets = vec![snip("broken", "{{#if x}}unclosed")];
         let err = render_template("{{> broken }}", &json!({}), &snippets).unwrap_err();
         assert_eq!(err.status_code(), 400);
+    }
+
+    // ── Cross-renderer conformance ──────────────────────────────────────
+    //
+    // These fixtures are shared with the JS send path
+    // (`__tests__/render-conformance.test.mjs`). Both renderers assert against
+    // the SAME expected HTML, so if the Rust preview and JS send diverge on any
+    // shared fixture, one side's test fails — guaranteeing preview == delivered.
+
+    #[derive(serde::Deserialize)]
+    struct ConformanceSnippet {
+        name: String,
+        content: String,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct ConformanceCase {
+        name: String,
+        template: String,
+        data: Value,
+        #[serde(default)]
+        snippets: Vec<ConformanceSnippet>,
+        expected: String,
+    }
+
+    #[test]
+    fn render_conformance_fixtures() {
+        let raw = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/__tests__/fixtures/render-conformance.json"
+        ));
+        let cases: Vec<ConformanceCase> =
+            serde_json::from_str(raw).expect("render-conformance.json should be valid JSON");
+        assert!(!cases.is_empty(), "conformance fixtures must not be empty");
+
+        for case in cases {
+            let snippets: Vec<Snippet> = case
+                .snippets
+                .into_iter()
+                .map(|s| Snippet {
+                    name: s.name,
+                    content: s.content,
+                })
+                .collect();
+            let out = render_template(&case.template, &case.data, &snippets)
+                .unwrap_or_else(|e| panic!("case \"{}\" failed to render: {:?}", case.name, e));
+            assert_eq!(
+                out, case.expected,
+                "case \"{}\" diverged from the shared expected HTML",
+                case.name
+            );
+        }
     }
 }

--- a/functions/src/api/controllers/templates.rs
+++ b/functions/src/api/controllers/templates.rs
@@ -1,4 +1,4 @@
-use crate::controllers::template_render;
+use crate::controllers::{snippets, template_render};
 use aws_sdk_dynamodb::types::AttributeValue;
 use lambda_http::{Body, Error, Request, Response};
 use newsletter::admin::{auth, aws_clients, error::AppError, response};
@@ -608,7 +608,11 @@ async fn render_preview(
     content: &str,
     data: &Value,
 ) -> Result<Response<Body>, AppError> {
-    let snippets = template_render::query_snippets_by_tenant(tenant_id).await?;
+    let snippets: Vec<template_render::Snippet> = snippets::query_snippets_by_tenant(tenant_id)
+        .await?
+        .into_iter()
+        .map(Into::into)
+        .collect();
     let html = template_render::render_template(content, data, &snippets)?;
     response::format_response(200, PreviewResponse { html })
 }

--- a/functions/utils/render-template.mjs
+++ b/functions/utils/render-template.mjs
@@ -1,0 +1,67 @@
+import Handlebars from 'handlebars';
+
+/**
+ * Scans a template source for partial references (`{{> name }}`) and registers
+ * any that are not already registered on `hbs` as an empty-string partial. This
+ * guarantees a referenced-but-missing snippet renders as empty rather than
+ * throwing during compilation.
+ *
+ * NOTE (parity with the Rust preview renderer in `template_render.rs`): this
+ * scan is intentionally permissive on the *name* charset (`[\w./-]+`) where the
+ * Rust scan requires a leading letter (`[a-zA-Z][a-zA-Z0-9_-]*`). Snippet names
+ * are validated to the stricter rule on write, so for any real snippet both
+ * scans pick up the same references — the only divergence would be on partial
+ * names that could never be a stored snippet anyway.
+ *
+ * @param {object} hbs - Handlebars instance.
+ * @param {string} source - Template source to scan.
+ */
+export const registerMissingPartialsAsEmpty = (hbs, source) => {
+  const partialRegex = /\{\{\s*>\s*([\w./-]+)/g;
+  let match;
+  while ((match = partialRegex.exec(source)) !== null) {
+    const name = match[1];
+    if (!hbs.partials[name]) {
+      console.warn(`Partial '${name}' not found, registering as empty`);
+      hbs.registerPartial(name, '');
+    }
+  }
+};
+
+/**
+ * Renders Handlebars `templateContent` against `data`, registering `snippets`
+ * as partials and treating any referenced-but-missing partial as an empty
+ * string. This is the JS send-path counterpart to the Rust preview renderer
+ * (`template_render::render_template`); both must produce identical output so
+ * the live preview matches the delivered email.
+ *
+ * Everything is compiled with `noEscape: true` so authored HTML fields render
+ * verbatim, mirroring `handlebars::no_escape` on the Rust side.
+ *
+ * @param {string} templateContent - Handlebars template source.
+ * @param {object} data - Data to render against.
+ * @param {Array<{name?: string, content?: string}>} snippets - Tenant snippets.
+ * @returns {string} Rendered HTML.
+ */
+export const renderWithSnippets = (templateContent, data, snippets = []) => {
+  const hbs = Handlebars.create();
+
+  // Register each snippet as a partial, compiled with noEscape so snippet
+  // output matches the no-escape rendering used for the template itself.
+  for (const snippet of snippets) {
+    if (snippet.name) {
+      hbs.registerPartial(snippet.name, hbs.compile(snippet.content ?? '', { noEscape: true }));
+    }
+  }
+
+  // Any partial referenced by the template OR by a snippet body that is not a
+  // known snippet renders as empty instead of throwing during compilation.
+  registerMissingPartialsAsEmpty(hbs, templateContent);
+  for (const snippet of snippets) {
+    if (snippet.content) {
+      registerMissingPartialsAsEmpty(hbs, snippet.content);
+    }
+  }
+
+  return hbs.compile(templateContent, { noEscape: true })(data);
+};


### PR DESCRIPTION
Two render-parity follow-ups to the merged template builder/send work (#270, #271).

## #273 — De-duplicate the Rust snippet read
- `snippets::query_snippets_by_tenant` is now `pub(crate)` (returning `SnippetRecord`) — the single canonical snippet-by-tenant GSI1 read, used by both the snippets CRUD list and the template preview renderer.
- Deleted the duplicate `query_snippets_by_tenant` (and its `table_name`/`snippet_gsi1pk` plumbing) from `template_render.rs`. It now maps `SnippetRecord` → the minimal render `Snippet` via `From`.
- `render_preview` in `templates.rs` calls the canonical reader and maps into the renderer's type.
- Only one snippet-by-tenant DynamoDB read remains in the Rust codebase. No behavior change (same GSI1 key, same tenant scoping).

## #274 — Guarantee preview (Rust) == send (JS) render
- Added a shared fixture set `__tests__/fixtures/render-conformance.json` (template + data + snippets + expected HTML) consumed by **both**:
  - Rust preview renderer — `template_render::tests::render_conformance_fixtures`
  - JS send path — `__tests__/render-conformance.test.mjs`
- Both sides assert against the **same** expected HTML, so if either engine drifts on a shared fixture, that side's test fails in CI.
- Coverage: variable interpolation (incl. nested path), missing-variable→empty, no-HTML-escape passthrough, `{{#each}}`, `{{#if}}`/`{{else}}` (both branches), a registered snippet partial, a missing partial→empty, a nested missing partial→empty, and a realistic combined case.
- Extracted the JS renderer into `functions/utils/render-template.mjs` (`renderWithSnippets`) so the send path and the conformance test exercise identical logic; `publish-issue.mjs` now delegates to it.
- Documented the one intentional difference: the missing-partial scan regex charset (JS `[\w./-]+` vs Rust `[a-zA-Z][a-zA-Z0-9_-]*`). Snippet names are validated to the stricter rule on write, so the two scans pick up the same references for any real snippet.

## Verification
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `cargo test --workspace` — green (incl. the new conformance test)
- `npm run lint` — clean
- `npm test` — 854 tests green (incl. the new JS conformance suite)

Closes #273
Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KcoMVe13jS15kdPyU6rcNY)_