### PR TITLE
feat: cross-issue A/B history — data model & write path

### DIFF
--- a/__tests__/evaluate-ab-winner.test.mjs
+++ b/__tests__/evaluate-ab-winner.test.mjs
@@ -42,7 +42,8 @@ const loadIsolated = async () => {
     jest.unstable_mockModule('@aws-sdk/client-dynamodb', () => ({
       DynamoDBClient: jest.fn(() => ({ send: ddbSend })),
       GetItemCommand: jest.fn((params) => ({ __type: 'GetItem', ...params })),
-      UpdateItemCommand: jest.fn((params) => ({ __type: 'UpdateItem', ...params }))
+      UpdateItemCommand: jest.fn((params) => ({ __type: 'UpdateItem', ...params })),
+      PutItemCommand: jest.fn((params) => ({ __type: 'PutItem', ...params }))
     }));
 
     jest.unstable_mockModule('@aws-sdk/client-eventbridge', () => ({
@@ -166,6 +167,25 @@ describe('evaluate-ab-winner', () => {
     expect(data.winnerVariantId).toBe('b');
     expect(data.status).toBe('sent');
     expect(data.issueId).toBe('tenant-1#42');
+  });
+
+  it('writes a cross-issue A/B history record (idempotent upsert keyed by issue)', async () => {
+    wireDdb({
+      abTest: abTestConfig(),
+      aStats: { opens: 200, clicks: 10, deliveries: 1000 },
+      bStats: { opens: 400, clicks: 20, deliveries: 1000 }
+    });
+
+    await handler(baseEvent);
+
+    const putCall = ddbSend.mock.calls.find(([cmd]) => cmd.__type === 'PutItem');
+    expect(putCall).toBeDefined();
+    const item = unmarshall(putCall[0].Item);
+    expect(item.recordType).toBe('abHistory');
+    expect(item.pk).toBe('tenant-1#abhistory');
+    expect(item.sk).toBe('test#42'); // keyed by issue => upsert is idempotent
+    expect(item.winnerVariantId).toBe('b');
+    expect(item.dimension).toBe('subject');
   });
 
   it('inconclusive: persists status inconclusive, sends control variant a subject', async () => {

--- a/functions/evaluate-ab-winner.mjs
+++ b/functions/evaluate-ab-winner.mjs
@@ -1,7 +1,8 @@
-import { DynamoDBClient, GetItemCommand, UpdateItemCommand } from '@aws-sdk/client-dynamodb';
+import { DynamoDBClient, GetItemCommand, UpdateItemCommand, PutItemCommand } from '@aws-sdk/client-dynamodb';
 import { EventBridgeClient, PutEventsCommand } from '@aws-sdk/client-eventbridge';
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
 import { evaluateAbResult } from './utils/ab-stats.mjs';
+import { buildAbHistoryRecord } from './utils/ab-history.mjs';
 import { publishIssueEvent, EVENT_TYPES } from './utils/event-publisher.mjs';
 
 const ddb = new DynamoDBClient();
@@ -87,6 +88,10 @@ export const handler = async (event) => {
       };
       await finalizeEvaluation(issueId, updatedAbTest, status);
 
+      // Record the completed test in the tenant's cross-issue A/B history.
+      // Best-effort: a failure here must not affect the (already enqueued) send.
+      await writeAbHistory(tenantId, issueNumber, updatedAbTest, { a: aCounters, b: bCounters });
+
       await publishIssueEvent(
         tenantId,
         'system',
@@ -165,6 +170,28 @@ const finalizeEvaluation = async (issueId, updatedAbTest, status) => {
       ':now': new Date().toISOString()
     })
   }));
+};
+
+/**
+ * Records the completed test in the tenant's cross-issue A/B history. The record
+ * is keyed by issue, so the PutItem is an idempotent upsert (a redelivery
+ * overwrites rather than duplicating). Best-effort: failures are logged and
+ * swallowed so history never affects the winner send or finalize.
+ * @param {string} tenantId
+ * @param {number|string} issueNumber
+ * @param {Object} abTest - The finalized abTest config.
+ * @param {Object} counters - Per-variant counters keyed by variantId.
+ */
+const writeAbHistory = async (tenantId, issueNumber, abTest, counters) => {
+  try {
+    const record = buildAbHistoryRecord({ tenantId, issueNumber, abTest, counters });
+    await ddb.send(new PutItemCommand({
+      TableName: process.env.TABLE_NAME,
+      Item: marshall(record, { removeUndefinedValues: true })
+    }));
+  } catch (err) {
+    console.error('Failed to write A/B history record', { tenantId, issueNumber, error: err.message });
+  }
 };
 
 /**

--- a/functions/utils/__tests__/ab-history.test.mjs
+++ b/functions/utils/__tests__/ab-history.test.mjs
@@ -1,0 +1,100 @@
+import { describe, it, expect } from '@jest/globals';
+import { buildAbHistoryRecord } from '../ab-history.mjs';
+
+const subjectAbTest = (overrides = {}) => ({
+  dimension: 'subject',
+  winMetric: 'openRate',
+  status: 'sent',
+  winnerVariantId: 'b',
+  variants: [
+    { variantId: 'a', subject: 'Control' },
+    { variantId: 'b', subject: 'Challenger' }
+  ],
+  evaluation: { significant: true, confidence: 0.95, decidedAt: '2026-06-01T00:00:00.000Z' },
+  ...overrides
+});
+
+const counters = {
+  a: { opens: 300, clicks: 50, deliveries: 1000 },
+  b: { opens: 450, clicks: 90, deliveries: 1000 }
+};
+
+describe('buildAbHistoryRecord', () => {
+  it('keys the record per issue and denormalizes variant rates', () => {
+    const record = buildAbHistoryRecord({ tenantId: 'tenant-1', issueNumber: 42, abTest: subjectAbTest(), counters });
+
+    expect(record.pk).toBe('tenant-1#abhistory');
+    expect(record.sk).toBe('test#42');
+    expect(record.recordType).toBe('abHistory');
+    expect(record.issueNumber).toBe(42);
+    expect(record.dimension).toBe('subject');
+    expect(record.winMetric).toBe('openRate');
+    expect(record.winnerVariantId).toBe('b');
+    expect(record.significant).toBe(true);
+    expect(record.confidence).toBe(0.95);
+    expect(record.decidedAt).toBe('2026-06-01T00:00:00.000Z');
+
+    const a = record.variants.find((v) => v.variantId === 'a');
+    const b = record.variants.find((v) => v.variantId === 'b');
+    expect(a.openRate).toBe(30); // 300/1000
+    expect(b.openRate).toBe(45); // 450/1000
+    expect(b.clickRate).toBe(9); // 90/1000
+    expect(a.subject).toBe('Control');
+  });
+
+  it('computes lift as winner minus control on the win metric', () => {
+    const record = buildAbHistoryRecord({ tenantId: 't', issueNumber: 7, abTest: subjectAbTest(), counters });
+    // open rate: winner b 45 - control a 30 = 15
+    expect(record.lift).toBe(15);
+  });
+
+  it('uses click rate for lift when winMetric is clickRate', () => {
+    const record = buildAbHistoryRecord({
+      tenantId: 't', issueNumber: 7,
+      abTest: subjectAbTest({ winMetric: 'clickRate' }),
+      counters
+    });
+    // click rate: winner b 9 - control a 5 = 4
+    expect(record.lift).toBe(4);
+  });
+
+  it('returns null lift for an inconclusive test (no winner)', () => {
+    const record = buildAbHistoryRecord({
+      tenantId: 't', issueNumber: 7,
+      abTest: subjectAbTest({ status: 'inconclusive', winnerVariantId: null, evaluation: { significant: false } }),
+      counters
+    });
+    expect(record.winnerVariantId).toBeNull();
+    expect(record.lift).toBeNull();
+    expect(record.significant).toBe(false);
+  });
+
+  it('carries sendAt (not subject) for send-time variants', () => {
+    const record = buildAbHistoryRecord({
+      tenantId: 't', issueNumber: 9,
+      abTest: {
+        dimension: 'sendTime',
+        winMetric: 'openRate',
+        status: 'sent',
+        winnerVariantId: 'a',
+        variants: [
+          { variantId: 'a', sendAt: '2026-06-01T09:00:00.000Z' },
+          { variantId: 'b', sendAt: '2026-06-01T17:00:00.000Z' }
+        ],
+        evaluation: { significant: true, confidence: 0.95 }
+      },
+      counters
+    });
+    const a = record.variants.find((v) => v.variantId === 'a');
+    expect(a.sendAt).toBe('2026-06-01T09:00:00.000Z');
+    expect(a.subject).toBeUndefined();
+    expect(record.dimension).toBe('sendTime');
+  });
+
+  it('defaults missing counters to zero rates', () => {
+    const record = buildAbHistoryRecord({
+      tenantId: 't', issueNumber: 1, abTest: subjectAbTest(), counters: {}
+    });
+    expect(record.variants.every((v) => v.openRate === 0 && v.clickRate === 0 && v.deliveries === 0)).toBe(true);
+  });
+});

--- a/functions/utils/ab-history.mjs
+++ b/functions/utils/ab-history.mjs
@@ -1,0 +1,70 @@
+/**
+ * Builds the cross-issue A/B test history record (A/B Testing R2).
+ *
+ * Pure module: given a finalized abTest config and the per-variant counters, it
+ * produces a self-contained, denormalized DynamoDB item so the read API and the
+ * LLM-suggestion path can consume history without re-reading issue/stats records.
+ *
+ * Record key: pk = `${tenantId}#abhistory`, sk = `test#${issueNumber}` — one row
+ * per test, queryable per tenant via the partition. Writing with the same key is
+ * an idempotent upsert (redeliveries update, never duplicate).
+ */
+
+const round = (value) => {
+  const n = Number(value);
+  return Number.isFinite(n) ? Number(n.toFixed(2)) : 0;
+};
+
+const rate = (successes, deliveries) =>
+  deliveries > 0 ? round((Number(successes || 0) / Number(deliveries)) * 100) : 0;
+
+/**
+ * @param {Object} params
+ * @param {string} params.tenantId
+ * @param {number|string} params.issueNumber
+ * @param {Object} params.abTest - The finalized abTest config (with evaluation, winnerVariantId, status).
+ * @param {Object} params.counters - Per-variant counters keyed by variantId: { a: {opens,clicks,deliveries}, b: {...} }.
+ * @returns {Object} The history record item (plain object, ready to marshall).
+ */
+export const buildAbHistoryRecord = ({ tenantId, issueNumber, abTest, counters = {} }) => {
+  const winMetric = abTest.winMetric === 'clickRate' ? 'clickRate' : 'openRate';
+
+  const variants = (abTest.variants || []).map((variant) => {
+    const counter = counters[variant.variantId] || {};
+    const opens = Number(counter.opens || 0);
+    const clicks = Number(counter.clicks || 0);
+    const deliveries = Number(counter.deliveries || 0);
+    return {
+      variantId: variant.variantId,
+      ...(variant.subject !== undefined && { subject: variant.subject }),
+      ...(variant.sendAt !== undefined && { sendAt: variant.sendAt }),
+      opens,
+      clicks,
+      deliveries,
+      openRate: rate(opens, deliveries),
+      clickRate: rate(clicks, deliveries)
+    };
+  });
+
+  const byId = Object.fromEntries(variants.map((v) => [v.variantId, v]));
+  const control = byId.a;
+  const winner = abTest.winnerVariantId ? byId[abTest.winnerVariantId] : null;
+  const lift = winner && control ? round(winner[winMetric] - control[winMetric]) : null;
+
+  return {
+    pk: `${tenantId}#abhistory`,
+    sk: `test#${issueNumber}`,
+    recordType: 'abHistory',
+    tenantId,
+    issueNumber: Number(issueNumber),
+    dimension: abTest.dimension,
+    winMetric,
+    status: abTest.status ?? null,
+    winnerVariantId: abTest.winnerVariantId ?? null,
+    significant: Boolean(abTest.evaluation?.significant),
+    confidence: abTest.evaluation?.confidence ?? null,
+    lift,
+    variants,
+    decidedAt: abTest.evaluation?.decidedAt || new Date().toISOString()
+  };
+};

--- a/template.yaml
+++ b/template.yaml
@@ -2181,6 +2181,7 @@ Resources:
               Action:
                 - dynamodb:GetItem
                 - dynamodb:UpdateItem
+                - dynamodb:PutItem
               Resource: !GetAtt NewsletterTable.Arn
             - Effect: Allow
               Action: events:PutEvents


### PR DESCRIPTION
Closes #302 (part of epic #300). The **foundation** for the history read API (#303) and LLM-assisted suggestions (#304): durably record every completed A/B test so we can learn across issues.

## Changes
- **`functions/utils/ab-history.mjs`** (new) — pure `buildAbHistoryRecord`. Produces a self-contained, **denormalized** record so downstream consumers never re-read issue/stats records:
  - Key: `pk = ${tenantId}#abhistory`, `sk = test#${issueNumber}` — one row per test, queryable per tenant via the partition.
  - Fields: dimension, win metric, status, winner, per-variant `subject`/`sendAt` + opens/clicks/deliveries + open/click rates, computed **lift** (winner vs control on the win metric), confidence, significance, decidedAt.
- **`functions/evaluate-ab-winner.mjs`** — after `finalizeEvaluation`, upsert the history record. Keyed by issue ⇒ a redelivery **overwrites, not duplicates** (idempotent). Best-effort: wrapped in try/catch so a history-write failure can't affect the already-enqueued winner send or the finalize.
- **`template.yaml`** — grant `EvaluateAbWinnerFunction` `dynamodb:PutItem`.

## Testing
- New `ab-history` builder suite: rates, lift by win metric (open vs click), inconclusive ⇒ null lift, send-time variants carry `sendAt`, missing counters default to 0.
- `evaluate-ab-winner` gains a test asserting the idempotent history upsert (record key + winner).
- Full backend jest suite: **898 passing**; `template.yaml` validates.

## Notes
- The record is intentionally denormalized so #303 (read API/aggregates) and #304 (LLM grounding) can read just the `${tenantId}#abhistory` partition cheaply.
- Optional backfill from already-completed issues is noted in #302 as low priority; not included here.

Part of #300. Unblocks #303 and #304.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KEvcSBGrCS6wBQBW7ALRax)_