### PR TITLE
Add content heatmap with link click overlays to issue analytics

### DIFF
--- a/dashboard-ui/src/components/issues/ContentHeatmap.tsx
+++ b/dashboard-ui/src/components/issues/ContentHeatmap.tsx
@@ -1,0 +1,300 @@
+/* eslint-disable react-refresh/only-export-components */
+import React, { useMemo } from 'react';
+import { scaleLinear } from 'd3-scale';
+import { Flame, ArrowDownWideNarrow } from 'lucide-react';
+import { cn } from '../../utils/cn';
+import { formatMarkdown, escapeHtmlAttribute } from '../../utils/markdown';
+import { ColorLegend } from '../analytics/ColorLegend';
+import { InfoTooltip } from '../ui/InfoTooltip';
+import type { LinkPerformance } from '../../types/issues';
+
+export interface ContentHeatmapProps {
+  /** The raw markdown content of the issue. */
+  content: string;
+  /** Per-link click performance from issue analytics. */
+  links: LinkPerformance[];
+  /** Total clicks across the issue (used for the share narrative). */
+  totalClicks: number;
+  /** Optional additional CSS classes for the container. */
+  className?: string;
+}
+
+/** Cool → hot color ramp used for the link heat overlay. */
+export function createHeatColorScale(maxClicks: number): (clicks: number) => string {
+  if (maxClicks <= 0) {
+    return () => 'transparent';
+  }
+  return scaleLinear<string>()
+    .domain([0, maxClicks / 2, maxClicks])
+    .range(['#fef9c3', '#fb923c', '#b91c1c'])
+    .clamp(true);
+}
+
+export interface ReadDepthStats {
+  /** Links with a known position, sorted in document order. */
+  ordered: LinkPerformance[];
+  /** Total clicks attributed to positioned links. */
+  attributedClicks: number;
+  /** Number of links that received at least one click. */
+  clickedLinks: number;
+  /** Total number of positioned links. */
+  totalLinks: number;
+  /** Highest link position (1-based) that received any click; 0 if none. */
+  deepestClickedPosition: number;
+  /** Number of links from the top by which 80% of clicks had occurred; 0 if none. */
+  depthForEightyPercent: number;
+  /** Share (0-100) of clicks captured by the single best-performing link. */
+  topLinkSharePct: number;
+}
+
+/**
+ * Derives "how far did readers get" statistics from per-link click data. The
+ * proxy for read depth is link position: links are wrapped for tracking in
+ * document order, so engagement on later links implies readers scrolled
+ * further. See functions/update-link-tracking.mjs for the position semantics.
+ */
+export function computeReadDepth(links: LinkPerformance[]): ReadDepthStats {
+  const ordered = links
+    .filter((link) => link.position > 0)
+    .sort((a, b) => a.position - b.position);
+
+  const attributedClicks = ordered.reduce((sum, link) => sum + link.clicks, 0);
+  const clickedLinks = ordered.filter((link) => link.clicks > 0).length;
+  const deepestClickedPosition = ordered.reduce(
+    (deepest, link) => (link.clicks > 0 ? Math.max(deepest, link.position) : deepest),
+    0
+  );
+
+  let cumulative = 0;
+  let depthForEightyPercent = 0;
+  if (attributedClicks > 0) {
+    for (let i = 0; i < ordered.length; i += 1) {
+      cumulative += ordered[i].clicks;
+      if (cumulative / attributedClicks >= 0.8) {
+        depthForEightyPercent = i + 1;
+        break;
+      }
+    }
+  }
+
+  const topLinkClicks = ordered.reduce((max, link) => Math.max(max, link.clicks), 0);
+  const topLinkSharePct = attributedClicks > 0 ? (topLinkClicks / attributedClicks) * 100 : 0;
+
+  return {
+    ordered,
+    attributedClicks,
+    clickedLinks,
+    totalLinks: ordered.length,
+    deepestClickedPosition,
+    depthForEightyPercent,
+    topLinkSharePct,
+  };
+}
+
+/**
+ * Renders the issue's content with a click heat overlay on every tracked link
+ * plus per-link annotations, a legend, and a read-depth summary. Lets the author
+ * see, in context, which links drew attention and how far down the content
+ * readers engaged.
+ */
+export const ContentHeatmap: React.FC<ContentHeatmapProps> = React.memo(
+  ({ content, links, totalClicks, className }) => {
+    const maxClicks = useMemo(
+      () => links.reduce((max, link) => Math.max(max, link.clicks), 0),
+      [links]
+    );
+
+    const readDepth = useMemo(() => computeReadDepth(links), [links]);
+
+    const html = useMemo(() => {
+      const colorScale = createHeatColorScale(maxClicks);
+
+      // Match each rendered link to its click data by URL. LinkPerformance.url
+      // is the original markdown URL (see functions/update-link-tracking.mjs), so
+      // anchors that share a URL share the aggregated data, and untracked links
+      // (e.g. mailto:) simply have no match and render plain.
+      const byUrl = new Map<string, LinkPerformance>();
+      for (const link of links) {
+        byUrl.set(link.url.trim(), link);
+      }
+
+      const renderLink = (anchorText: string, url: string): string => {
+        const perf = byUrl.get(url.trim());
+        const safeUrl = escapeHtmlAttribute(url);
+        const baseAnchorClasses =
+          'rounded-sm px-1 font-medium transition-shadow hover:ring-2 hover:ring-offset-1 hover:ring-gray-400 focus:outline-none focus:ring-2 focus:ring-primary-500';
+
+        // Links without click data render plain (e.g. mailto links).
+        if (!perf || maxClicks <= 0) {
+          return `<a href="${safeUrl}" target="_blank" rel="noopener noreferrer" class="text-primary-600 underline decoration-primary-300 hover:decoration-primary-500">${anchorText}</a>`;
+        }
+
+        const { clicks, percentOfTotal, position } = perf;
+        const intensity = clicks / maxClicks;
+        const background = clicks > 0 ? colorScale(clicks) : 'transparent';
+        const textColor = clicks > 0 && intensity > 0.55 ? '#ffffff' : '#1f2937';
+        const noun = clicks === 1 ? 'click' : 'clicks';
+        const linkLabel = position > 0 ? `Link #${position}` : 'Link';
+        const title = escapeHtmlAttribute(
+          `${linkLabel} — ${clicks.toLocaleString()} ${noun} (${percentOfTotal.toFixed(1)}% of total)`
+        );
+
+        if (clicks > 0) {
+          const badge = `<sup class="ml-0.5 inline-block rounded px-1 text-[10px] font-bold leading-tight align-super" style="background-color:#111827;color:#ffffff;">${clicks.toLocaleString()}</sup>`;
+          return `<a href="${safeUrl}" target="_blank" rel="noopener noreferrer" title="${title}" class="${baseAnchorClasses}" style="background-color:${background};color:${textColor};box-shadow:inset 0 0 0 1px rgba(0,0,0,0.08);">${anchorText}${badge}</a>`;
+        }
+
+        // Tracked but never clicked — show a muted marker so "dead" links stand out.
+        const badge = `<sup class="ml-0.5 inline-block rounded px-1 text-[10px] font-semibold leading-tight align-super" style="background-color:#e5e7eb;color:#6b7280;">0</sup>`;
+        return `<a href="${safeUrl}" target="_blank" rel="noopener noreferrer" title="${title}" class="${baseAnchorClasses} text-gray-600" style="box-shadow:inset 0 0 0 1px rgba(0,0,0,0.08);border-bottom:1px dashed #9ca3af;">${anchorText}${badge}</a>`;
+      };
+
+      return formatMarkdown(content, { renderLink });
+    }, [content, links, maxClicks]);
+
+    const hasClickData = maxClicks > 0;
+
+    return (
+      <div className={cn('space-y-4', className)}>
+        <div className="flex items-center gap-2">
+          <Flame className="w-5 h-5 text-red-500" aria-hidden="true" />
+          <h3 className="text-base sm:text-lg font-semibold text-foreground">Content Heatmap</h3>
+          <InfoTooltip
+            label="Content Heatmap"
+            description="Your rendered content with each tracked link shaded by how many clicks it received and annotated with its click count. Darker, hotter links drew more attention. Use it to see which links worked and how far down the content readers stayed engaged."
+          />
+        </div>
+
+        {hasClickData ? (
+          <ReadDepthSummary readDepth={readDepth} totalClicks={totalClicks} />
+        ) : (
+          <div className="text-sm text-muted-foreground bg-muted/30 p-3 rounded-lg">
+            No link clicks were recorded for this issue yet, so the content below is shown without heat shading.
+          </div>
+        )}
+
+        {hasClickData && (
+          <div className="bg-muted/20 border border-border rounded-lg px-3 py-2">
+            <ColorLegend
+              minValue={0}
+              maxValue={maxClicks}
+              colorScale={createHeatColorScale(maxClicks)}
+              metricLabel="clicks per link"
+            />
+          </div>
+        )}
+
+        <article
+          aria-label="Issue content heatmap"
+          className={cn(
+            'prose prose-sm max-w-none rounded-lg border border-border bg-background p-4 sm:p-6',
+            'text-foreground',
+            '[&_h1]:text-foreground [&_h2]:text-foreground [&_h3]:text-foreground',
+            '[&_p]:text-foreground [&_li]:text-foreground'
+          )}
+          dangerouslySetInnerHTML={{ __html: html }}
+        />
+      </div>
+    );
+  }
+);
+
+ContentHeatmap.displayName = 'ContentHeatmap';
+
+interface ReadDepthSummaryProps {
+  readDepth: ReadDepthStats;
+  totalClicks: number;
+}
+
+/** Compact "how far did readers read" summary derived from link positions. */
+const ReadDepthSummary: React.FC<ReadDepthSummaryProps> = ({ readDepth }) => {
+  const {
+    ordered,
+    attributedClicks,
+    clickedLinks,
+    totalLinks,
+    deepestClickedPosition,
+    depthForEightyPercent,
+    topLinkSharePct,
+  } = readDepth;
+
+  if (totalLinks === 0) return null;
+
+  const maxClicks = ordered.reduce((max, link) => Math.max(max, link.clicks), 0);
+
+  return (
+    <div className="rounded-lg border border-border bg-muted/20 p-3 sm:p-4 space-y-3">
+      <div className="flex items-center gap-2">
+        <ArrowDownWideNarrow className="w-4 h-4 text-primary-600" aria-hidden="true" />
+        <h4 className="text-sm font-semibold text-foreground">Reader engagement depth</h4>
+        <InfoTooltip
+          label="Reader engagement depth"
+          description="Links are tracked in the order they appear in your content, so clicks on links further down imply readers scrolled further. These stats estimate how far readers engaged based on which positions were clicked."
+        />
+      </div>
+
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <Stat
+          label="Links clicked"
+          value={`${clickedLinks} / ${totalLinks}`}
+          hint="Distinct links that got at least one click"
+        />
+        <Stat
+          label="Deepest click"
+          value={deepestClickedPosition > 0 ? `Link #${deepestClickedPosition}` : '—'}
+          hint="Furthest link position that drew a click"
+        />
+        <Stat
+          label="80% of clicks by"
+          value={depthForEightyPercent > 0 ? `Link #${depthForEightyPercent}` : '—'}
+          hint="Most engagement happened within these links"
+        />
+        <Stat
+          label="Top link share"
+          value={`${topLinkSharePct.toFixed(0)}%`}
+          hint="Share of link clicks taken by the best link"
+        />
+      </div>
+
+      {/* Per-position click distribution, in document order — the falloff curve. */}
+      <ol className="space-y-1.5" aria-label="Click distribution by link position">
+        {ordered.map((link) => {
+          const widthPct = maxClicks > 0 ? (link.clicks / maxClicks) * 100 : 0;
+          const sharePct = attributedClicks > 0 ? (link.clicks / attributedClicks) * 100 : 0;
+          return (
+            <li key={`${link.position}-${link.url}`} className="flex items-center gap-2 text-xs">
+              <span className="w-10 flex-shrink-0 text-right font-mono text-muted-foreground">
+                #{link.position}
+              </span>
+              <div className="flex-1 h-3 bg-gray-200 rounded-full overflow-hidden">
+                <div
+                  className="h-full rounded-full bg-gradient-to-r from-amber-300 via-orange-400 to-red-600 transition-all"
+                  style={{ width: `${widthPct}%` }}
+                  aria-hidden="true"
+                />
+              </div>
+              <span className="w-24 flex-shrink-0 text-right text-muted-foreground tabular-nums">
+                {link.clicks.toLocaleString()} ({sharePct.toFixed(0)}%)
+              </span>
+            </li>
+          );
+        })}
+      </ol>
+    </div>
+  );
+};
+
+interface StatProps {
+  label: string;
+  value: string;
+  hint: string;
+}
+
+const Stat: React.FC<StatProps> = ({ label, value, hint }) => (
+  <div className="rounded-md bg-background border border-border px-3 py-2" title={hint}>
+    <div className="text-xs text-muted-foreground">{label}</div>
+    <div className="text-base sm:text-lg font-semibold text-foreground">{value}</div>
+  </div>
+);
+
+export default ContentHeatmap;

