### PR TITLE
feat: A/B testing Phase 3 — send-time dimension

### DIFF
--- a/__tests__/evaluate-ab-winner.test.mjs
+++ b/__tests__/evaluate-ab-winner.test.mjs
@@ -259,6 +259,43 @@ describe('evaluate-ab-winner', () => {
     expect(updateCalls.find((v) => v[':v'] !== undefined)).toBeUndefined();
   });
 
+  it('send-time: keeps base subject, records winning send time, applies winning time', async () => {
+    const winnerSendAt = new Date(Date.now() + 3600 * 1000).toISOString();
+    wireDdb({
+      abTest: abTestConfig({
+        dimension: 'sendTime',
+        variants: [
+          { variantId: 'a', sendAt: new Date(Date.now() + 1800 * 1000).toISOString() },
+          { variantId: 'b', sendAt: winnerSendAt }
+        ]
+      }),
+      // b's send time clearly outperforms a.
+      aStats: { opens: 200, clicks: 10, deliveries: 1000 },
+      bStats: { opens: 400, clicks: 20, deliveries: 1000 }
+    });
+
+    const event = {
+      detail: {
+        ...baseEvent.detail,
+        sendPayload: { ...baseEvent.detail.sendPayload, subject: 'Original subject' }
+      }
+    };
+
+    const result = await handler(event);
+    expect(result).toBe(true);
+
+    const persisted = getUpdateAbTest();
+    expect(persisted.status).toBe('sent');
+    expect(persisted.winnerVariantId).toBe('b');
+    expect(persisted.evaluation.winningSendAt).toBe(winnerSendAt);
+
+    const sent = getSentEmail();
+    // Send-time winner keeps the shared subject (no per-variant subject) ...
+    expect(sent.detail.subject).toBe('Original subject');
+    // ... and targets the winning send time (still in the future here).
+    expect(sent.detail.sendAt).toBe(winnerSendAt);
+  });
+
   it('guard: status already sent => no Send Email v2 and no DDB write', async () => {
     wireDdb({
       abTest: abTestConfig({ status: 'sent' }),

--- a/__tests__/send-email-v2.test.mjs
+++ b/__tests__/send-email-v2.test.mjs
@@ -3,6 +3,7 @@ import { jest } from '@jest/globals';
 // Mock instances
 const sesInstance = { send: jest.fn() };
 const schedulerInstance = { send: jest.fn() };
+const eventBridgeInstance = { send: jest.fn() };
 const ddbInstance = { send: jest.fn() };
 
 // Mock AWS SDK
@@ -14,6 +15,11 @@ jest.unstable_mockModule('@aws-sdk/client-sesv2', () => ({
 jest.unstable_mockModule('@aws-sdk/client-scheduler', () => ({
   SchedulerClient: jest.fn(() => schedulerInstance),
   CreateScheduleCommand: jest.fn((params) => ({ __type: 'CreateSchedule', ...params }))
+}));
+
+jest.unstable_mockModule('@aws-sdk/client-eventbridge', () => ({
+  EventBridgeClient: jest.fn(() => eventBridgeInstance),
+  PutEventsCommand: jest.fn((params) => ({ __type: 'PutEvents', ...params }))
 }));
 
 jest.unstable_mockModule('@aws-sdk/client-dynamodb', () => ({
@@ -546,6 +552,89 @@ describe('send-email-v2', () => {
       expect(detail.issueNumber).toBe('42');
       expect(detail.sendPayload.html).toBe('<p>Hello __EMAIL__</p>');
       expect(detail.sendPayload.to.list).toBe('my-list');
+    });
+  });
+
+  describe('A/B send-time testing', () => {
+    const makeSubscribers = (count) =>
+      Array.from({ length: count }, (_, i) => ({ email: `user${i}@example.com`, lastIssueSent: null }));
+    const futureIso = (h) => new Date(Date.now() + h * 3600 * 1000).toISOString();
+    const sendTimeDetail = (overrides = {}) => ({
+      subject: 'Same subject for all',
+      html: '<p>Hello __EMAIL__</p>',
+      to: { list: 'my-list' },
+      from: 'sender@example.com',
+      tenantId: 'tenant-123',
+      referenceNumber: 'tenant-123_42',
+      replacements: { emailAddress: '__EMAIL__' },
+      abTest: {
+        dimension: 'sendTime',
+        testFraction: 0.5,
+        evaluateAfterMinutes: 120,
+        variants: [
+          { variantId: 'a', sendAt: futureIso(2) },
+          { variantId: 'b', sendAt: futureIso(6) }
+        ]
+      },
+      ...overrides
+    });
+
+    beforeEach(() => {
+      ddbInstance.send.mockResolvedValueOnce({
+        Items: [{
+          unmarshalled: { senderId: 'sender-123', email: 'sender@example.com', verificationStatus: 'verified', isDefault: false }
+        }]
+      });
+      ddbInstance.send.mockResolvedValue({});
+      sesInstance.send.mockResolvedValue({ MessageId: 'msg-123' });
+      schedulerInstance.send.mockResolvedValue({});
+      eventBridgeInstance.send.mockResolvedValue({});
+    });
+
+    test('initial publish fans out one Send Email v2 per variant and sends nothing inline', async () => {
+      const result = await handler({ detail: sendTimeDetail() });
+
+      expect(result.scheduled).toBe(true);
+      // Nothing is sent in this invocation; subscribers are not even retrieved.
+      expect(sesInstance.send).not.toHaveBeenCalled();
+      expect(listSubscribers).not.toHaveBeenCalled();
+
+      // One per-variant Send Email v2 event per variant, each with a variantFilter.
+      expect(eventBridgeInstance.send).toHaveBeenCalledTimes(2);
+      const filters = eventBridgeInstance.send.mock.calls.map(([cmd]) => {
+        const entry = cmd.Entries[0];
+        expect(entry.DetailType).toBe('Send Email v2');
+        const detail = JSON.parse(entry.Detail);
+        expect(detail.abTest.dimension).toBe('sendTime');
+        expect(detail.sendAt).toBeDefined();
+        return detail.variantFilter;
+      });
+      expect(new Set(filters)).toEqual(new Set(['a', 'b']));
+
+      // Evaluation scheduled once, after the latest candidate send time.
+      expect(schedulerInstance.send).toHaveBeenCalledTimes(1);
+      const entry = JSON.parse(schedulerInstance.send.mock.calls[0][0].Target.Input).Entries[0];
+      expect(entry.DetailType).toBe('Evaluate AB Test');
+    });
+
+    test('per-variant fire (variantFilter) sends only that variant bucket and schedules nothing', async () => {
+      listSubscribers.mockResolvedValue({ subscribers: makeSubscribers(40), lastEvaluatedKey: undefined });
+
+      const result = await handler({ detail: sendTimeDetail({ variantFilter: 'a' }) });
+
+      // Only variant a's slice of the 50% sample is sent.
+      expect(result.recipients).toBeGreaterThan(0);
+      expect(result.recipients).toBeLessThan(20);
+      expect(sesInstance.send).toHaveBeenCalledTimes(result.recipients);
+      for (const [cmd] of sesInstance.send.mock.calls) {
+        const variantTag = (cmd.EmailTags ?? []).find((t) => t.Name === 'variant');
+        expect(variantTag?.Value).toBe('a');
+        // Send-time variants share the base subject.
+        expect(cmd.Content.Simple.Subject.Data).toBe('Same subject for all');
+      }
+      // No fan-out and no duplicate evaluation scheduling on a per-variant fire.
+      expect(eventBridgeInstance.send).not.toHaveBeenCalled();
+      expect(schedulerInstance.send).not.toHaveBeenCalled();
     });
   });
 });

--- a/functions/evaluate-ab-winner.mjs
+++ b/functions/evaluate-ab-winner.mjs
@@ -61,13 +61,23 @@ export const handler = async (event) => {
 
       // Inconclusive => fall back to the control (variant "a").
       const winningVariantId = winnerVariantId ?? 'a';
-      const winningSubject = resolveSubject(abTest, winningVariantId);
+      const isSendTime = abTest.dimension === 'sendTime';
+      const winningVariant = (abTest.variants || []).find((v) => v.variantId === winningVariantId);
+
+      // Subject-line tests send the winning subject. Send-time tests keep the
+      // shared subject and deliver the hold-out at the winning send time (or
+      // immediately if that time has already passed).
+      const winningSubject = isSendTime ? sendPayload?.subject : resolveSubject(abTest, winningVariantId);
+      const winningSendAt = isSendTime ? winningVariant?.sendAt : undefined;
+      if (isSendTime && winningSendAt) {
+        evaluation.winningSendAt = winningSendAt;
+      }
 
       // Enqueue the winner BEFORE marking the test final. Together with the claim
       // above this gives: exactly one invocation ever sends (no duplicate
       // emails), and if the publish fails the claim is released so a redelivery
       // retries instead of the test being stuck in a final state.
-      await sendWinner(sendPayload, winningSubject);
+      await sendWinner(sendPayload, winningSubject, winningSendAt);
 
       const updatedAbTest = {
         ...abTest,
@@ -261,16 +271,21 @@ const resolveSubject = (abTest, variantId) => {
  * @param {Object} sendPayload - Everything needed to send except the subject.
  * @param {string} winningSubject - The chosen subject line.
  */
-const sendWinner = async (sendPayload, winningSubject) => {
+const sendWinner = async (sendPayload, winningSubject, winningSendAt) => {
   const { abTest: _abTest, variants: _variants, ...rest } = sendPayload || {};
+  const detail = { ...rest, subject: winningSubject };
+
+  // Send-time winner: deliver at the winning time when it is still in the
+  // future; otherwise send immediately (send-email-v2 schedules future sends).
+  if (winningSendAt && new Date(winningSendAt).getTime() > Date.now()) {
+    detail.sendAt = winningSendAt;
+  }
+
   await eventBridge.send(new PutEventsCommand({
     Entries: [{
       Source: 'newsletter-service',
       DetailType: 'Send Email v2',
-      Detail: JSON.stringify({
-        ...rest,
-        subject: winningSubject
-      })
+      Detail: JSON.stringify(detail)
     }]
   }));
 };

--- a/functions/publish-issue.mjs
+++ b/functions/publish-issue.mjs
@@ -39,7 +39,7 @@ export const handler = async (state) => {
         sendAt: state.sendAtDate,
         referenceNumber: `${tenant.pk}_${state.data.metadata.number}`,
         tenantId: state.tenantId,
-        abTest: abTest?.dimension === 'subject' ? abTest : undefined
+        abTest: (abTest?.dimension === 'subject' || abTest?.dimension === 'sendTime') ? abTest : undefined
       });
 
       await publishIssueEvent(

--- a/functions/send-email-v2.mjs
+++ b/functions/send-email-v2.mjs
@@ -1,5 +1,6 @@
 import { SESv2Client, SendEmailCommand } from "@aws-sdk/client-sesv2";
 import { SchedulerClient, CreateScheduleCommand } from "@aws-sdk/client-scheduler";
+import { EventBridgeClient, PutEventsCommand } from "@aws-sdk/client-eventbridge";
 import { DynamoDBClient, QueryCommand, UpdateItemCommand } from "@aws-sdk/client-dynamodb";
 import { marshall, unmarshall } from "@aws-sdk/util-dynamodb";
 import { encrypt, sendWithRetry } from './utils/helpers.mjs';
@@ -14,6 +15,7 @@ const KEY_PATTERNS = {
 
 const ses = new SESv2Client();
 const scheduler = new SchedulerClient();
+const eventBridge = new EventBridgeClient();
 const ddb = new DynamoDBClient();
 
 const tpsLimit = parseInt(process.env.SES_TPS_LIMIT || "14", 10);
@@ -391,7 +393,7 @@ const updateSubscriberTrackingPhase = async (tenantId, sentRecipients, issueIden
  * @param {string} [params.from] - Optional sender email
  * @param {Object} params.to - Recipient config ({ list })
  */
-const scheduleAbEvaluation = async ({ tenantId, referenceNumber, abTest, html, replacements, from, to }) => {
+const scheduleAbEvaluation = async ({ tenantId, referenceNumber, abTest, subject, html, replacements, from, to }) => {
   if (!referenceNumber) {
     console.warn('[A/B] Skipping evaluation schedule - missing referenceNumber');
     return;
@@ -399,7 +401,15 @@ const scheduleAbEvaluation = async ({ tenantId, referenceNumber, abTest, html, r
 
   const evaluateAfterMinutes = typeof abTest.evaluateAfterMinutes === 'number' ? abTest.evaluateAfterMinutes : 240;
   const issueNumber = referenceNumber.slice(referenceNumber.lastIndexOf('_') + 1);
-  const evalAt = new Date(Date.now() + evaluateAfterMinutes * 60 * 1000);
+  // For send-time tests the variants are delivered at different times, so the
+  // evaluation window starts after the LAST candidate send time, not now.
+  const candidateTimes = abTest.dimension === 'sendTime'
+    ? (abTest.variants || [])
+      .map(variant => new Date(variant.sendAt).getTime())
+      .filter(time => !Number.isNaN(time))
+    : [];
+  const baseMs = Math.max(Date.now(), ...candidateTimes);
+  const evalAt = new Date(baseMs + evaluateAfterMinutes * 60 * 1000);
   const scheduleName = `AB-EVAL-${referenceNumber}-${Date.now()}`.replace(/[^0-9a-zA-Z-_.]/g, '-').slice(0, 64);
 
   const detail = {
@@ -407,6 +417,7 @@ const scheduleAbEvaluation = async ({ tenantId, referenceNumber, abTest, html, r
     issueNumber,
     referenceNumber,
     sendPayload: {
+      subject,
       html,
       to: { list: to.list },
       tenantId,
@@ -439,6 +450,51 @@ const scheduleAbEvaluation = async ({ tenantId, referenceNumber, abTest, html, r
   }, 'Schedule A/B winner evaluation');
 
   console.log(`[A/B] Scheduled winner evaluation at ${evalAt.toISOString()} (${evaluateAfterMinutes}m) for ${referenceNumber}`);
+};
+
+/**
+ * Fan out a send-time A/B test: emit one `Send Email v2` event per variant, each
+ * carrying a `variantFilter` and the variant's `sendAt`. The existing future-send
+ * scheduling defers each event to its send time; when it fires, the handler sends
+ * only that variant's bucket of the test sample. The subject/content is identical
+ * across variants — only the send time differs.
+ * @param {Object} params
+ * @param {Object} params.data - The original event detail (for referenceNumber).
+ * @param {string} params.subject - The shared subject line.
+ * @param {string} params.html - Rendered email HTML.
+ * @param {Object} params.to - Recipient config ({ list }).
+ * @param {string} params.tenantId
+ * @param {Object} [params.replacements]
+ * @param {string} [params.from]
+ * @param {Object} params.abTest - Normalized A/B config (dimension 'sendTime').
+ */
+const fanOutSendTimeVariants = async ({ data, subject, html, to, tenantId, replacements, from, abTest }) => {
+  for (const variant of abTest.variants) {
+    const detail = {
+      subject,
+      html,
+      to: { list: to.list },
+      tenantId,
+      referenceNumber: data.referenceNumber,
+      ...replacements && { replacements },
+      ...from && { from },
+      abTest,
+      variantFilter: variant.variantId,
+      ...variant.sendAt && { sendAt: variant.sendAt }
+    };
+
+    await sendWithRetry(async () => {
+      return await eventBridge.send(new PutEventsCommand({
+        Entries: [{
+          Source: 'newsletter-service',
+          DetailType: 'Send Email v2',
+          Detail: JSON.stringify(detail)
+        }]
+      }));
+    }, `Fan out send-time variant ${variant.variantId}`);
+
+    console.log(`[A/B] Fanned out send-time variant ${variant.variantId} at ${variant.sendAt || 'now'} for ${data.referenceNumber}`);
+  }
 };
 
 export const handler = async (event) => {
@@ -506,6 +562,24 @@ export const handler = async (event) => {
       }
     }
 
+    // Recognize a managed A/B test (subject-line or send-time dimension).
+    const abTest = (data.abTest?.dimension === 'subject' || data.abTest?.dimension === 'sendTime')
+      ? data.abTest
+      : null;
+    const variantFilter = data.variantFilter ?? null;
+
+    // Initial send-time test: don't send anything now. Defer each variant to its
+    // own send time via per-variant events, and schedule the winner evaluation.
+    // Each per-variant event re-enters this handler with `variantFilter` set.
+    if (abTest?.dimension === 'sendTime' && !variantFilter && to.list) {
+      await executePhase('A/B Send-Time Fan-Out', async () => {
+        await fanOutSendTimeVariants({ data, subject, html, to, tenantId, replacements, from, abTest });
+        await scheduleAbEvaluation({ tenantId, referenceNumber: data.referenceNumber, abTest, subject, html, replacements, from, to });
+      });
+      console.log('[EXECUTION COMPLETE] Send-time A/B test fanned out to per-variant sends');
+      return { sent: false, scheduled: true, abTest: 'sendTime', variants: abTest.variants.length };
+    }
+
     let subscribers = [];
     if (to.email) {
       const subscriber = await getSubscriberByEmail(tenantId, to.email);
@@ -537,32 +611,42 @@ export const handler = async (event) => {
     }
 
     // Phase 3: Email Sending
-    // For a managed A/B test (data.abTest), only a deterministic hold-out
-    // *sample* receives the variants now; the winner is sent to the remainder
-    // later by the evaluate-ab-winner lambda. A legacy `data.variants` payload
-    // (no hold-out) splits the whole list. Otherwise a single version is sent.
-    const abTest = data.abTest?.dimension === 'subject' ? data.abTest : null;
+    // For a managed A/B test, only a deterministic hold-out *sample* receives the
+    // variants; the winner is sent to the remainder later by evaluate-ab-winner.
+    // The sample + variant split are derived from the FULL recipient list (not
+    // the idempotency-filtered one) so the partition is identical across a
+    // send-time test's staggered per-variant sends; already-sent recipients are
+    // then filtered out per bucket. A legacy `data.variants` payload (no
+    // hold-out) splits the eligible list directly. Otherwise a single send.
     const variants = abTest?.variants ?? (Array.isArray(data.variants) ? data.variants : null);
+    const allEmails = subscribers.map(subscriber => subscriber.email);
+    const eligibleSet = new Set(emailAddresses);
     const { sentCount, sentRecipients } = await executePhase('Email Sending', async () => {
       if (variants?.length && to.list) {
         const subjectByVariant = Object.fromEntries(
           variants.map(variant => [variant.variantId, variant.subject])
         );
 
-        let testRecipients = emailAddresses;
+        let buckets;
         if (abTest) {
           const testFraction = typeof abTest.testFraction === 'number' ? abTest.testFraction : 0.2;
-          const { sample } = selectHoldoutSample(emailAddresses, data.referenceNumber, testFraction);
-          testRecipients = sample;
-          console.log(`[A/B] Hold-out test send - sample: ${sample.length}/${emailAddresses.length}, fraction: ${testFraction}`);
+          const { sample } = selectHoldoutSample(allEmails, data.referenceNumber, testFraction);
+          buckets = splitRecipients(sample, data.referenceNumber);
+          console.log(`[A/B] Test sample: ${sample.length}/${allEmails.length} (fraction ${testFraction})${variantFilter ? `, variant ${variantFilter}` : ''}`);
+        } else {
+          buckets = splitRecipients(emailAddresses, data.referenceNumber);
         }
 
-        const buckets = splitRecipients(testRecipients, data.referenceNumber);
+        // A send-time per-variant fire targets only its own bucket.
+        const variantIds = variantFilter ? [variantFilter] : Object.keys(buckets);
 
         let total = 0;
         const allRecipients = [];
-        for (const variantId of Object.keys(buckets)) {
-          const bucketRecipients = buckets[variantId];
+        for (const variantId of variantIds) {
+          let bucketRecipients = buckets[variantId] || [];
+          if (abTest) {
+            bucketRecipients = bucketRecipients.filter(email => eligibleSet.has(email));
+          }
           if (!bucketRecipients.length) {
             continue;
           }
@@ -602,10 +686,12 @@ export const handler = async (event) => {
       });
     }
 
-    // Phase 5: Schedule A/B winner evaluation (managed A/B tests only).
+    // Phase 5: Schedule A/B winner evaluation (subject-line tests only here).
     // The test sample has now been sent; schedule the evaluation that picks a
-    // winner and sends it to the hold-out remainder.
-    if (abTest && to.list) {
+    // winner and sends it to the hold-out remainder. Send-time tests schedule
+    // their evaluation up front during fan-out, and their per-variant fires
+    // (variantFilter set) must not schedule a duplicate.
+    if (abTest && to.list && !variantFilter) {
       await executePhase('Schedule A/B Evaluation', async () => {
         return await scheduleAbEvaluation({
           tenantId,

--- a/functions/src/api/controllers/issues.rs
+++ b/functions/src/api/controllers/issues.rs
@@ -2806,13 +2806,6 @@ mod tests {
     }
 
     #[test]
-    fn test_ab_test_rejects_non_subject_dimension() {
-        let mut ab = valid_ab_test();
-        ab["dimension"] = serde_json::json!("sendTime");
-        assert!(validate_and_normalize_ab_test(&ab).is_err());
-    }
-
-    #[test]
     fn test_ab_test_requires_exactly_two_variants() {
         let mut ab = valid_ab_test();
         ab["variants"] = serde_json::json!([{ "variantId": "a", "subject": "only one" }]);

--- a/functions/src/api/controllers/issues.rs
+++ b/functions/src/api/controllers/issues.rs
@@ -911,6 +911,7 @@ fn validate_list_params(query: &ListIssuesQuery) -> Result<(), AppError> {
 }
 
 const AB_DIMENSION_SUBJECT: &str = "subject";
+const AB_DIMENSION_SENDTIME: &str = "sendTime";
 
 /// Extracts the optional `abTest` object from the raw request body. Kept out of
 /// the typed request structs so the (many) existing call sites stay untouched;
@@ -943,9 +944,9 @@ fn validate_and_normalize_ab_test(
         .get("dimension")
         .and_then(|v| v.as_str())
         .ok_or_else(|| AppError::BadRequest("abTest.dimension is required".to_string()))?;
-    if dimension != AB_DIMENSION_SUBJECT {
+    if dimension != AB_DIMENSION_SUBJECT && dimension != AB_DIMENSION_SENDTIME {
         return Err(AppError::BadRequest(
-            "abTest.dimension must be \"subject\"".to_string(),
+            "abTest.dimension must be \"subject\" or \"sendTime\"".to_string(),
         ));
     }
 
@@ -961,6 +962,7 @@ fn validate_and_normalize_ab_test(
 
     let mut normalized_variants = Vec::with_capacity(2);
     let mut seen_ids: Vec<String> = Vec::new();
+    let mut seen_send_at: Vec<i64> = Vec::new();
     for variant in variants {
         let variant_id = variant
             .get("variantId")
@@ -980,27 +982,61 @@ fn validate_and_normalize_ab_test(
         }
         seen_ids.push(variant_id.to_string());
 
-        let subject = variant
-            .get("subject")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| {
-                AppError::BadRequest("each abTest variant requires a subject".to_string())
-            })?;
-        if subject.trim().is_empty() {
-            return Err(AppError::BadRequest(
-                "abTest variant subject cannot be empty".to_string(),
-            ));
-        }
-        if subject.len() > 200 {
-            return Err(AppError::BadRequest(
-                "abTest variant subject must not exceed 200 characters".to_string(),
-            ));
-        }
+        if dimension == AB_DIMENSION_SUBJECT {
+            let subject = variant
+                .get("subject")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| {
+                    AppError::BadRequest("each abTest variant requires a subject".to_string())
+                })?;
+            if subject.trim().is_empty() {
+                return Err(AppError::BadRequest(
+                    "abTest variant subject cannot be empty".to_string(),
+                ));
+            }
+            if subject.len() > 200 {
+                return Err(AppError::BadRequest(
+                    "abTest variant subject must not exceed 200 characters".to_string(),
+                ));
+            }
 
-        normalized_variants.push(serde_json::json!({
-            "variantId": variant_id,
-            "subject": subject,
-        }));
+            normalized_variants.push(serde_json::json!({
+                "variantId": variant_id,
+                "subject": subject,
+            }));
+        } else {
+            // send-time dimension: each variant is delivered at its own sendAt.
+            let send_at = variant
+                .get("sendAt")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| {
+                    AppError::BadRequest(
+                        "each abTest variant requires a sendAt for send-time tests".to_string(),
+                    )
+                })?;
+            let parsed = chrono::DateTime::parse_from_rfc3339(send_at).map_err(|_| {
+                AppError::BadRequest(
+                    "abTest variant sendAt must be an RFC3339 timestamp".to_string(),
+                )
+            })?;
+            if parsed.with_timezone(&chrono::Utc) <= chrono::Utc::now() {
+                return Err(AppError::BadRequest(
+                    "abTest variant sendAt must be in the future".to_string(),
+                ));
+            }
+            let instant = parsed.timestamp_millis();
+            if seen_send_at.contains(&instant) {
+                return Err(AppError::BadRequest(
+                    "abTest variant sendAt values must be distinct".to_string(),
+                ));
+            }
+            seen_send_at.push(instant);
+
+            normalized_variants.push(serde_json::json!({
+                "variantId": variant_id,
+                "sendAt": parsed.to_rfc3339(),
+            }));
+        }
     }
     if !seen_ids.iter().any(|id| id == "a") || !seen_ids.iter().any(|id| id == "b") {
         return Err(AppError::BadRequest(
@@ -1085,7 +1121,7 @@ fn validate_and_normalize_ab_test(
 
     Ok(serde_json::json!({
         "testId": ulid::Ulid::new().to_string(),
-        "dimension": AB_DIMENSION_SUBJECT,
+        "dimension": dimension,
         "variants": normalized_variants,
         "winMetric": win_metric,
         "confidence": confidence,
@@ -2809,6 +2845,65 @@ mod tests {
         let mut bad_fraction = valid_ab_test();
         bad_fraction["testFraction"] = serde_json::json!(0.8);
         assert!(validate_and_normalize_ab_test(&bad_fraction).is_err());
+    }
+
+    fn future_rfc3339(hours: i64) -> String {
+        (chrono::Utc::now() + chrono::Duration::hours(hours)).to_rfc3339()
+    }
+
+    fn valid_send_time_ab_test() -> serde_json::Value {
+        serde_json::json!({
+            "dimension": "sendTime",
+            "variants": [
+                { "variantId": "a", "sendAt": future_rfc3339(2) },
+                { "variantId": "b", "sendAt": future_rfc3339(6) }
+            ]
+        })
+    }
+
+    #[test]
+    fn test_ab_test_send_time_normalizes() {
+        let normalized = validate_and_normalize_ab_test(&valid_send_time_ab_test()).unwrap();
+        assert_eq!(normalized["dimension"], "sendTime");
+        assert_eq!(normalized["status"], "pending");
+        let variants = normalized["variants"].as_array().unwrap();
+        assert_eq!(variants.len(), 2);
+        // Each variant carries a normalized sendAt and no subject.
+        assert!(variants[0]["sendAt"].as_str().is_some());
+        assert!(variants[0].get("subject").is_none());
+    }
+
+    #[test]
+    fn test_ab_test_send_time_rejects_past_sendat() {
+        let mut ab = valid_send_time_ab_test();
+        ab["variants"][1]["sendAt"] = serde_json::json!(future_rfc3339(-2));
+        assert!(validate_and_normalize_ab_test(&ab).is_err());
+    }
+
+    #[test]
+    fn test_ab_test_send_time_rejects_missing_and_duplicate_sendat() {
+        // Missing sendAt.
+        let mut missing = valid_send_time_ab_test();
+        missing["variants"][0] = serde_json::json!({ "variantId": "a" });
+        assert!(validate_and_normalize_ab_test(&missing).is_err());
+
+        // Identical send times for both variants.
+        let when = future_rfc3339(3);
+        let dup = serde_json::json!({
+            "dimension": "sendTime",
+            "variants": [
+                { "variantId": "a", "sendAt": when },
+                { "variantId": "b", "sendAt": when }
+            ]
+        });
+        assert!(validate_and_normalize_ab_test(&dup).is_err());
+    }
+
+    #[test]
+    fn test_ab_test_rejects_unknown_dimension() {
+        let mut ab = valid_ab_test();
+        ab["dimension"] = serde_json::json!("fromName");
+        assert!(validate_and_normalize_ab_test(&ab).is_err());
     }
 
     #[test]

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4154,7 +4154,6 @@ components:
       type: object
       required:
         - variantId
-        - subject
       properties:
         variantId:
           type: string
@@ -4163,7 +4162,11 @@ components:
         subject:
           type: string
           maxLength: 200
-          description: Subject line used for this variant
+          description: Subject line used for this variant (used for "subject" dimension tests)
+        sendAt:
+          type: string
+          format: date-time
+          description: Absolute send time for this variant (used for "sendTime" dimension tests only)
 
     AbTest:
       type: object
@@ -4177,8 +4180,11 @@ components:
           description: Server-generated test identifier (ULID), assigned on create
         dimension:
           type: string
-          enum: [subject]
-          description: The dimension being tested. Phase 1 supports "subject" only.
+          enum: [subject, sendTime]
+          description: >-
+            The dimension being tested. "subject" runs a subject-line test where
+            variants differ by subject line; "sendTime" runs a send-time test where
+            all variants share the same subject and content but differ by send time.
         variants:
           type: array
           minItems: 2
@@ -4256,7 +4262,10 @@ components:
               type: string
               enum: [a, b]
               nullable: true
-              description: The winning variant ("a" or "b"), or null when inconclusive
+              description: >-
+                The winning variant ("a" or "b"), or null when inconclusive. For
+                send-time tests, the winning variant represents the better-performing
+                send time.
             decidedAt:
               type: string
               format: date-time

--- a/template.yaml
+++ b/template.yaml
@@ -2124,6 +2124,9 @@ Resources:
               Action: iam:PassRole
               Resource: !GetAtt SchedulerExecutionRole.Arn
             - Effect: Allow
+              Action: events:PutEvents
+              Resource: !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:event-bus/default
+            - Effect: Allow
               Action:
                 - dynamodb:UpdateItem
                 - dynamodb:Query


### PR DESCRIPTION
Implements **Phase 3** of the A/B testing epic (#291): adds `sendTime` as a test dimension. Closes #294.

Builds on Phases 1 & 2 (merged in #296). Variants now differ by **send time** instead of subject — same subject/content, delivered at different times — and the winning time is applied to the hold-out.

## How it works
1. **Initial publish** (`send-email-v2`): for a send-time test, the handler does **not** send inline. It fans out one `Send Email v2` event per variant, each carrying a `variantFilter` and the variant's `sendAt`, reusing the existing future-send scheduling to defer each to its time. The winner evaluation is scheduled after the **last** candidate send time + `evaluateAfterMinutes`.
2. **Per-variant fire**: when an event returns with `variantFilter` set, only that variant's bucket of the test sample is sent (variant-tagged, shared subject).
3. **Evaluation** (`evaluate-ab-winner`): the same two-proportion z-test picks the better-performing time; for send-time it keeps the shared subject and delivers the hold-out **at the winning time** (or immediately if that time has already passed), recording `winningSendAt` in the evaluation.

## Changes
- **`functions/src/api/controllers/issues.rs`** — validate/normalize the `sendTime` dimension: each variant requires a **future, distinct** RFC3339 `sendAt` (instead of `subject`); the normalized `dimension` is preserved (no longer hard-coded to `subject`).
- **`functions/send-email-v2.mjs`** — send-time fan-out + per-variant `variantFilter` send; evaluation scheduled after the last candidate time. **Correctness fix:** the sample/split is now derived from the *full* recipient list (then filtered by eligibility) so the staggered per-variant sends partition identically (re-deriving from the post-idempotency list would have produced mismatched buckets).
- **`functions/evaluate-ab-winner.mjs`** — dimension-aware winner: send-time keeps the shared subject and targets the winning `sendAt`.
- **`functions/publish-issue.mjs`** — forward `abTest` for the send-time dimension.
- **`template.yaml`** — grant `SendEmailV2Function` `events:PutEvents` (fan-out).
- **`openapi.yaml`** — document the `sendTime` dimension and per-variant `sendAt`.

## Testing
- Full JS suite: **889 passing** (new tests: send-time fan-out, per-variant send, send-time winner path).
- Rust: A/B validation tests incl. send-time (future/distinct/missing `sendAt`, unknown dimension) + full issues/router suites pass; `rustfmt` clean; `clippy` clean (only the pre-existing `start_issue_schedule` arg-count warning).
- ESLint clean; `template.yaml` and `openapi.yaml` validated.

## Notes
- Orchestration continues to use the repo's EventBridge Scheduler deferred-work idiom (consistent with Phases 1–2) rather than a Step Functions `Wait`, since sends are async and the winner send needs the rendered HTML at evaluation time.
- Remaining epic work: Phase 4 — dashboard UI & analytics (#295).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KEvcSBGrCS6wBQBW7ALRax)_