### PR TITLE
Fix production "Prism is not defined" crash (infinite spinner)

### DIFF
--- a/dashboard-ui/vite.config.ts
+++ b/dashboard-ui/vite.config.ts
@@ -139,6 +139,15 @@ export default defineConfig(({ command: _command, mode }) => {
     },
     // Environment variables
     define: {
+      // prismjs (pulled in transitively via @mdxeditor → @lexical/code) exposes
+      // its core only through `global.Prism`, guarded by `typeof global`. In a
+      // browser `global` is undefined, so the core never sets a global Prism —
+      // yet prismjs's language components reference a bare global `Prism`,
+      // throwing "Prism is not defined" the moment the (eagerly loaded) chunk
+      // evaluates, which takes down the whole app. Aliasing `global` to
+      // `globalThis` lets the core publish `globalThis.Prism`, which the
+      // components then resolve.
+      global: 'globalThis',
       __APP_VERSION__: JSON.stringify(process.env.npm_package_version || '1.0.0'),
       __BUILD_TIME__: JSON.stringify(new Date().toISOString()),
     },


### PR DESCRIPTION
## Problem

The deployed app crashes on load (infinite loading spinner) with `ReferenceError: Prism is not defined` in the console — on every route, including the home/dashboard page.

## Root cause

`prismjs` is pulled in transitively: `@mdxeditor/editor → @lexical/markdown → @lexical/code → prismjs`. In the production bundle:

- prism **core** exposes itself only via `module.exports` and `global.Prism`, and the latter is guarded by `typeof global` — e.g. `"undefined"!=typeof global&&(global.Prism=n)`. In a browser `global` is undefined, so **no global `Prism` is ever set**. (There is no `window.Prism`/`self.Prism` assignment in the bundle.)
- prism **language components** (clike, javascript, …) reference a **bare global `Prism`**: `Prism.languages.clike = {…}`.

The editor stack lands in an **eagerly-loaded** chunk, so that chunk evaluates on initial page load regardless of route. The bare `Prism` reference throws immediately → the chunk fails → the whole app fails to mount → infinite spinner.

This is a production bug. The earlier `optimizeDeps` change fixed only the dev server (Vite pre-bundles `@mdxeditor` there); it does not affect production builds.

## Fix

Alias `global` to `globalThis` via esbuild `define` in `vite.config.ts`. This turns the guard into `"undefined"!=typeof globalThis&&(globalThis.Prism=n)` — always true in a browser — so prism core publishes `globalThis.Prism`, which the language components then resolve. Fixes both dev and prod.

Verified in the rebuilt bundle:
```
"undefined"!=typeof globalThis&&(globalThis.Prism=n)
```

`global: 'globalThis'` is a standard, widely-used Vite setting; no source code declares its own `global` identifier, so there's no clash.

## Testing
- `tsc --noEmit` ✅
- ESLint (full project config) ✅
- Vitest: **947 passed (88 files)** ✅
- Production build succeeds; confirmed the prism chunk now publishes `globalThis.Prism` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WnqiidvXB7zgF55SJry3vv)_