### PR TITLE
Visualize delivery breakdown as a pie chart and sharpen issue analytics metrics

### DIFF
--- a/dashboard-ui/src/components/issues/DeliveryBreakdownChart.tsx
+++ b/dashboard-ui/src/components/issues/DeliveryBreakdownChart.tsx
@@ -1,0 +1,207 @@
+import React, { useMemo } from 'react';
+import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from 'recharts';
+import { Send } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '../ui/Card';
+import { InfoTooltip } from '../ui/InfoTooltip';
+import { formatNumber } from '../../utils/issueDetailUtils';
+
+export interface DeliveryBreakdownChartProps {
+  /** Number of emails successfully delivered to recipients. */
+  delivered: number;
+  /** Number of emails that bounced (could not be delivered). */
+  bounced: number;
+}
+
+const COLORS = {
+  delivered: '#10b981', // success / emerald
+  bounced: '#ef4444', // error / red
+};
+
+interface ChartDatum {
+  key: 'delivered' | 'bounced';
+  name: string;
+  value: number;
+  percentage: number;
+  color: string;
+}
+
+interface ChartTooltipEntry {
+  name?: string | number;
+  value?: number | string | readonly (string | number)[];
+  payload?: {
+    percentage?: number;
+    [key: string]: unknown;
+  };
+}
+
+interface ChartTooltipProps {
+  active?: boolean;
+  payload?: readonly ChartTooltipEntry[];
+}
+
+function CustomTooltip({ active, payload }: ChartTooltipProps) {
+  if (active && payload && payload.length > 0) {
+    const item = payload[0];
+    const label = item?.name ?? 'Value';
+    const count = typeof item?.value === 'number' ? item.value : 0;
+    const percentage =
+      item?.payload && typeof item.payload === 'object' && 'percentage' in item.payload
+        ? Number(item.payload.percentage ?? 0)
+        : 0;
+    return (
+      <div className="bg-surface p-3 border border-border rounded-lg shadow-lg">
+        <p className="font-medium text-foreground">{label}</p>
+        <p className="text-sm text-muted-foreground">
+          {formatNumber(count)} ({percentage.toFixed(1)}%)
+        </p>
+      </div>
+    );
+  }
+  return null;
+}
+
+interface BreakdownRowProps {
+  color: string;
+  label: string;
+  value: number;
+  percentage: number;
+}
+
+const BreakdownRow: React.FC<BreakdownRowProps> = ({ color, label, value, percentage }) => (
+  <div className="flex items-center justify-between">
+    <div className="flex items-center gap-2">
+      <span
+        className="w-2.5 h-2.5 rounded-full flex-shrink-0"
+        style={{ backgroundColor: color }}
+        aria-hidden="true"
+      />
+      <span className="text-xs sm:text-sm text-muted-foreground">{label}</span>
+    </div>
+    <span className="text-xs sm:text-sm font-medium text-foreground">
+      {formatNumber(value)} ({percentage.toFixed(1)}%)
+    </span>
+  </div>
+);
+
+export const DeliveryBreakdownChart: React.FC<DeliveryBreakdownChartProps> = React.memo(({
+  delivered,
+  bounced,
+}) => {
+  const safeDelivered = Math.max(0, delivered || 0);
+  const safeBounced = Math.max(0, bounced || 0);
+  const sent = safeDelivered + safeBounced;
+
+  const deliveredPct = sent > 0 ? (safeDelivered / sent) * 100 : 0;
+  const bouncedPct = sent > 0 ? (safeBounced / sent) * 100 : 0;
+
+  const chartData = useMemo<ChartDatum[]>(
+    () =>
+      [
+        {
+          key: 'delivered' as const,
+          name: 'Delivered',
+          value: safeDelivered,
+          percentage: deliveredPct,
+          color: COLORS.delivered,
+        },
+        {
+          key: 'bounced' as const,
+          name: 'Bounced',
+          value: safeBounced,
+          percentage: bouncedPct,
+          color: COLORS.bounced,
+        },
+      ].filter((item) => item.value > 0),
+    [safeDelivered, safeBounced, deliveredPct, bouncedPct]
+  );
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <CardTitle className="flex items-center gap-2">
+            <Send className="w-5 h-5 text-primary-600 dark:text-primary-400" aria-hidden="true" />
+            Delivery Breakdown
+          </CardTitle>
+          <InfoTooltip
+            label="Delivery Breakdown"
+            description="How this issue's send resolved — the share of messages that were successfully delivered versus those that bounced. Sent is the total of delivered and bounced messages."
+          />
+        </div>
+      </CardHeader>
+
+      <CardContent>
+        {sent === 0 ? (
+          <div className="text-center py-8 text-muted-foreground">
+            No delivery data available for this issue.
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 items-center">
+            {/* Donut chart with total Sent in the center */}
+            <div
+              className="relative h-56"
+              role="img"
+              aria-label={`Delivery breakdown: ${formatNumber(safeDelivered)} delivered (${deliveredPct.toFixed(1)}%) and ${formatNumber(safeBounced)} bounced (${bouncedPct.toFixed(1)}%) out of ${formatNumber(sent)} sent.`}
+            >
+              <ResponsiveContainer width="100%" height="100%">
+                <PieChart>
+                  <Pie
+                    data={chartData}
+                    cx="50%"
+                    cy="50%"
+                    innerRadius={60}
+                    outerRadius={90}
+                    paddingAngle={2}
+                    dataKey="value"
+                    nameKey="name"
+                    startAngle={90}
+                    endAngle={-270}
+                  >
+                    {chartData.map((entry) => (
+                      <Cell key={`cell-${entry.key}`} fill={entry.color} />
+                    ))}
+                  </Pie>
+                  <Tooltip content={CustomTooltip} />
+                </PieChart>
+              </ResponsiveContainer>
+
+              {/* Center label */}
+              <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none">
+                <span className="text-2xl sm:text-3xl font-bold text-foreground">
+                  {formatNumber(sent)}
+                </span>
+                <span className="text-xs sm:text-sm text-muted-foreground">Sent</span>
+              </div>
+            </div>
+
+            {/* Breakdown list */}
+            <div className="space-y-3">
+              <BreakdownRow
+                color={COLORS.delivered}
+                label="Delivered"
+                value={safeDelivered}
+                percentage={deliveredPct}
+              />
+              <BreakdownRow
+                color={COLORS.bounced}
+                label="Bounced"
+                value={safeBounced}
+                percentage={bouncedPct}
+              />
+              <div className="flex items-center justify-between pt-3 border-t border-border">
+                <span className="text-xs sm:text-sm font-medium text-muted-foreground">Sent</span>
+                <span className="text-xs sm:text-sm font-semibold text-foreground">
+                  {formatNumber(sent)}
+                </span>
+              </div>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+});
+
+DeliveryBreakdownChart.displayName = 'DeliveryBreakdownChart';
+
+export default DeliveryBreakdownChart;

--- a/dashboard-ui/src/components/issues/KeyMetricsSummary.tsx
+++ b/dashboard-ui/src/components/issues/KeyMetricsSummary.tsx
@@ -9,8 +9,10 @@ export interface KeyMetricsSummaryProps {
     deliveries: number;
     openRate: number;
     clickRate: number;
+    clickToOpenRate: number;
     bounceRate: number;
     complaintRate: number;
+    unsubscribeRate: number;
   };
   comparisons?: {
     average?: IssueMetrics;
@@ -135,6 +137,21 @@ export const KeyMetricsSummary: React.FC<KeyMetricsSummaryProps> = React.memo(({
     [activeComparison, metrics.clickRate]
   );
 
+  const clickToOpenRateComparison = useMemo(() =>
+    activeComparison
+      ? calculateComparison(metrics.clickToOpenRate, activeComparison.clickToOpenRate, 'positive')
+      : undefined,
+    [activeComparison, metrics.clickToOpenRate]
+  );
+
+  const unsubscribeRateComparison = useMemo(() => {
+    if (!activeComparison || activeComparison.unsubscribes === undefined || !activeComparison.delivered) {
+      return undefined;
+    }
+    const comparisonRate = (activeComparison.unsubscribes / activeComparison.delivered) * 100;
+    return calculateComparison(metrics.unsubscribeRate, comparisonRate, 'negative');
+  }, [activeComparison, metrics.unsubscribeRate]);
+
   const bounceRateComparison = useMemo(() =>
     activeComparison
       ? calculateComparison(metrics.bounceRate, activeComparison.bounceRate, 'negative')
@@ -155,7 +172,7 @@ export const KeyMetricsSummary: React.FC<KeyMetricsSummaryProps> = React.memo(({
 
   return (
     <div
-      className="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4"
+      className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3 sm:gap-4"
       role="region"
       aria-label="Key performance metrics"
     >
@@ -178,6 +195,17 @@ export const KeyMetricsSummary: React.FC<KeyMetricsSummaryProps> = React.memo(({
         comparisonLabel={comparisonLabel}
         tooltipLabel="Click Rate"
         tooltipDescription="Percentage of delivered emails where recipients clicked at least one link. Industry average is typically 2-5%."
+        colorClass="text-primary-600 dark:text-primary-400"
+      />
+
+      <MetricCard
+        label="Click-to-Open Rate"
+        value={formatPercentageValue(metrics.clickToOpenRate, 1)}
+        percentage="of opens"
+        comparison={clickToOpenRateComparison}
+        comparisonLabel={comparisonLabel}
+        tooltipLabel="Click-to-Open Rate (CTOR)"
+        tooltipDescription="Percentage of recipients who opened the email and then clicked a link. It isolates content and copy effectiveness from subject-line performance. Industry average is typically 10-15%."
         colorClass="text-primary-600 dark:text-primary-400"
       />
 
@@ -205,6 +233,17 @@ export const KeyMetricsSummary: React.FC<KeyMetricsSummaryProps> = React.memo(({
             ? 'text-error-600 dark:text-error-400'
             : 'text-error-600 dark:text-error-400'
         }
+      />
+
+      <MetricCard
+        label="Unsubscribe Rate"
+        value={formatPercentageValue(metrics.unsubscribeRate, 2)}
+        percentage={`${formatNumber(Math.round((metrics.unsubscribeRate / 100) * metrics.deliveries))} unsubscribes`}
+        comparison={unsubscribeRateComparison}
+        comparisonLabel={comparisonLabel}
+        tooltipLabel="Unsubscribe Rate"
+        tooltipDescription="Percentage of delivered recipients who opted out after this issue. Keep this below 0.5% — a healthy list typically sees 0.1-0.3%."
+        colorClass="text-warning-600 dark:text-warning-400"
       />
     </div>
   );

--- a/dashboard-ui/src/components/issues/KeyMetricsSummary.tsx
+++ b/dashboard-ui/src/components/issues/KeyMetricsSummary.tsx
@@ -155,18 +155,10 @@ export const KeyMetricsSummary: React.FC<KeyMetricsSummaryProps> = React.memo(({
 
   return (
     <div
-      className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3 sm:gap-4"
+      className="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4"
       role="region"
       aria-label="Key performance metrics"
     >
-      <MetricCard
-        label="Deliveries"
-        value={formatNumber(metrics.deliveries)}
-        tooltipLabel="Deliveries"
-        tooltipDescription="Total number of emails successfully delivered to recipients."
-        colorClass="text-foreground"
-      />
-
       <MetricCard
         label="Open Rate"
         value={formatPercentageValue(metrics.openRate, 1)}

--- a/dashboard-ui/src/components/issues/__tests__/DeliveryBreakdownChart.test.tsx
+++ b/dashboard-ui/src/components/issues/__tests__/DeliveryBreakdownChart.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { DeliveryBreakdownChart } from '../DeliveryBreakdownChart';
+
+describe('DeliveryBreakdownChart', () => {
+  describe('Rendering', () => {
+    it('should render delivered, bounced, and sent labels', () => {
+      render(<DeliveryBreakdownChart delivered={950} bounced={50} />);
+
+      expect(screen.getAllByText('Delivered').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('Bounced').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('Sent').length).toBeGreaterThan(0);
+    });
+
+    it('should display the total sent count in the center', () => {
+      render(<DeliveryBreakdownChart delivered={950} bounced={50} />);
+
+      // Sent = delivered + bounced = 1,000 (appears in center and breakdown list)
+      expect(screen.getAllByText('1,000').length).toBeGreaterThan(0);
+    });
+
+    it('should display counts with percentages in the breakdown list', () => {
+      render(<DeliveryBreakdownChart delivered={950} bounced={50} />);
+
+      expect(screen.getByText('950 (95.0%)')).toBeInTheDocument();
+      expect(screen.getByText('50 (5.0%)')).toBeInTheDocument();
+    });
+
+    it('should expose an accessible summary of the breakdown', () => {
+      render(<DeliveryBreakdownChart delivered={950} bounced={50} />);
+
+      expect(
+        screen.getByRole('img', {
+          name: /950 delivered \(95\.0%\) and 50 bounced \(5\.0%\) out of 1,000 sent/i,
+        })
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('should render an empty state when nothing was sent', () => {
+      render(<DeliveryBreakdownChart delivered={0} bounced={0} />);
+
+      expect(screen.getByText(/no delivery data available/i)).toBeInTheDocument();
+    });
+
+    it('should handle a 100% delivered send', () => {
+      render(<DeliveryBreakdownChart delivered={500} bounced={0} />);
+
+      expect(screen.getByText('500 (100.0%)')).toBeInTheDocument();
+      expect(screen.getByText('0 (0.0%)')).toBeInTheDocument();
+    });
+
+    it('should treat negative inputs as zero', () => {
+      render(<DeliveryBreakdownChart delivered={-10} bounced={-5} />);
+
+      expect(screen.getByText(/no delivery data available/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/dashboard-ui/src/components/issues/__tests__/KeyMetricsSummary.test.tsx
+++ b/dashboard-ui/src/components/issues/__tests__/KeyMetricsSummary.test.tsx
@@ -27,20 +27,24 @@ describe('KeyMetricsSummary', () => {
   };
 
   describe('Rendering', () => {
-    it('should render all five metric cards', () => {
+    it('should render all four rate metric cards', () => {
       render(<KeyMetricsSummary metrics={mockMetrics} />);
 
-      expect(screen.getAllByText('Deliveries').length).toBeGreaterThan(0);
       expect(screen.getAllByText('Open Rate').length).toBeGreaterThan(0);
       expect(screen.getAllByText('Click Rate').length).toBeGreaterThan(0);
       expect(screen.getAllByText('Bounce Rate').length).toBeGreaterThan(0);
       expect(screen.getAllByText('Complaint Rate').length).toBeGreaterThan(0);
     });
 
+    it('should not render a standalone Deliveries card', () => {
+      render(<KeyMetricsSummary metrics={mockMetrics} />);
+
+      expect(screen.queryByText('Deliveries')).not.toBeInTheDocument();
+    });
+
     it('should display formatted metric values', () => {
       render(<KeyMetricsSummary metrics={mockMetrics} />);
 
-      expect(screen.getByText('1,000')).toBeInTheDocument();
       expect(screen.getByText('45.5%')).toBeInTheDocument();
       expect(screen.getByText('12.3%')).toBeInTheDocument();
       expect(screen.getByText('2.1%')).toBeInTheDocument();
@@ -118,7 +122,7 @@ describe('KeyMetricsSummary', () => {
 
       render(<KeyMetricsSummary metrics={zeroMetrics} />);
 
-      expect(screen.getByText('0')).toBeInTheDocument();
+      expect(screen.getByText('0 opens')).toBeInTheDocument();
       expect(screen.getAllByText('0.0%').length).toBeGreaterThan(0);
     });
 

--- a/dashboard-ui/src/components/issues/__tests__/KeyMetricsSummary.test.tsx
+++ b/dashboard-ui/src/components/issues/__tests__/KeyMetricsSummary.test.tsx
@@ -8,32 +8,38 @@ describe('KeyMetricsSummary', () => {
     deliveries: 1000,
     openRate: 45.5,
     clickRate: 12.3,
+    clickToOpenRate: 27.0,
     bounceRate: 2.1,
     complaintRate: 0.05,
+    unsubscribeRate: 0.3,
   };
 
   const mockComparisons = {
     average: {
       openRate: 40.0,
       clickRate: 10.0,
+      clickToOpenRate: 25.0,
       bounceRate: 3.0,
       delivered: 900,
       opens: 360,
       clicks: 90,
       bounces: 27,
       complaints: 1,
+      unsubscribes: 4,
       subscribers: 1000,
     } as IssueMetrics,
   };
 
   describe('Rendering', () => {
-    it('should render all four rate metric cards', () => {
+    it('should render all six rate metric cards', () => {
       render(<KeyMetricsSummary metrics={mockMetrics} />);
 
       expect(screen.getAllByText('Open Rate').length).toBeGreaterThan(0);
       expect(screen.getAllByText('Click Rate').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('Click-to-Open Rate').length).toBeGreaterThan(0);
       expect(screen.getAllByText('Bounce Rate').length).toBeGreaterThan(0);
       expect(screen.getAllByText('Complaint Rate').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('Unsubscribe Rate').length).toBeGreaterThan(0);
     });
 
     it('should not render a standalone Deliveries card', () => {
@@ -47,8 +53,10 @@ describe('KeyMetricsSummary', () => {
 
       expect(screen.getByText('45.5%')).toBeInTheDocument();
       expect(screen.getByText('12.3%')).toBeInTheDocument();
+      expect(screen.getByText('27.0%')).toBeInTheDocument();
       expect(screen.getByText('2.1%')).toBeInTheDocument();
       expect(screen.getByText('0.05%')).toBeInTheDocument();
+      expect(screen.getByText('0.30%')).toBeInTheDocument();
     });
 
     it('should display absolute numbers alongside percentages', () => {
@@ -58,6 +66,7 @@ describe('KeyMetricsSummary', () => {
       expect(screen.getByText('123 clicks')).toBeInTheDocument();
       expect(screen.getByText('21 bounces')).toBeInTheDocument();
       expect(screen.getByText('1 complaints')).toBeInTheDocument();
+      expect(screen.getByText('3 unsubscribes')).toBeInTheDocument();
     });
   });
 
@@ -116,8 +125,10 @@ describe('KeyMetricsSummary', () => {
         deliveries: 0,
         openRate: 0,
         clickRate: 0,
+        clickToOpenRate: 0,
         bounceRate: 0,
         complaintRate: 0,
+        unsubscribeRate: 0,
       };
 
       render(<KeyMetricsSummary metrics={zeroMetrics} />);
@@ -131,8 +142,10 @@ describe('KeyMetricsSummary', () => {
         deliveries: 1000,
         openRate: 45.5,
         clickRate: 12.3,
+        clickToOpenRate: 27.0,
         bounceRate: 2.1,
         complaintRate: 0.15,
+        unsubscribeRate: 0.3,
       };
 
       render(<KeyMetricsSummary metrics={highComplaintMetrics} />);

--- a/dashboard-ui/src/pages/issues/IssueDetailPage.tsx
+++ b/dashboard-ui/src/pages/issues/IssueDetailPage.tsx
@@ -55,6 +55,7 @@ const BounceReasonsChart = lazy(() => import('../../components/issues/BounceReas
 const EngagementTypeIndicator = lazy(() => import('../../components/issues/EngagementTypeIndicator').then(m => ({ default: m.EngagementTypeIndicator })));
 const IssueComparisonCard = lazy(() => import('../../components/issues/IssueComparisonCard').then(m => ({ default: m.IssueComparisonCard })));
 const TrafficSourceChart = lazy(() => import('../../components/issues/TrafficSourceChart').then(m => ({ default: m.TrafficSourceChart })));
+const DeliveryBreakdownChart = lazy(() => import('../../components/issues/DeliveryBreakdownChart').then(m => ({ default: m.DeliveryBreakdownChart })));
 const TimingMetricsChart = lazy(() => import('../../components/issues/TimingMetricsChart').then(m => ({ default: m.TimingMetricsChart })));
 const GeoMap = lazy(() => import('../../components/analytics/GeoMap').then(m => ({ default: m.GeoMap })));
 const LinkSelector = lazy(() => import('../../components/analytics/LinkSelector').then(m => ({ default: m.LinkSelector })));
@@ -820,6 +821,22 @@ export const IssueDetailPage: React.FC = () => {
                     insights={issue.insightsV2}
                     onRefreshInsights={handleRebuildAnalytics}
                     isRefreshing={isAnalyticsRebuilding}
+                  />
+                </AsyncErrorBoundary>
+              </FadeIn>
+            </Suspense>
+          </div>
+        )}
+
+        {/* DeliveryBreakdownChart - Visual delivery overview (delivered vs bounced of total sent) */}
+        {isPublished && issue.stats && (issue.stats.deliveries + issue.stats.bounces) > 0 && (
+          <div className="mb-4 sm:mb-6">
+            <Suspense fallback={<ChartSkeleton />}>
+              <FadeIn variant="slideUp" speed="normal" delay={50}>
+                <AsyncErrorBoundary onRetry={loadIssue}>
+                  <DeliveryBreakdownChart
+                    delivered={issue.stats.deliveries}
+                    bounced={issue.stats.bounces}
                   />
                 </AsyncErrorBoundary>
               </FadeIn>

--- a/dashboard-ui/src/pages/issues/IssueDetailPage.tsx
+++ b/dashboard-ui/src/pages/issues/IssueDetailPage.tsx
@@ -602,8 +602,10 @@ export const IssueDetailPage: React.FC = () => {
       deliveries: issue.stats.deliveries,
       openRate: issue.stats.deliveries > 0 ? (issue.stats.opens / issue.stats.deliveries) * 100 : 0,
       clickRate: issue.stats.deliveries > 0 ? (issue.stats.clicks / issue.stats.deliveries) * 100 : 0,
+      clickToOpenRate: issue.stats.opens > 0 ? (issue.stats.clicks / issue.stats.opens) * 100 : 0,
       bounceRate: issue.stats.deliveries > 0 ? (issue.stats.bounces / issue.stats.deliveries) * 100 : 0,
       complaintRate: complaintRate,
+      unsubscribeRate: issue.stats.deliveries > 0 ? ((issue.stats.unsubscribes ?? 0) / issue.stats.deliveries) * 100 : 0,
     };
   }, [issue?.stats, complaintRate]);
 

--- a/dashboard-ui/vite.config.ts
+++ b/dashboard-ui/vite.config.ts
@@ -44,8 +44,22 @@ export default defineConfig(({ command: _command, mode }) => {
     // this, prismjs's language component files load as separate ESM modules in
     // dev and their bare `Prism` global is undefined, throwing
     // "Prism is not defined" when the issue editor mounts.
+    //
+    // The remaining entries are pre-bundled for dev-server performance.
     optimizeDeps: {
-      include: ['@mdxeditor/editor'],
+      include: [
+        '@mdxeditor/editor',
+        'react',
+        'react-dom',
+        'react-router-dom',
+        '@headlessui/react',
+        '@heroicons/react',
+        'lucide-react',
+        'react-hook-form',
+        'zod',
+        'clsx',
+        'tailwind-merge',
+      ],
     },
     build: {
       outDir: 'dist',
@@ -122,21 +136,6 @@ export default defineConfig(({ command: _command, mode }) => {
       chunkSizeWarningLimit: 1000,
       // Enable gzip compression analysis
       reportCompressedSize: true,
-    },
-    // Performance optimizations
-    optimizeDeps: {
-      include: [
-        'react',
-        'react-dom',
-        'react-router-dom',
-        '@headlessui/react',
-        '@heroicons/react',
-        'lucide-react',
-        'react-hook-form',
-        'zod',
-        'clsx',
-        'tailwind-merge',
-      ],
     },
     // Environment variables
     define: {


### PR DESCRIPTION
## Summary

Enhances the visual takeaway of the issue detail analytics page by turning the delivered/sent/bounced numbers into a pie chart and tightening the surrounding metrics.

### What changed
- **New `DeliveryBreakdownChart`** — a recharts donut showing **Delivered** (green) vs **Bounced** (red) as proportions of the whole, with **total Sent** in the center and a labeled breakdown beside it. Includes hover tooltips, an accessible `role="img"` summary, dark-mode-aware colors, and a graceful empty state. It's lazy-loaded with a `ChartSkeleton` fallback + `AsyncErrorBoundary`, matching the page's other charts, and rendered above the key metrics so the deliverability story leads the page.
- **Removed the redundant `Deliveries` number card** from `KeyMetricsSummary` — that count now lives in the donut. (`deliveries` stays as a prop since the rate cards use it to derive absolute counts.)
- **Added two high-signal newsletter KPIs** to `KeyMetricsSummary`:
  - **Click-to-Open Rate (CTOR)** — isolates content/copy effectiveness from subject-line performance; previously only shown in the comparison card.
  - **Unsubscribe Rate** — a core list-health metric that was only available as a raw count in the Subscriber Activity panel.
  
  Both compute from existing stats and participate in the avg/last/best comparison indicators. The grid expands to six cards that group naturally into engagement (open / click / click-to-open) and deliverability & health (bounce / complaint / unsubscribe).

### Testing
- `tsc --noEmit` ✅
- Unit tests ✅ — new `DeliveryBreakdownChart` suite (rendering, percentages, accessibility, zero/negative edges) and updated `KeyMetricsSummary` suite (six cards, CTOR + unsubscribe values, comparisons, edge cases)
- ESLint on changed files ✅
- Production build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WnqiidvXB7zgF55SJry3vv)_