### PR TITLE
feat: surface A/B test results in the monthly report

### DIFF
--- a/functions/__tests__/build-monthly-report-data.test.mjs
+++ b/functions/__tests__/build-monthly-report-data.test.mjs
@@ -102,6 +102,58 @@ describe('build-monthly-report-data', () => {
     expect(reportData.bestIssue.byClicks.issueNumber).toBe(43);
   });
 
+  test('includes A/B test summaries for issues that ran a test', async () => {
+    const abItems = [
+      {
+        pk: 'tenant123#43', sk: 'stats', subject: 'Second May issue',
+        publishedAt: '2026-05-20T10:00:00.000Z', deliveries: 1100, sends: 1110,
+        opens: 700, bounces: 4, unsubscribes: 1, subscribers: 1100, clicks_total: 200,
+        analytics: {
+          abTest: {
+            dimension: 'subject',
+            winMetric: 'openRate',
+            status: 'sent',
+            winnerVariantId: 'b',
+            variants: [
+              { variantId: 'a', subject: 'Control subject', opens: 300, clicks: 50, deliveries: 550, openRate: 54.5, clickRate: 9.1 },
+              { variantId: 'b', subject: 'Challenger subject', opens: 400, clicks: 70, deliveries: 550, openRate: 72.7, clickRate: 12.7 }
+            ],
+            evaluation: { significant: true, confidence: 0.95 }
+          }
+        }
+      }
+    ];
+    mockSend = jest.fn(async (command) => {
+      const input = command.input;
+      if (input.IndexName === 'GSI1') {
+        return { Items: abItems.map((i) => marshall(i)) };
+      }
+      const pk = input.ExpressionAttributeValues[':pk'].S;
+      return { Items: (linksByIssue[pk] || []).map((l) => marshall(l)) };
+    });
+    DynamoDBClient.prototype.send = mockSend;
+
+    const { reportData } = await handler(baseInput);
+
+    expect(reportData.abTests).toHaveLength(1);
+    const test = reportData.abTests[0];
+    expect(test.issueNumber).toBe('43');
+    expect(test.dimension).toBe('subject');
+    expect(test.winnerVariantId).toBe('b');
+    expect(test.significant).toBe(true);
+    expect(test.confidence).toBe(0.95);
+    // lift = winner open rate (72.7) - control open rate (54.5)
+    expect(test.lift).toBeCloseTo(18.2, 1);
+    const winner = test.variants.find((v) => v.variantId === 'b');
+    expect(winner.isWinner).toBe(true);
+    expect(winner.label).toBe('Challenger subject');
+  });
+
+  test('omits abTests for issues without a test', async () => {
+    const { reportData } = await handler(baseInput);
+    expect(reportData.abTests).toEqual([]);
+  });
+
   test('returns hasIssues=false when no issues fall in the window', async () => {
     mockSend = jest.fn(async () => ({ Items: [] }));
     DynamoDBClient.prototype.send = mockSend;

--- a/functions/build-monthly-report-data.mjs
+++ b/functions/build-monthly-report-data.mjs
@@ -8,6 +8,58 @@ const pct = (num, den) => (den > 0 ? Number(((n(num) / n(den)) * 100).toFixed(2)
 const round = (v) => Number(n(v).toFixed(2));
 
 /**
+ * Format an A/B variant send time (ISO) as a short, human-friendly UTC label.
+ */
+const formatSendAt = (iso) => {
+  if (!iso) return '—';
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return String(iso);
+  return `${date.toLocaleString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    timeZone: 'UTC'
+  })} UTC`;
+};
+
+/**
+ * Builds a monthly-report A/B entry from an issue's consolidated abTest summary
+ * (written by aggregate-issue-analytics). Returns null when the issue has no test.
+ */
+const buildAbTestEntry = (issueNumber, subject, abTest) => {
+  if (!abTest || !Array.isArray(abTest.variants) || abTest.variants.length === 0) {
+    return null;
+  }
+
+  const metricKey = abTest.winMetric === 'clickRate' ? 'clickRate' : 'openRate';
+  const byId = new Map(abTest.variants.map((v) => [v.variantId, v]));
+  const control = byId.get('a');
+  const winner = abTest.winnerVariantId ? byId.get(abTest.winnerVariantId) : null;
+  const lift = winner && control ? round(n(winner[metricKey]) - n(control[metricKey])) : null;
+
+  return {
+    issueNumber: String(issueNumber),
+    subject: subject || 'Untitled issue',
+    dimension: abTest.dimension,
+    winMetric: metricKey,
+    status: abTest.status || null,
+    winnerVariantId: abTest.winnerVariantId ?? null,
+    significant: Boolean(abTest.evaluation?.significant),
+    confidence: abTest.evaluation?.confidence ?? null,
+    lift,
+    variants: abTest.variants.map((v) => ({
+      variantId: v.variantId,
+      label: abTest.dimension === 'sendTime' ? formatSendAt(v.sendAt) : (v.subject || '—'),
+      openRate: round(v.openRate),
+      clickRate: round(v.clickRate),
+      deliveries: n(v.deliveries),
+      isWinner: abTest.winnerVariantId === v.variantId
+    }))
+  };
+};
+
+/**
  * Derive a short, human friendly label for a link (hostname + trimmed path).
  */
 const linkLabel = (url) => {
@@ -107,6 +159,7 @@ export const handler = async (state) => {
 
   const linkTotals = new Map(); // url -> { url, clicks, issues:Set }
   const issues = [];
+  const abTests = [];
 
   const summary = {
     issuesSent: monthIssues.length,
@@ -165,6 +218,11 @@ export const handler = async (state) => {
       clickToOpenRate: pct(clicks, uniqueOpens),
       bounceRate: pct(bounces, sends)
     });
+
+    const abEntry = buildAbTestEntry(issueNumber, issue.subject, issue.analytics?.abTest);
+    if (abEntry) {
+      abTests.push(abEntry);
+    }
   }
 
   summary.avgOpenRate = pct(summary.totalUniqueOpens, summary.totalDelivered);
@@ -213,6 +271,6 @@ export const handler = async (state) => {
     periodStart,
     periodEnd,
     hasIssues: true,
-    reportData: { summary, subscriberGrowth, topLinks, issues, bestIssue }
+    reportData: { summary, subscriberGrowth, topLinks, issues, bestIssue, abTests }
   };
 };

--- a/functions/compile-monthly-report.mjs
+++ b/functions/compile-monthly-report.mjs
@@ -58,7 +58,7 @@ export const handler = async (event) => {
   const normalizedBase = dashboardBaseUrl ? dashboardBaseUrl.replace(/\/+$/, '') : '';
   const reportUrl = normalizedBase ? `${normalizedBase}/reports/${month}` : null;
 
-  const { summary, subscriberGrowth, topLinks, issues, bestIssue } = report;
+  const { summary, subscriberGrowth, topLinks, issues, bestIssue, abTests = [] } = report;
 
   const templateData = {
     monthLabel,
@@ -107,7 +107,34 @@ export const handler = async (event) => {
       ...insight,
       color: severityColor(insight.severity)
     })),
-    hasInsights: report.insights.length > 0
+    hasInsights: report.insights.length > 0,
+    abTests: abTests.map((test) => ({
+      issueNumber: test.issueNumber,
+      subject: test.subject,
+      dimensionLabel: test.dimension === 'sendTime' ? 'Send time' : 'Subject line',
+      winMetricLabel: test.winMetric === 'clickRate' ? 'click rate' : 'open rate',
+      outcome:
+        test.status === 'inconclusive'
+          ? 'Inconclusive'
+          : test.winnerVariantId
+            ? `Variant ${test.winnerVariantId.toUpperCase()} won`
+            : 'In progress',
+      significanceText:
+        test.status === 'inconclusive'
+          ? 'No significant difference — control was sent'
+          : test.significant
+            ? `Significant${test.confidence != null ? ` at ${Math.round(n(test.confidence) * 100)}% confidence` : ''}`
+            : 'Not yet significant',
+      liftText: test.lift != null ? `${n(test.lift) >= 0 ? '+' : ''}${n(test.lift).toFixed(2)} pts` : '—',
+      variants: (test.variants || []).map((v) => ({
+        variantId: String(v.variantId).toUpperCase(),
+        label: v.label,
+        openRate: `${n(v.openRate).toFixed(2)}%`,
+        clickRate: `${n(v.clickRate).toFixed(2)}%`,
+        isWinner: Boolean(v.isWinner)
+      }))
+    })),
+    hasAbTests: abTests.length > 0
   };
 
   const html = template(templateData);

--- a/templates/monthly-report.hbs
+++ b/templates/monthly-report.hbs
@@ -145,6 +145,36 @@
             </td>
           </tr>
 
+          {{#if hasAbTests}}
+          <!-- A/B tests -->
+          <tr>
+            <td style="padding:20px;">
+              <h3 style="margin:0 0 12px 0;font-size:18px;color:#333;border-bottom:2px solid #e9ecef;padding-bottom:8px;">A/B tests</h3>
+              {{#each abTests}}
+              <table width="100%" cellpadding="6" cellspacing="0" border="0" style="border-collapse:collapse;margin-bottom:16px;">
+                <tr>
+                  <td style="font-size:13px;color:#222;font-weight:bold;padding:4px 6px;">#{{this.issueNumber}} {{this.subject}}</td>
+                  <td style="font-size:12px;color:#666;padding:4px 6px;text-align:right;">{{this.dimensionLabel}} · {{this.outcome}}</td>
+                </tr>
+                <tr style="background-color:#f1f3f5;">
+                  <td style="font-size:12px;color:#666;padding:6px;">Variant</td>
+                  <td style="font-size:12px;color:#666;padding:6px;text-align:right;">Open / Click</td>
+                </tr>
+                {{#each this.variants}}
+                <tr style="border-top:1px solid #e9ecef;">
+                  <td style="font-size:12px;color:#222;padding:6px;">{{#if this.isWinner}}🏆 {{/if}}Variant {{this.variantId}} — {{this.label}}</td>
+                  <td style="font-size:12px;color:#222;padding:6px;text-align:right;">{{this.openRate}} / {{this.clickRate}}</td>
+                </tr>
+                {{/each}}
+                <tr>
+                  <td colspan="2" style="font-size:11px;color:#999;padding:6px;">Win metric: {{this.winMetricLabel}} · Lift: {{this.liftText}} · {{this.significanceText}}</td>
+                </tr>
+              </table>
+              {{/each}}
+            </td>
+          </tr>
+          {{/if}}
+
           <!-- Footer -->
           <tr>
             <td style="padding:20px;text-align:center;border-top:1px solid #e9ecef;">


### PR DESCRIPTION
Closes #301 (part of epic #300).

The per-issue consolidated analytics already include an `abTest` summary (added in Phase 4); the monthly report didn't render it. This adds an "A/B tests" section to the report.

## Changes
- **`functions/build-monthly-report-data.mjs`** — collect an `abTests` array from each in-window issue's `analytics.abTest` summary: dimension, win metric, status, winner, per-variant open/click rates, computed **lift** (winner vs control on the win metric), and the significance verdict. Send-time variants get a human-friendly UTC label.
- **`functions/compile-monthly-report.mjs`** — format `abTests` into template data (outcome, significance text, lift, per-variant rates) + `hasAbTests`.
- **`templates/monthly-report.hbs`** — new "A/B tests" section, rendered **only** when the period had at least one test; shows each test's variants, the winner (🏆), lift, and significance.

No new data or pipeline changes — purely reads what's already stored.

## Behavior
- Issues without a test (and periods with none) are unaffected — the section is omitted entirely.
- Open/click rates and the winner mirror the per-issue analytics.

## Testing
- `build-monthly-report-data` suite: **8 passing** (2 new — A/B extraction/lift/winner, and the no-test omission case).
- Template render verified against sample A/B data (section, winner badge, and lift render correctly).
- ESLint clean.

Part of #300. Independent of the other round-2 work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KEvcSBGrCS6wBQBW7ALRax)_