--- a/dashboard-ui/src/components/issues/MarkdownPreview.tsx
+++ b/dashboard-ui/src/components/issues/MarkdownPreview.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { cn } from '../../utils/cn';
+import { formatMarkdown } from '../../utils/markdown';
 
 /**
  * Props for the MarkdownPreview component
@@ -17,32 +18,6 @@ export interface MarkdownPreviewProps {
  * Uses a simple regex-based parser for basic markdown formatting
  */
 export const MarkdownPreview: React.FC<MarkdownPreviewProps> = React.memo(({ content, className }) => {
-  const formatMarkdown = (text: string): string => {
-    let formatted = text;
-
-    formatted = formatted.replace(/^### (.*$)/gim, '<h3 class="text-lg font-semibold mt-6 mb-3 text-foreground">$1</h3>');
-    formatted = formatted.replace(/^## (.*$)/gim, '<h2 class="text-xl font-semibold mt-8 mb-4 text-foreground">$1</h2>');
-    formatted = formatted.replace(/^# (.*$)/gim, '<h1 class="text-2xl font-bold mt-8 mb-4 text-foreground">$1</h1>');
-
-    formatted = formatted.replace(/\*\*\*(.+?)\*\*\*/g, '<strong class="font-bold"><em class="italic">$1</em></strong>');
-    formatted = formatted.replace(/\*\*(.+?)\*\*/g, '<strong class="font-bold">$1</strong>');
-    formatted = formatted.replace(/\*(.+?)\*/g, '<em class="italic">$1</em>');
-
-    formatted = formatted.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" class="text-primary-600 hover:text-primary-700 underline decoration-primary-300 hover:decoration-primary-500 transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 rounded" target="_blank" rel="noopener noreferrer">$1</a>');
-
-    formatted = formatted.replace(/^- (.+)$/gim, '<li class="ml-4 text-foreground">$1</li>');
-    formatted = formatted.replace(/(<li.*<\/li>)/s, '<ul class="list-disc space-y-2 my-4 pl-4">$1</ul>');
-
-    formatted = formatted.replace(/^> (.+)$/gim, '<blockquote class="border-l-4 border-primary-500 pl-4 py-2 italic my-4 text-muted-foreground bg-muted/30 rounded-r">$1</blockquote>');
-
-    formatted = formatted.replace(/`([^`]+)`/g, '<code class="bg-muted px-2 py-0.5 rounded text-sm font-mono text-foreground border border-border">$1</code>');
-
-    formatted = formatted.replace(/\n\n/g, '</p><p class="mb-4 text-foreground leading-relaxed">');
-    formatted = `<p class="mb-4 text-foreground leading-relaxed">${formatted}</p>`;
-
-    return formatted;
-  };
-
   return (
     <div
       className={cn(

--- a/dashboard-ui/src/components/issues/__tests__/ContentHeatmap.test.tsx
+++ b/dashboard-ui/src/components/issues/__tests__/ContentHeatmap.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ContentHeatmap, computeReadDepth, createHeatColorScale } from '../ContentHeatmap';
+import type { LinkPerformance } from '../../../types/issues';
+
+const links: LinkPerformance[] = [
+  { url: 'https://a.com', clicks: 100, percentOfTotal: 62.5, position: 1 },
+  { url: 'https://b.com', clicks: 60, percentOfTotal: 37.5, position: 2 },
+  { url: 'https://c.com', clicks: 0, percentOfTotal: 0, position: 3 },
+];
+
+const content =
+  'Intro paragraph.\n\nRead [the launch post](https://a.com) and [the changelog](https://b.com).\n\nAlso [a quiet link](https://c.com) at the end.';
+
+describe('computeReadDepth', () => {
+  it('summarizes click distribution by link position', () => {
+    const stats = computeReadDepth(links);
+    expect(stats.totalLinks).toBe(3);
+    expect(stats.clickedLinks).toBe(2);
+    expect(stats.attributedClicks).toBe(160);
+    expect(stats.deepestClickedPosition).toBe(2); // c.com (pos 3) had 0 clicks
+    expect(stats.topLinkSharePct).toBeCloseTo(62.5, 1);
+    // 100/160 = 62.5% < 80%, +60 = 100% >= 80% at second link
+    expect(stats.depthForEightyPercent).toBe(2);
+  });
+
+  it('ignores links without a known position and handles no-click issues', () => {
+    const stats = computeReadDepth([
+      { url: 'https://x.com', clicks: 0, percentOfTotal: 0, position: 0 },
+      { url: 'https://y.com', clicks: 0, percentOfTotal: 0, position: 1 },
+    ]);
+    expect(stats.totalLinks).toBe(1);
+    expect(stats.clickedLinks).toBe(0);
+    expect(stats.deepestClickedPosition).toBe(0);
+    expect(stats.depthForEightyPercent).toBe(0);
+    expect(stats.topLinkSharePct).toBe(0);
+  });
+});
+
+describe('createHeatColorScale', () => {
+  it('returns transparent when there are no clicks', () => {
+    const scale = createHeatColorScale(0);
+    expect(scale(0)).toBe('transparent');
+  });
+
+  it('maps higher click counts to hotter colors', () => {
+    const scale = createHeatColorScale(100);
+    expect(scale(0)).not.toBe(scale(100));
+  });
+});
+
+describe('ContentHeatmap', () => {
+  it('renders the content with per-link click annotations', () => {
+    const { container } = render(
+      <ContentHeatmap content={content} links={links} totalClicks={160} />
+    );
+
+    // Anchor text is preserved
+    expect(screen.getByText('the launch post')).toBeInTheDocument();
+    expect(screen.getByText('the changelog')).toBeInTheDocument();
+
+    // Click-count badges are rendered as superscripts
+    const anchors = container.querySelectorAll('a[title]');
+    expect(anchors.length).toBeGreaterThan(0);
+    const launchAnchor = Array.from(anchors).find((a) => a.getAttribute('href') === 'https://a.com');
+    expect(launchAnchor?.getAttribute('title')).toContain('100 clicks');
+    expect(launchAnchor?.getAttribute('title')).toContain('62.5% of total');
+    expect(launchAnchor?.querySelector('sup')?.textContent).toBe('100');
+  });
+
+  it('shows the reader engagement depth summary', () => {
+    render(<ContentHeatmap content={content} links={links} totalClicks={160} />);
+    expect(
+      screen.getByRole('heading', { name: 'Reader engagement depth' })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Links clicked')).toBeInTheDocument();
+    // 2 of 3 links clicked
+    expect(screen.getByText('2 / 3')).toBeInTheDocument();
+  });
+
+  it('renders gracefully with no click data', () => {
+    render(<ContentHeatmap content={content} links={[]} totalClicks={0} />);
+    expect(screen.getByText(/No link clicks were recorded/i)).toBeInTheDocument();
+    // Content is still shown
+    expect(screen.getByText('the launch post')).toBeInTheDocument();
+  });
+});

--- a/dashboard-ui/src/components/issues/index.ts
+++ b/dashboard-ui/src/components/issues/index.ts
@@ -7,6 +7,9 @@ export type { IssueCardProps } from './IssueCard';
 export { MarkdownPreview } from './MarkdownPreview';
 export type { MarkdownPreviewProps } from './MarkdownPreview';
 
+export { ContentHeatmap } from './ContentHeatmap';
+export type { ContentHeatmapProps } from './ContentHeatmap';
+
 export { MarkdownWysiwygEditor } from './MarkdownWysiwygEditor';
 export type { MarkdownWysiwygEditorProps } from './MarkdownWysiwygEditor';
 

--- a/dashboard-ui/src/pages/issues/IssueDetailPage.tsx
+++ b/dashboard-ui/src/pages/issues/IssueDetailPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo, useCallback, lazy, Suspense, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { ArrowLeft, Pencil, Trash, RefreshCw, AlertCircle, TrendingUp, Users, Shield, FileText, CheckCircle } from 'lucide-react';
+import { ArrowLeft, Pencil, Trash, RefreshCw, AlertCircle, TrendingUp, Users, Shield, FileText, CheckCircle, Flame } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '../../components/ui/Card';
 import { Button } from '../../components/ui/Button';
 import { useToast } from '../../components/ui/Toast';
@@ -58,6 +58,7 @@ const TrafficSourceChart = lazy(() => import('../../components/issues/TrafficSou
 const TimingMetricsChart = lazy(() => import('../../components/issues/TimingMetricsChart').then(m => ({ default: m.TimingMetricsChart })));
 const GeoMap = lazy(() => import('../../components/analytics/GeoMap').then(m => ({ default: m.GeoMap })));
 const LinkSelector = lazy(() => import('../../components/analytics/LinkSelector').then(m => ({ default: m.LinkSelector })));
+const ContentHeatmap = lazy(() => import('../../components/issues/ContentHeatmap').then(m => ({ default: m.ContentHeatmap })));
 
 // Section configuration for the new single-page layout
 interface SectionConfig {
@@ -115,6 +116,7 @@ export const IssueDetailPage: React.FC = () => {
   const [selectedLinkId, setSelectedLinkId] = useState<string | null>(null);
   const [isAnalyticsRebuilding, setIsAnalyticsRebuilding] = useState(false);
   const [isMarkingPublished, setIsMarkingPublished] = useState(false);
+  const [contentView, setContentView] = useState<'preview' | 'heatmap'>('preview');
 
   // New state for single-page layout
   const [expandedSections, setExpandedSections] = useState<Set<string>>(new Set());
@@ -509,6 +511,13 @@ export const IssueDetailPage: React.FC = () => {
   const isDraft = useMemo(() => issue?.status === 'draft', [issue?.status]);
   const isPublished = useMemo(() => issue?.status === 'published', [issue?.status]);
   const canMarkAsPublished = useMemo(() => issue?.status === 'in progress' || issue?.status === 'failed', [issue?.status]);
+
+  // The content heatmap overlays click data on the rendered markdown, so it only
+  // applies to markdown issues that have per-link analytics.
+  const canShowHeatmap = useMemo(
+    () => issue?.contentType !== 'json' && !!analytics?.links && analytics.links.length > 0,
+    [issue?.contentType, analytics]
+  );
 
   const complaintRate = useMemo(() => {
     if (!issue?.stats) return 0;
@@ -1115,21 +1124,68 @@ export const IssueDetailPage: React.FC = () => {
         {/* Content Preview Section - Moved to bottom */}
         <Card className="mb-6">
           <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <FileText className="w-5 h-5" aria-hidden="true" />
-              Content
-            </CardTitle>
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+              <CardTitle className="flex items-center gap-2">
+                <FileText className="w-5 h-5" aria-hidden="true" />
+                Content
+              </CardTitle>
+              {canShowHeatmap && (
+                <div
+                  className="inline-flex rounded-lg border border-border bg-muted/30 p-0.5 self-start"
+                  role="group"
+                  aria-label="Content view mode"
+                >
+                  <button
+                    type="button"
+                    onClick={() => setContentView('preview')}
+                    aria-pressed={contentView === 'preview'}
+                    className={`px-3 py-1.5 text-xs sm:text-sm font-medium rounded-md transition-colors min-h-[36px] ${
+                      contentView === 'preview'
+                        ? 'bg-background text-foreground shadow-sm'
+                        : 'text-muted-foreground hover:text-foreground'
+                    }`}
+                  >
+                    Preview
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setContentView('heatmap')}
+                    aria-pressed={contentView === 'heatmap'}
+                    className={`inline-flex items-center gap-1 px-3 py-1.5 text-xs sm:text-sm font-medium rounded-md transition-colors min-h-[36px] ${
+                      contentView === 'heatmap'
+                        ? 'bg-background text-foreground shadow-sm'
+                        : 'text-muted-foreground hover:text-foreground'
+                    }`}
+                  >
+                    <Flame className="w-3.5 h-3.5" aria-hidden="true" />
+                    Heatmap
+                  </button>
+                </div>
+              )}
+            </div>
           </CardHeader>
           <CardContent>
-            <article aria-label="Issue content preview">
-              {issue.contentType === 'json' ? (
-                <pre className="overflow-x-auto rounded-lg border border-border bg-muted/40 p-4 text-sm font-mono text-foreground whitespace-pre-wrap break-words">
-                  {issue.content}
-                </pre>
-              ) : (
-                <MarkdownPreview content={issue.content} />
-              )}
-            </article>
+            {canShowHeatmap && contentView === 'heatmap' ? (
+              <Suspense fallback={<ChartSkeleton />}>
+                <AsyncErrorBoundary onRetry={loadIssue}>
+                  <ContentHeatmap
+                    content={issue.content}
+                    links={analytics?.links || []}
+                    totalClicks={issue.stats?.clicks || 0}
+                  />
+                </AsyncErrorBoundary>
+              </Suspense>
+            ) : (
+              <article aria-label="Issue content preview">
+                {issue.contentType === 'json' ? (
+                  <pre className="overflow-x-auto rounded-lg border border-border bg-muted/40 p-4 text-sm font-mono text-foreground whitespace-pre-wrap break-words">
+                    {issue.content}
+                  </pre>
+                ) : (
+                  <MarkdownPreview content={issue.content} />
+                )}
+              </article>
+            )}
           </CardContent>
         </Card>
 

--- a/dashboard-ui/src/utils/__tests__/markdown.test.ts
+++ b/dashboard-ui/src/utils/__tests__/markdown.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { formatMarkdown, escapeHtml, escapeHtmlAttribute } from '../markdown';
+
+describe('formatMarkdown', () => {
+  it('renders headings, bold and italic', () => {
+    const html = formatMarkdown('# Title\n\nSome **bold** and *italic* text');
+    expect(html).toContain('<h1 class="text-2xl font-bold mt-8 mb-4 text-foreground">Title</h1>');
+    expect(html).toContain('<strong class="font-bold">bold</strong>');
+    expect(html).toContain('<em class="italic">italic</em>');
+  });
+
+  it('renders links with the default styling when no custom renderer is provided', () => {
+    const html = formatMarkdown('Check [the docs](https://example.com/docs)');
+    expect(html).toContain('href="https://example.com/docs"');
+    expect(html).toContain('>the docs</a>');
+    expect(html).toContain('target="_blank"');
+  });
+
+  it('passes anchor text, url and a document-order index to a custom link renderer', () => {
+    const seen: Array<{ anchorText: string; url: string; index: number }> = [];
+    formatMarkdown('[first](https://a.com) then [second](https://b.com)', {
+      renderLink: (anchorText, url, ctx) => {
+        seen.push({ anchorText, url, index: ctx.index });
+        return `<a data-i="${ctx.index}">${anchorText}</a>`;
+      },
+    });
+
+    expect(seen).toEqual([
+      { anchorText: 'first', url: 'https://a.com', index: 0 },
+      { anchorText: 'second', url: 'https://b.com', index: 1 },
+    ]);
+  });
+
+  it('uses the custom renderer output verbatim', () => {
+    const html = formatMarkdown('[x](https://a.com)', {
+      renderLink: (anchorText) => `<span class="custom">${anchorText}</span>`,
+    });
+    expect(html).toContain('<span class="custom">x</span>');
+  });
+
+  it('does not misinterpret $ characters in URLs (function replacer is literal)', () => {
+    const html = formatMarkdown('[pay](https://a.com/?amount=$5&ref=$1)');
+    expect(html).toContain('href="https://a.com/?amount=$5&ref=$1"');
+  });
+});
+
+describe('escapeHtml / escapeHtmlAttribute', () => {
+  it('escapes angle brackets and ampersands', () => {
+    expect(escapeHtml('a & b <c>')).toBe('a &amp; b &lt;c&gt;');
+  });
+
+  it('additionally escapes double quotes for attributes', () => {
+    expect(escapeHtmlAttribute('say "hi" & <go>')).toBe('say &quot;hi&quot; &amp; &lt;go&gt;');
+  });
+});

--- a/dashboard-ui/src/utils/markdown.ts
+++ b/dashboard-ui/src/utils/markdown.ts
@@ -1,0 +1,85 @@
+/**
+ * Shared markdown-to-HTML formatting used by the issue content preview and the
+ * content heatmap. Both renderers must produce identical structure for non-link
+ * elements so that the heatmap overlay lines up with the plain preview — the
+ * only thing the heatmap customizes is how individual links are rendered.
+ *
+ * This is intentionally the same lightweight regex-based parser that the
+ * dashboard has always used for newsletter content. It supports headings, bold,
+ * italic, links, unordered lists, blockquotes and inline code.
+ */
+
+export interface RenderLinkContext {
+  /**
+   * Zero-based index of this link among all markdown links in the content, in
+   * document order. Mirrors the order links are wrapped for click tracking on
+   * the backend (see functions/update-link-tracking.mjs).
+   */
+  index: number;
+}
+
+export interface FormatMarkdownOptions {
+  /**
+   * Custom renderer for markdown links. Receives the (already inline-formatted)
+   * anchor text, the URL, and context describing the link's position. Must
+   * return an HTML string. When omitted, links render with the default
+   * newsletter styling.
+   */
+  renderLink?: (anchorText: string, url: string, context: RenderLinkContext) => string;
+}
+
+/** Default anchor rendering — kept byte-for-byte compatible with the historic preview output. */
+export const defaultRenderLink = (anchorText: string, url: string): string =>
+  `<a href="${url}" class="text-primary-600 hover:text-primary-700 underline decoration-primary-300 hover:decoration-primary-500 transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 rounded" target="_blank" rel="noopener noreferrer">${anchorText}</a>`;
+
+/**
+ * Converts markdown content into the dashboard's HTML representation.
+ *
+ * @param text - Raw markdown content.
+ * @param options - Optional hooks, e.g. a custom link renderer for the heatmap.
+ * @returns An HTML string suitable for `dangerouslySetInnerHTML`.
+ */
+export function formatMarkdown(text: string, options: FormatMarkdownOptions = {}): string {
+  const renderLink = options.renderLink ?? defaultRenderLink;
+  let formatted = text;
+
+  formatted = formatted.replace(/^### (.*$)/gim, '<h3 class="text-lg font-semibold mt-6 mb-3 text-foreground">$1</h3>');
+  formatted = formatted.replace(/^## (.*$)/gim, '<h2 class="text-xl font-semibold mt-8 mb-4 text-foreground">$1</h2>');
+  formatted = formatted.replace(/^# (.*$)/gim, '<h1 class="text-2xl font-bold mt-8 mb-4 text-foreground">$1</h1>');
+
+  formatted = formatted.replace(/\*\*\*(.+?)\*\*\*/g, '<strong class="font-bold"><em class="italic">$1</em></strong>');
+  formatted = formatted.replace(/\*\*(.+?)\*\*/g, '<strong class="font-bold">$1</strong>');
+  formatted = formatted.replace(/\*(.+?)\*/g, '<em class="italic">$1</em>');
+
+  let linkIndex = 0;
+  formatted = formatted.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_match, anchorText: string, url: string) => {
+    const html = renderLink(anchorText, url, { index: linkIndex });
+    linkIndex += 1;
+    return html;
+  });
+
+  formatted = formatted.replace(/^- (.+)$/gim, '<li class="ml-4 text-foreground">$1</li>');
+  formatted = formatted.replace(/(<li.*<\/li>)/s, '<ul class="list-disc space-y-2 my-4 pl-4">$1</ul>');
+
+  formatted = formatted.replace(/^> (.+)$/gim, '<blockquote class="border-l-4 border-primary-500 pl-4 py-2 italic my-4 text-muted-foreground bg-muted/30 rounded-r">$1</blockquote>');
+
+  formatted = formatted.replace(/`([^`]+)`/g, '<code class="bg-muted px-2 py-0.5 rounded text-sm font-mono text-foreground border border-border">$1</code>');
+
+  formatted = formatted.replace(/\n\n/g, '</p><p class="mb-4 text-foreground leading-relaxed">');
+  formatted = `<p class="mb-4 text-foreground leading-relaxed">${formatted}</p>`;
+
+  return formatted;
+}
+
+/** Escapes text for safe inclusion in HTML element content. */
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+/** Escapes a value for safe inclusion inside a double-quoted HTML attribute. */
+export function escapeHtmlAttribute(value: string): string {
+  return escapeHtml(value).replace(/"/g, '&quot;');
+}


### PR DESCRIPTION
Adds a "Heatmap" view to the issue analytics Content card that renders the
issue's content with each tracked link shaded by click intensity and annotated
with its click count. Includes a reader-engagement-depth summary that uses link
position as a proxy for how far down the content readers engaged.

- Extract markdown formatting into a shared util (src/utils/markdown.ts) with a
  pluggable link renderer; MarkdownPreview now consumes it (behavior unchanged).
- New ContentHeatmap component: per-link heat shading (d3 cool->hot scale),
  click-count badges, color legend, and a per-position click distribution.
- Wire a Preview/Heatmap toggle into IssueDetailPage for published markdown
  issues that have per-link analytics.
- Tests for the markdown util and ContentHeatmap.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BVJzLm8dqw9gJoRdLCJcA3