### PR TITLE
Fix domain sender stuck on pending and over-numbered setup instructions

### DIFF
--- a/dashboard-ui/src/components/senders/DomainVerificationGuide.tsx
+++ b/dashboard-ui/src/components/senders/DomainVerificationGuide.tsx
@@ -438,15 +438,12 @@ export const DomainVerificationGuide: React.FC<DomainVerificationGuideProps> = (
         <h4 className="text-sm font-medium text-primary-900 mb-3">
           Setup Instructions
         </h4>
-        <div className="space-y-2 text-sm text-primary-800">
-          {verification?.instructions?.map((instruction, index) => (
-            <div key={index} className="flex items-start space-x-2">
-              <span className="flex-shrink-0 w-5 h-5 bg-primary-200 text-primary-800 rounded-full text-xs flex items-center justify-center font-medium mt-0.5">
-                {index + 1}
-              </span>
-              <p>{instruction}</p>
-            </div>
-          ))}
+        {/* The API returns instructions as a preformatted multi-line block that
+            already includes its own step numbers, bullets, and spacing. Render
+            it as-is rather than numbering every line (which made a short set of
+            steps look like 20+). */}
+        <div className="text-sm text-primary-800 whitespace-pre-wrap font-sans">
+          {verification?.instructions?.join('\n')}
         </div>
       </div>
 

--- a/functions/src/api/controllers/domain.rs
+++ b/functions/src/api/controllers/domain.rs
@@ -306,6 +306,20 @@ async fn handle_get_domain_verification(
         }
     }
 
+    // A domain sender's verification can only ever be satisfied by the domain
+    // identity being verified — SES has no per-address identity for it. Once the
+    // domain is verified, propagate that to its senders so they don't stay stuck
+    // on "pending" while the domain shows "verified". Non-fatal: a failure here
+    // shouldn't block returning the domain status.
+    if current_status == VerificationStatus::Verified {
+        if let Err(e) = mark_domain_senders_verified(&tenant_id, &domain).await {
+            tracing::error!(
+                "Failed to propagate domain verification to senders: {}",
+                e
+            );
+        }
+    }
+
     let response_data = GetDomainVerificationResponse {
         domain: domain.to_string(),
         verification_status: current_status_str.to_string(),
@@ -408,6 +422,72 @@ async fn update_domain_verification_status(
             tracing::error!("Error updating domain verification status: {:?}", e);
             AppError::InternalError("Failed to update domain status".to_string())
         })?;
+
+    Ok(())
+}
+
+/// Marks every pending domain sender for `domain` as verified. Called once the
+/// domain identity is confirmed verified by SES. Idempotent: senders already
+/// verified are skipped so repeated polls don't issue redundant writes.
+async fn mark_domain_senders_verified(tenant_id: &str, domain: &str) -> Result<(), AppError> {
+    let ddb = aws_clients::get_dynamodb_client().await;
+    let table_name = std::env::var("TABLE_NAME")
+        .map_err(|_| AppError::InternalError("TABLE_NAME not set".to_string()))?;
+
+    let result = ddb
+        .query()
+        .table_name(&table_name)
+        .index_name("GSI1")
+        .key_condition_expression("GSI1PK = :gsi1pk")
+        .expression_attribute_values(
+            ":gsi1pk",
+            AttributeValue::S(KeyPatterns::sender_gsi1pk(tenant_id)),
+        )
+        .send()
+        .await
+        .map_err(|e| AppError::AwsError(format!("Failed to query senders: {}", e)))?;
+
+    let senders: Vec<SenderRecord> = result
+        .items()
+        .iter()
+        .filter_map(|item| serde_dynamo::from_item(item.clone()).ok())
+        .collect();
+
+    for sender in senders {
+        let is_pending_domain_sender = matches!(sender.verification_type, VerificationType::Domain)
+            && sender.domain.as_deref() == Some(domain)
+            && sender.verification_status != VerificationStatus::Verified;
+
+        if !is_pending_domain_sender {
+            continue;
+        }
+
+        let now = chrono::Utc::now().to_rfc3339();
+        if let Err(e) = ddb
+            .update_item()
+            .table_name(&table_name)
+            .key("pk", AttributeValue::S(tenant_id.to_string()))
+            .key(
+                "sk",
+                AttributeValue::S(KeyPatterns::sender(&sender.sender_id)),
+            )
+            .update_expression(
+                "SET verificationStatus = :status, verifiedAt = :verifiedAt, updatedAt = :updatedAt",
+            )
+            .expression_attribute_values(":status", AttributeValue::S("verified".to_string()))
+            .expression_attribute_values(":verifiedAt", AttributeValue::S(now.clone()))
+            .expression_attribute_values(":updatedAt", AttributeValue::S(now))
+            .condition_expression("attribute_exists(pk) AND attribute_exists(sk)")
+            .send()
+            .await
+        {
+            tracing::error!(
+                "Failed to mark domain sender {} verified: {}",
+                sender.sender_id,
+                e
+            );
+        }
+    }
 
     Ok(())
 }

--- a/functions/src/api/controllers/senders.rs
+++ b/functions/src/api/controllers/senders.rs
@@ -1337,7 +1337,18 @@ async fn handle_get_sender_status(
     let last_checked = chrono::Utc::now().to_rfc3339();
 
     if sender.verification_status != VerificationStatus::Verified {
-        let ses_status = check_ses_verification_status(&ses_client, &sender.email).await?;
+        // Domain senders are verified via the domain identity in SES, not a
+        // per-address identity. Checking the email would always return
+        // "not found" and leave the sender stuck on pending, so resolve the
+        // correct identity for the sender's verification type.
+        let ses_identity = match sender.verification_type {
+            VerificationType::Domain => sender
+                .domain
+                .clone()
+                .unwrap_or_else(|| sender.email.clone()),
+            VerificationType::Mailbox => sender.email.clone(),
+        };
+        let ses_status = check_ses_verification_status(&ses_client, &ses_identity).await?;
 
         if let Some(new_status) = map_ses_status_to_internal(&ses_status.verification_status) {
             if new_status != sender.verification_status {


### PR DESCRIPTION
Two domain-verification UI bugs:

1. Domain senders stayed "pending" even after the domain showed "verified".
   SES only tracks the domain identity, but the sender status check queried
   SES with the sender's email address (which isn't a registered identity),
   so it always came back "not found" and never updated. Now:
   - When GET /senders/domain-verification/{domain} confirms the domain is
     verified, propagate that to every pending domain sender under it.
   - GET /senders/{id}/status resolves the SES identity by verification type
     (domain identity for domain senders, email for mailbox senders).

2. The Setup Instructions help box numbered every line of the instructions
   block, including blank lines, bullets, and the API's own "1."-"6." steps,
   making a handful of steps look like 20+. Render the preformatted block
   as-is instead of adding a badge per line.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PQBgDV3DNr2p3ToRuF7TfU