### PR TITLE
Group Templates+Snippets under "Content" and reorder left nav by priority

### DIFF
--- a/dashboard-ui/src/components/layout/AppSidebar.tsx
+++ b/dashboard-ui/src/components/layout/AppSidebar.tsx
@@ -1,8 +1,9 @@
+import { Fragment } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { responsiveA11y } from '@/utils/accessibility';
 import { preloadRoute } from '@/utils/lazyImports';
 import { cn } from '@/utils/cn';
-import { NAV_ITEMS, isNavItemActive } from './sidebarNav';
+import { getNavSections, isNavItemActive } from './sidebarNav';
 import { BRAND } from '@/constants/brand';
 
 export function AppSidebar() {
@@ -23,31 +24,42 @@ export function AppSidebar() {
       {/* Navigation */}
       <nav aria-label="Main navigation" className="flex-1 px-3 py-2">
         <ul className="space-y-1">
-          {NAV_ITEMS.map((item) => {
-            const Icon = item.icon;
-            const active = isNavItemActive(item, location.pathname);
+          {getNavSections().map((section) => (
+            <Fragment key={section.label ?? section.items[0].href}>
+              {section.label && (
+                <li role="presentation" className="pt-3 first:pt-0">
+                  <h3 className="px-3 pb-1 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                    {section.label}
+                  </h3>
+                </li>
+              )}
+              {section.items.map((item) => {
+                const Icon = item.icon;
+                const active = isNavItemActive(item, location.pathname);
 
-            return (
-              <li key={item.href}>
-                <Link
-                  to={item.href}
-                  onMouseEnter={() => preloadRoute(item.preloadKey)}
-                  onFocus={() => preloadRoute(item.preloadKey)}
-                  className={cn(
-                    'flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors',
-                    responsiveA11y.focusRing.className,
-                    active
-                      ? 'bg-primary-100 text-primary-700 border-l-4 border-primary-700'
-                      : 'text-muted-foreground hover:bg-muted'
-                  )}
-                  aria-current={active ? 'page' : undefined}
-                >
-                  <Icon className="h-5 w-5 shrink-0" aria-hidden="true" />
-                  {item.name}
-                </Link>
-              </li>
-            );
-          })}
+                return (
+                  <li key={item.href}>
+                    <Link
+                      to={item.href}
+                      onMouseEnter={() => preloadRoute(item.preloadKey)}
+                      onFocus={() => preloadRoute(item.preloadKey)}
+                      className={cn(
+                        'flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors',
+                        responsiveA11y.focusRing.className,
+                        active
+                          ? 'bg-primary-100 text-primary-700 border-l-4 border-primary-700'
+                          : 'text-muted-foreground hover:bg-muted'
+                      )}
+                      aria-current={active ? 'page' : undefined}
+                    >
+                      <Icon className="h-5 w-5 shrink-0" aria-hidden="true" />
+                      {item.name}
+                    </Link>
+                  </li>
+                );
+              })}
+            </Fragment>
+          ))}
         </ul>
       </nav>
     </aside>

--- a/dashboard-ui/src/components/layout/MobileDrawer.tsx
+++ b/dashboard-ui/src/components/layout/MobileDrawer.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useRef, useCallback } from 'react';
+import { Fragment, useEffect, useRef, useCallback } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { useAuth } from '@/contexts/AuthContext';
 import { useTheme } from '@/hooks/useTheme';
 import { keyboardUtils, responsiveA11y } from '@/utils/accessibility';
-import { NAV_ITEMS } from './sidebarNav';
+import { getNavSections } from './sidebarNav';
 import { ACCOUNT_ITEMS } from './accountNav';
 import { BRAND } from '@/constants/brand';
 import { cn } from '@/utils/cn';
@@ -148,33 +148,44 @@ export function MobileDrawer({ isOpen, onClose }: MobileDrawerProps) {
                 Navigation
               </h3>
               <ul className="space-y-1">
-                {NAV_ITEMS.map((item) => {
-                  const Icon = item.icon;
-                  const active = item.matchPaths.some((matchPath) => {
-                    if (matchPath === '/') return location.pathname === '/';
-                    return location.pathname.startsWith(matchPath);
-                  });
+                {getNavSections().map((section) => (
+                  <Fragment key={section.label ?? section.items[0].href}>
+                    {section.label && (
+                      <li role="presentation" className="pt-2 first:pt-0">
+                        <h4 className="px-3 pb-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground/80">
+                          {section.label}
+                        </h4>
+                      </li>
+                    )}
+                    {section.items.map((item) => {
+                      const Icon = item.icon;
+                      const active = item.matchPaths.some((matchPath) => {
+                        if (matchPath === '/') return location.pathname === '/';
+                        return location.pathname.startsWith(matchPath);
+                      });
 
-                  return (
-                    <li key={item.href}>
-                      <Link
-                        to={item.href}
-                        onClick={handleLinkClick}
-                        className={cn(
-                          'flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors',
-                          responsiveA11y.focusRing.className,
-                          active
-                            ? 'bg-primary-100 text-primary-700 border-l-4 border-primary-700'
-                            : 'text-muted-foreground hover:bg-muted hover:text-foreground'
-                        )}
-                        aria-current={active ? 'page' : undefined}
-                      >
-                        <Icon className="h-5 w-5 shrink-0" aria-hidden="true" />
-                        {item.name}
-                      </Link>
-                    </li>
-                  );
-                })}
+                      return (
+                        <li key={item.href}>
+                          <Link
+                            to={item.href}
+                            onClick={handleLinkClick}
+                            className={cn(
+                              'flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors',
+                              responsiveA11y.focusRing.className,
+                              active
+                                ? 'bg-primary-100 text-primary-700 border-l-4 border-primary-700'
+                                : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                            )}
+                            aria-current={active ? 'page' : undefined}
+                          >
+                            <Icon className="h-5 w-5 shrink-0" aria-hidden="true" />
+                            {item.name}
+                          </Link>
+                        </li>
+                      );
+                    })}
+                  </Fragment>
+                ))}
               </ul>
             </div>
 

--- a/dashboard-ui/src/components/layout/__tests__/AppSidebar.test.tsx
+++ b/dashboard-ui/src/components/layout/__tests__/AppSidebar.test.tsx
@@ -56,6 +56,31 @@ describe('AppSidebar', () => {
       const icons = nav.querySelectorAll('svg[aria-hidden="true"]');
       expect(icons).toHaveLength(8);
     });
+
+    it('renders nav items in audience-first priority order', () => {
+      renderSidebar();
+      const nav = screen.getByRole('navigation', { name: 'Main navigation' });
+      const labels = Array.from(nav.querySelectorAll('a')).map((a) => a.textContent?.trim());
+      expect(labels).toEqual([
+        'Dashboard',
+        'Issues',
+        'Subscribers',
+        'Templates',
+        'Snippets',
+        'Sponsors',
+        'Brand',
+        'Pricing',
+      ]);
+    });
+
+    it('groups Templates and Snippets under a "Content" heading', () => {
+      renderSidebar();
+      const nav = screen.getByRole('navigation', { name: 'Main navigation' });
+      const heading = screen.getByText('Content');
+      expect(heading).toBeInTheDocument();
+      // The heading is not a link, so the nav still has exactly 8 anchors.
+      expect(nav.querySelectorAll('a')).toHaveLength(8);
+    });
   });
 
   // ---- Requirement 2.3: Does not render account items ----

--- a/dashboard-ui/src/components/layout/__tests__/MobileDrawerParity.property.test.ts
+++ b/dashboard-ui/src/components/layout/__tests__/MobileDrawerParity.property.test.ts
@@ -60,12 +60,14 @@ describe('Mobile Drawer Parity - Property-Based Tests', () => {
           const drawerNavNames = NAV_ITEMS.map((item) => item.name);
           const sidebarNavNames = NAV_ITEMS.map((item) => item.name);
           expect(drawerNavNames).toEqual(sidebarNavNames);
+          // Audience-first priority order; Templates/Snippets sit adjacent under
+          // the shared "Content" group.
           expect(drawerNavNames).toEqual([
             'Dashboard',
             'Issues',
+            'Subscribers',
             'Templates',
             'Snippets',
-            'Subscribers',
             'Sponsors',
             'Brand',
             'Pricing',

--- a/dashboard-ui/src/components/layout/__tests__/sidebarNav.test.ts
+++ b/dashboard-ui/src/components/layout/__tests__/sidebarNav.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { NAV_ITEMS, getNavSections, isNavItemActive } from '../sidebarNav';
+
+describe('sidebarNav', () => {
+  describe('NAV_ITEMS order and grouping', () => {
+    it('is in audience-first priority order', () => {
+      expect(NAV_ITEMS.map((i) => i.name)).toEqual([
+        'Dashboard',
+        'Issues',
+        'Subscribers',
+        'Templates',
+        'Snippets',
+        'Sponsors',
+        'Brand',
+        'Pricing',
+      ]);
+    });
+
+    it('tags Templates and Snippets (and only those) with the "Content" group', () => {
+      const grouped = NAV_ITEMS.filter((i) => i.group === 'Content').map((i) => i.name);
+      expect(grouped).toEqual(['Templates', 'Snippets']);
+      expect(NAV_ITEMS.filter((i) => i.group !== undefined && i.group !== 'Content')).toEqual([]);
+    });
+  });
+
+  describe('getNavSections', () => {
+    it('folds consecutive same-group items into one labeled section, preserving order', () => {
+      const sections = getNavSections();
+      expect(sections.map((s) => s.label)).toEqual([
+        null, // Dashboard
+        null, // Issues
+        null, // Subscribers
+        'Content', // Templates + Snippets
+        null, // Sponsors
+        null, // Brand
+        null, // Pricing
+      ]);
+
+      const content = sections.find((s) => s.label === 'Content');
+      expect(content?.items.map((i) => i.name)).toEqual(['Templates', 'Snippets']);
+
+      // The flattened section items exactly reproduce NAV_ITEMS in order.
+      expect(sections.flatMap((s) => s.items).map((i) => i.name)).toEqual(
+        NAV_ITEMS.map((i) => i.name),
+      );
+    });
+
+    it('keeps each ungrouped item in its own label-less section', () => {
+      const sections = getNavSections([
+        { name: 'A', href: '/a', icon: () => null, preloadKey: 'a', matchPaths: ['/a'] },
+        { name: 'B', href: '/b', icon: () => null, preloadKey: 'b', matchPaths: ['/b'] },
+      ]);
+      expect(sections).toHaveLength(2);
+      expect(sections.every((s) => s.label === null && s.items.length === 1)).toBe(true);
+    });
+  });
+
+  describe('isNavItemActive', () => {
+    const dashboard = NAV_ITEMS.find((i) => i.name === 'Dashboard')!;
+    const subscribers = NAV_ITEMS.find((i) => i.name === 'Subscribers')!;
+
+    it('matches Dashboard only on exact "/"', () => {
+      expect(isNavItemActive(dashboard, '/')).toBe(true);
+      expect(isNavItemActive(dashboard, '/issues')).toBe(false);
+    });
+
+    it('matches Subscribers on /subscribers and /segments via startsWith', () => {
+      expect(isNavItemActive(subscribers, '/subscribers')).toBe(true);
+      expect(isNavItemActive(subscribers, '/segments/abc')).toBe(true);
+      expect(isNavItemActive(subscribers, '/sponsors')).toBe(false);
+    });
+  });
+});

--- a/dashboard-ui/src/components/layout/sidebarNav.ts
+++ b/dashboard-ui/src/components/layout/sidebarNav.ts
@@ -12,18 +12,54 @@ export interface SidebarNavItem {
   icon: React.FC<{ className?: string }>;
   preloadKey: string;
   matchPaths: string[];
+  /**
+   * Optional section label. Consecutive items that share a `group` are rendered
+   * together under a single heading (see {@link getNavSections}).
+   */
+  group?: string;
 }
 
+/**
+ * Left-nav items in priority order (most-used at top). Templates and Snippets
+ * share the "Content" group so they render together as one area instead of two
+ * separate top-level entries.
+ */
 export const NAV_ITEMS: SidebarNavItem[] = [
   { name: 'Dashboard', href: '/', icon: HomeIcon, preloadKey: 'dashboard', matchPaths: ['/'] },
   { name: 'Issues', href: '/issues', icon: FileText, preloadKey: 'issues', matchPaths: ['/issues'] },
-  { name: 'Templates', href: '/templates', icon: LayoutTemplate, preloadKey: 'templates', matchPaths: ['/templates'] },
-  { name: 'Snippets', href: '/snippets', icon: Puzzle, preloadKey: 'snippets', matchPaths: ['/snippets'] },
   { name: 'Subscribers', href: '/subscribers', icon: UserGroupIcon, preloadKey: 'subscribers', matchPaths: ['/subscribers', '/segments'] },
+  { name: 'Templates', href: '/templates', icon: LayoutTemplate, preloadKey: 'templates', matchPaths: ['/templates'], group: 'Content' },
+  { name: 'Snippets', href: '/snippets', icon: Puzzle, preloadKey: 'snippets', matchPaths: ['/snippets'], group: 'Content' },
   { name: 'Sponsors', href: '/sponsors', icon: Building2, preloadKey: 'sponsors', matchPaths: ['/sponsors'] },
   { name: 'Brand', href: '/brand', icon: BuildingOfficeIcon, preloadKey: 'brand', matchPaths: ['/brand'] },
   { name: 'Pricing', href: '/pricing', icon: CurrencyDollarIcon, preloadKey: 'pricing', matchPaths: ['/pricing'] },
 ];
+
+export interface SidebarNavSection {
+  /** Section heading, or `null` for standalone (ungrouped) items. */
+  label: string | null;
+  items: SidebarNavItem[];
+}
+
+/**
+ * Folds the flat, ordered {@link NAV_ITEMS} into render-ready sections.
+ * Consecutive items sharing a `group` collapse into one labeled section;
+ * ungrouped items each become their own label-less section. Order is preserved,
+ * so this is purely a presentational grouping over the canonical item list.
+ */
+export function getNavSections(items: SidebarNavItem[] = NAV_ITEMS): SidebarNavSection[] {
+  const sections: SidebarNavSection[] = [];
+  for (const item of items) {
+    const label = item.group ?? null;
+    const last = sections[sections.length - 1];
+    if (label !== null && last && last.label === label) {
+      last.items.push(item);
+    } else {
+      sections.push({ label, items: [item] });
+    }
+  }
+  return sections;
+}
 
 /**
  * Determines if a nav item is active based on the current pathname.


### PR DESCRIPTION
## What & why

Templates and Snippets were two separate top-level entries in the left nav even though they're really one area of work (content building). This groups them under a shared **"Content"** section heading and reorders the whole nav into audience-first priority order.

**Before**
```
Dashboard · Issues · Templates · Snippets · Subscribers · Sponsors · Brand · Pricing
```

**After**
```
Dashboard
Issues
Subscribers
CONTENT
  Templates
  Snippets
Sponsors
Brand
Pricing
```

Subscribers moves above the content-building tools since audience management is far more frequent than tweaking templates.

## Implementation

- `NAV_ITEMS` stays the flat, ordered single source of truth (consumed by the sidebar, mobile drawer, and the parity test). Added an optional `group` field and a `getNavSections()` helper that folds consecutive same-group items into one labeled section for rendering — so grouping is purely presentational over the canonical list.
- Applied the grouped rendering to both the desktop `AppSidebar` and the active `MobileDrawer`.
- `AppHeader` / `MobileNavigation` are unused dead code (nothing imports `AppHeader`; the live layout is `AppShell` → `AppHeaderBar` + `MobileDrawer`) and were left untouched.

## Tests

- New `sidebarNav` unit tests: order, group tagging, `getNavSections` folding, and active-matching.
- `AppSidebar`: asserts audience-first link order and the "Content" heading (still exactly 8 anchors).
- Updated the `MobileDrawer` parity property test to the new order.
- Full `dashboard-ui` suite green (918 tests); ESLint and `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KcoMVe13jS15kdPyU6rcNY)_