### PR TITLE
feat: cross-issue A/B history — read API & dashboard view

### DIFF
--- a/dashboard-ui/src/components/issues/AbTestHistory.tsx
+++ b/dashboard-ui/src/components/issues/AbTestHistory.tsx
@@ -1,0 +1,301 @@
+import React, { useMemo } from 'react';
+import {
+  FlaskConical,
+  Trophy,
+  Mail,
+  Clock,
+  Loader2,
+  AlertTriangle,
+  AlertCircle,
+  CheckCircle2,
+  MinusCircle,
+} from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '../ui/Card';
+import { formatDate } from '../../utils/issueDetailUtils';
+import { cn } from '../../utils/cn';
+import type {
+  AbHistoryResponse,
+  AbHistoryTest,
+  AbHistoryVariant,
+  VariantId,
+  AbTestDimension,
+} from '../../types/issues';
+
+export interface AbTestHistoryProps {
+  /** The A/B test history payload (tests + aggregates). */
+  data?: AbHistoryResponse | null;
+  /** Whether the history is currently loading. */
+  loading?: boolean;
+  /** An error message to surface instead of the panel body. */
+  error?: string | null;
+  /** Optional retry handler shown alongside the error state. */
+  onRetry?: () => void;
+}
+
+const VARIANT_LABELS: Record<VariantId, string> = {
+  a: 'A (Control)',
+  b: 'B (Challenger)',
+};
+
+const formatRate = (value: number): string => `${value.toFixed(1)}%`;
+
+const formatLift = (lift?: number): string => {
+  if (lift === undefined || lift === null) return '—';
+  const sign = lift > 0 ? '+' : '';
+  return `${sign}${lift.toFixed(1)} pts`;
+};
+
+const dimensionLabel = (dimension: AbTestDimension): string =>
+  dimension === 'subject' ? 'Subject line' : 'Send time';
+
+interface AggregateStatProps {
+  label: string;
+  value: React.ReactNode;
+  hint?: string;
+}
+
+const AggregateStat: React.FC<AggregateStatProps> = ({ label, value, hint }) => (
+  <div className="rounded-lg border border-border bg-muted/40 p-3">
+    <dt className="text-xs text-muted-foreground font-medium">{label}</dt>
+    <dd className="text-xl font-bold text-foreground mt-0.5">{value}</dd>
+    {hint && <dd className="text-xs text-muted-foreground mt-0.5">{hint}</dd>}
+  </div>
+);
+
+interface VariantRateProps {
+  variant: AbHistoryVariant;
+  dimension: AbTestDimension;
+  isWinner: boolean;
+}
+
+const VariantRate: React.FC<VariantRateProps> = ({ variant, dimension, isWinner }) => (
+  <div
+    className={cn(
+      'rounded-md border p-2 text-xs',
+      isWinner
+        ? 'border-success-400 bg-success-50 dark:border-success-500 dark:bg-success-900/20'
+        : 'border-border bg-muted/40'
+    )}
+  >
+    <div className="flex items-center justify-between gap-1 mb-1">
+      <span className="font-semibold text-foreground">{VARIANT_LABELS[variant.variantId]}</span>
+      {isWinner && (
+        <Trophy className="w-3 h-3 text-success-600 dark:text-success-400" aria-label="Winner" />
+      )}
+    </div>
+    <p className="text-muted-foreground break-words mb-1 min-h-[1rem]">
+      {dimension === 'subject'
+        ? variant.subject || 'No subject'
+        : variant.sendAt
+          ? formatDate(variant.sendAt)
+          : 'No send time'}
+    </p>
+    <div className="flex items-center gap-3 text-foreground">
+      <span>Open {formatRate(variant.openRate)}</span>
+      <span>Click {formatRate(variant.clickRate)}</span>
+    </div>
+  </div>
+);
+
+interface TestRowProps {
+  test: AbHistoryTest;
+}
+
+const TestRow: React.FC<TestRowProps> = ({ test }) => {
+  const winnerId = test.winnerVariantId ?? null;
+  return (
+    <li className="rounded-lg border border-border p-4" aria-label={`Issue #${test.issueNumber} A/B test`}>
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 mb-3">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="text-sm font-semibold text-foreground">Issue #{test.issueNumber}</span>
+          <span className="inline-flex items-center gap-1 text-xs text-muted-foreground font-medium">
+            {test.dimension === 'subject' ? (
+              <Mail className="w-3.5 h-3.5" aria-hidden="true" />
+            ) : (
+              <Clock className="w-3.5 h-3.5" aria-hidden="true" />
+            )}
+            {dimensionLabel(test.dimension)}
+          </span>
+          {test.decidedAt && (
+            <span className="text-xs text-muted-foreground">{formatDate(test.decidedAt, false)}</span>
+          )}
+        </div>
+        <div className="flex items-center gap-2 flex-wrap">
+          {test.significant ? (
+            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium border bg-success-100 text-success-800 border-success-300 dark:bg-success-800/60 dark:text-success-100 dark:border-success-400">
+              <CheckCircle2 className="w-3 h-3" aria-hidden="true" />
+              Significant
+              {test.confidence !== undefined && ` (${Math.round(test.confidence * 100)}%)`}
+            </span>
+          ) : (
+            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium border bg-gray-100 text-gray-700 border-gray-300 dark:bg-gray-700 dark:text-gray-100 dark:border-gray-500">
+              <MinusCircle className="w-3 h-3" aria-hidden="true" />
+              Not significant
+            </span>
+          )}
+          {winnerId && (
+            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium border bg-success-100 text-success-800 border-success-300 dark:bg-success-800/60 dark:text-success-100 dark:border-success-400">
+              <Trophy className="w-3 h-3" aria-hidden="true" />
+              Winner {VARIANT_LABELS[winnerId]}
+            </span>
+          )}
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between gap-2 mb-3 text-xs text-muted-foreground">
+        <span>
+          Decided on {test.winMetric === 'openRate' ? 'open rate' : 'click rate'}
+          {test.winMetric === 'openRate' && (
+            <span
+              className="inline-flex items-center gap-1 ml-1 text-amber-700 dark:text-amber-300"
+              title="Apple Mail Privacy Protection can inflate open rates."
+            >
+              <AlertTriangle className="w-3 h-3" aria-hidden="true" />
+              MPP caveat
+            </span>
+          )}
+        </span>
+        <span className="font-medium text-foreground">Lift {formatLift(test.lift)}</span>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+        {test.variants.map((variant) => (
+          <VariantRate
+            key={variant.variantId}
+            variant={variant}
+            dimension={test.dimension}
+            isWinner={winnerId === variant.variantId}
+          />
+        ))}
+      </div>
+    </li>
+  );
+};
+
+export const AbTestHistory: React.FC<AbTestHistoryProps> = ({
+  data,
+  loading = false,
+  error = null,
+  onRetry,
+}) => {
+  const aggregates = data?.aggregates;
+  const tests = useMemo(() => data?.tests ?? [], [data]);
+
+  const hasOpenRateTest = useMemo(
+    () => tests.some((t) => t.winMetric === 'openRate'),
+    [tests]
+  );
+
+  const topSendHours = aggregates?.topSendHoursUtc ?? [];
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <FlaskConical className="w-5 h-5" aria-hidden="true" />
+          A/B Test History
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <div
+            className="flex items-center justify-center gap-2 py-12 text-muted-foreground"
+            role="status"
+            aria-live="polite"
+          >
+            <Loader2 className="w-5 h-5 animate-spin" aria-hidden="true" />
+            <span className="text-sm">Loading A/B test history…</span>
+          </div>
+        ) : error ? (
+          <div
+            className="flex items-start gap-2 rounded-lg border border-error-200 bg-error-50 p-4"
+            role="alert"
+            aria-live="assertive"
+          >
+            <AlertCircle className="w-5 h-5 mt-0.5 text-error-500 flex-shrink-0" aria-hidden="true" />
+            <div>
+              <p className="text-sm font-medium text-error-800">Couldn’t load A/B test history</p>
+              <p className="text-xs text-error-700 mt-0.5">{error}</p>
+              {onRetry && (
+                <button
+                  onClick={onRetry}
+                  className="mt-2 px-3 py-1.5 rounded-md text-xs font-medium bg-error-100 text-error-800 hover:bg-error-200 focus:outline-none focus:ring-2 focus:ring-error-500 focus:ring-offset-2"
+                >
+                  Try again
+                </button>
+              )}
+            </div>
+          </div>
+        ) : tests.length === 0 ? (
+          <div className="text-center py-12" role="status">
+            <FlaskConical className="mx-auto h-10 w-10 text-muted-foreground" aria-hidden="true" />
+            <p className="mt-2 text-sm font-medium text-foreground">No A/B tests yet</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Once you run subject-line or send-time experiments, their results and trends will appear here.
+            </p>
+          </div>
+        ) : (
+          <>
+            {/* Headline aggregates */}
+            <dl className="grid grid-cols-2 lg:grid-cols-4 gap-3 mb-4">
+              <AggregateStat
+                label="Total tests"
+                value={aggregates?.totalTests ?? tests.length}
+                hint={`${aggregates?.significantTests ?? 0} significant`}
+              />
+              <AggregateStat
+                label="By dimension"
+                value={`${aggregates?.subjectTests ?? 0} / ${aggregates?.sendTimeTests ?? 0}`}
+                hint="Subject / Send-time"
+              />
+              <AggregateStat
+                label="Avg winning lift"
+                value={formatLift(aggregates?.avgWinningLift)}
+                hint="Significant winners"
+              />
+              <AggregateStat
+                label="Top send hours (UTC)"
+                value={
+                  topSendHours.length > 0
+                    ? topSendHours
+                        .map((h) => `${String(h.hourUtc).padStart(2, '0')}:00`)
+                        .join(', ')
+                    : '—'
+                }
+                hint={
+                  topSendHours.length > 0
+                    ? topSendHours.map((h) => `${h.wins} win${h.wins === 1 ? '' : 's'}`).join(' · ')
+                    : 'No send-time wins'
+                }
+              />
+            </dl>
+
+            {/* Aggregate-level MPP caveat */}
+            {hasOpenRateTest && (
+              <div className="flex items-start gap-2 rounded-lg border border-amber-300 bg-amber-50 dark:border-amber-500/50 dark:bg-amber-900/20 p-3 mb-4">
+                <AlertTriangle
+                  className="w-4 h-4 mt-0.5 text-amber-600 dark:text-amber-400 flex-shrink-0"
+                  aria-hidden="true"
+                />
+                <p className="text-xs text-amber-800 dark:text-amber-200">
+                  Some tests below are decided on open rate. Apple Mail Privacy Protection can inflate open
+                  rates, so click rate may be a more reliable signal.
+                </p>
+              </div>
+            )}
+
+            <ul className="space-y-3" aria-label="Past A/B tests">
+              {tests.map((test) => (
+                <TestRow key={test.issueNumber} test={test} />
+              ))}
+            </ul>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+AbTestHistory.displayName = 'AbTestHistory';
+
+export default AbTestHistory;

--- a/dashboard-ui/src/components/issues/__tests__/AbTestHistory.test.tsx
+++ b/dashboard-ui/src/components/issues/__tests__/AbTestHistory.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AbTestHistory } from '../AbTestHistory';
+import type { AbHistoryResponse } from '@/types/issues';
+
+const sampleData: AbHistoryResponse = {
+  tests: [
+    {
+      issueNumber: 42,
+      dimension: 'subject',
+      winMetric: 'openRate',
+      status: 'sent',
+      winnerVariantId: 'b',
+      significant: true,
+      confidence: 0.95,
+      lift: 15.0,
+      decidedAt: '2026-06-01T00:00:00Z',
+      variants: [
+        { variantId: 'a', subject: 'Control', opens: 300, clicks: 50, deliveries: 1000, openRate: 30.0, clickRate: 5.0 },
+        { variantId: 'b', subject: 'Challenger', opens: 450, clicks: 90, deliveries: 1000, openRate: 45.0, clickRate: 9.0 },
+      ],
+    },
+    {
+      issueNumber: 40,
+      dimension: 'sendTime',
+      winMetric: 'clickRate',
+      status: 'inconclusive',
+      winnerVariantId: null,
+      significant: false,
+      variants: [
+        { variantId: 'a', sendAt: '2026-05-20T09:00:00Z', opens: 200, clicks: 30, deliveries: 800, openRate: 25.0, clickRate: 3.75 },
+        { variantId: 'b', sendAt: '2026-05-20T17:00:00Z', opens: 210, clicks: 32, deliveries: 800, openRate: 26.25, clickRate: 4.0 },
+      ],
+    },
+  ],
+  aggregates: {
+    totalTests: 4,
+    significantTests: 3,
+    subjectTests: 2,
+    sendTimeTests: 2,
+    avgWinningLift: 8.0,
+    topSendHoursUtc: [{ hourUtc: 9, wins: 2 }],
+  },
+};
+
+describe('AbTestHistory', () => {
+  it('renders headline aggregates and a test row', () => {
+    render(<AbTestHistory data={sampleData} />);
+
+    // Aggregates
+    expect(screen.getByText('Total tests')).toBeInTheDocument();
+    expect(screen.getByText('4')).toBeInTheDocument();
+    expect(screen.getByText('3 significant')).toBeInTheDocument();
+    expect(screen.getByText('Avg winning lift')).toBeInTheDocument();
+    expect(screen.getByText('+8.0 pts')).toBeInTheDocument();
+    // Top send hour 09:00 UTC (exact aggregate value)
+    expect(screen.getByText('09:00')).toBeInTheDocument();
+    expect(screen.getByText('Top send hours (UTC)')).toBeInTheDocument();
+
+    // Test row
+    expect(screen.getByText('Issue #42')).toBeInTheDocument();
+    expect(screen.getByText('Not significant')).toBeInTheDocument();
+    expect(screen.getByText('Winner B (Challenger)')).toBeInTheDocument();
+    expect(screen.getByText('Lift +15.0 pts')).toBeInTheDocument();
+    // Per-variant rates
+    expect(screen.getByText('Open 45.0%')).toBeInTheDocument();
+    expect(screen.getByText('Click 9.0%')).toBeInTheDocument();
+  });
+
+  it('shows the Apple MPP caveat when an open-rate test is present', () => {
+    render(<AbTestHistory data={sampleData} />);
+    expect(screen.getAllByText(/Apple Mail Privacy Protection|MPP caveat/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders the empty state when there are no tests', () => {
+    render(
+      <AbTestHistory
+        data={{
+          tests: [],
+          aggregates: {
+            totalTests: 0,
+            significantTests: 0,
+            subjectTests: 0,
+            sendTimeTests: 0,
+            topSendHoursUtc: [],
+          },
+        }}
+      />
+    );
+    expect(screen.getByText('No A/B tests yet')).toBeInTheDocument();
+  });
+
+  it('renders the loading state', () => {
+    render(<AbTestHistory loading />);
+    expect(screen.getByText(/Loading A\/B test history/i)).toBeInTheDocument();
+  });
+
+  it('renders the error state', () => {
+    render(<AbTestHistory error="Boom" />);
+    expect(screen.getByText('Couldn’t load A/B test history')).toBeInTheDocument();
+    expect(screen.getByText('Boom')).toBeInTheDocument();
+  });
+});

--- a/dashboard-ui/src/components/issues/index.ts
+++ b/dashboard-ui/src/components/issues/index.ts
@@ -62,3 +62,6 @@ export type { SubscriberMetricsPanelProps } from './SubscriberMetricsPanel';
 
 export { AbTestConfig, validateAbTest, hasAbTestErrors } from './AbTestConfig';
 export type { AbTestConfigProps, AbTestErrors } from './AbTestConfig';
+
+export { AbTestHistory } from './AbTestHistory';
+export type { AbTestHistoryProps } from './AbTestHistory';

--- a/dashboard-ui/src/pages/dashboard/DashboardPage.tsx
+++ b/dashboard-ui/src/pages/dashboard/DashboardPage.tsx
@@ -3,12 +3,14 @@ import { useState, useEffect, useCallback, useMemo, lazy, Suspense } from 'react
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { dashboardService } from '@/services/dashboardService';
 import { profileService } from '@/services/profileService';
+import { issuesService } from '@/services/issuesService';
 import { DashboardSkeleton } from '@/components/ui/SkeletonLoader';
 import { InfoTooltip } from '@/components/ui/InfoTooltip';
 import MetricsCard from '@/components/MetricsCard';
 import { SubscriberGrowthChart } from '@/components/SubscriberGrowthChart';
 import { MiniSparkline } from '@/components/MiniSparkline';
 import type { TrendsData, UserProfile, TrendComparison } from '@/types';
+import type { AbHistoryResponse } from '@/types/issues';
 import { useAuth } from '@/contexts/AuthContext';
 import { calculatePercentageDifference, calculateHealthStatus } from '@/utils/analyticsCalculations';
 import {
@@ -28,6 +30,9 @@ const QualitySignalsChart = lazy(() => import('@/components/QualitySignalsChart'
 const EngagementTypeTrendChart = lazy(() => import('@/components/EngagementTypeTrendChart'));
 const TrafficSourceTrendChart = lazy(() => import('@/components/TrafficSourceTrendChart'));
 const TopRegionsWidget = lazy(() => import('@/components/TopRegionsWidget'));
+const AbTestHistory = lazy(() =>
+  import('@/components/issues/AbTestHistory').then((m) => ({ default: m.AbTestHistory }))
+);
 
 export function DashboardPage() {
   const { user } = useAuth();
@@ -35,6 +40,9 @@ export function DashboardPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const [profile, setProfile] = useState<UserProfile | null>(null);
   const [trendsData, setTrendsData] = useState<TrendsData | null>(null);
+  const [abHistory, setAbHistory] = useState<AbHistoryResponse | null>(null);
+  const [abHistoryLoading, setAbHistoryLoading] = useState(true);
+  const [abHistoryError, setAbHistoryError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -183,9 +191,28 @@ export function DashboardPage() {
     }
   }, [issueCount]);
 
+  const loadAbHistory = useCallback(async () => {
+    try {
+      setAbHistoryLoading(true);
+      setAbHistoryError(null);
+      const response = await issuesService.getAbHistory();
+      if (response.success && response.data) {
+        setAbHistory(response.data);
+      } else {
+        setAbHistoryError(response.error || 'Failed to load A/B test history');
+      }
+    } catch (err) {
+      console.error('A/B history error:', err);
+      setAbHistoryError(err instanceof Error ? err.message : 'Failed to load A/B test history');
+    } finally {
+      setAbHistoryLoading(false);
+    }
+  }, []);
+
   const handleRefresh = () => {
     dashboardService.invalidateTrendsCache();
     loadTrendsData(true);
+    loadAbHistory();
   };
 
   useEffect(() => {
@@ -210,6 +237,10 @@ export function DashboardPage() {
   useEffect(() => {
     loadTrendsData();
   }, [loadTrendsData]);
+
+  useEffect(() => {
+    loadAbHistory();
+  }, [loadAbHistory]);
 
   const formatPercentage = (value: number) => `${value.toFixed(1)}%`;
   const formatNumber = (value: number) => value.toLocaleString();
@@ -641,6 +672,21 @@ export function DashboardPage() {
                     )}
                   </div>
                 </div>
+              </div>
+
+              {/* A/B Test History */}
+              <div className="space-y-3 sm:space-y-4">
+                <div className="flex items-center justify-between pt-2 border-t border-border">
+                  <h3 className="text-sm uppercase tracking-widest text-muted-foreground">A/B Testing</h3>
+                </div>
+                <Suspense fallback={<div className="bg-surface rounded-lg shadow p-6 animate-pulse h-48" />}>
+                  <AbTestHistory
+                    data={abHistory}
+                    loading={abHistoryLoading}
+                    error={abHistoryError}
+                    onRetry={loadAbHistory}
+                  />
+                </Suspense>
               </div>
 
             </div>

--- a/dashboard-ui/src/services/issuesService.ts
+++ b/dashboard-ui/src/services/issuesService.ts
@@ -9,6 +9,7 @@ import type {
   UpdateIssueRequest,
   ListIssuesParams,
   VariantId,
+  AbHistoryResponse,
 } from '@/types/issues';
 import type { ApiResponse } from '@/types';
 import { calculateCompositeScore } from '@/utils/analyticsCalculations';
@@ -153,6 +154,16 @@ class IssuesService {
    */
   async declareAbWinner(issueId: string, variantId: VariantId): Promise<ApiResponse<Issue>> {
     return apiClient.post(`/issues/${issueId}/ab-test/declare-winner`, { variantId });
+  }
+
+  /**
+   * Retrieves the tenant's A/B test history: past tests with per-variant
+   * engagement plus headline aggregates (significant counts, avg winning lift,
+   * top winning send hours). Tests are returned newest-issue-first.
+   * @returns Promise resolving to the A/B test history response
+   */
+  async getAbHistory(): Promise<ApiResponse<AbHistoryResponse>> {
+    return apiClient.get<AbHistoryResponse>('/ab-test/history');
   }
 
   /**

--- a/dashboard-ui/src/types/issues.ts
+++ b/dashboard-ui/src/types/issues.ts
@@ -335,3 +335,60 @@ export interface InsightV2 {
   recommendation: string;
   evidence?: InsightEvidence[];
 }
+
+// ---------------------------------------------------------------------------
+// A/B test history (GET /ab-test/history)
+// ---------------------------------------------------------------------------
+
+/** Per-variant rollup for a completed A/B test in the history feed. */
+export interface AbHistoryVariant {
+  variantId: VariantId;
+  /** Subject line for this variant (subject-dimension tests). */
+  subject?: string;
+  /** Absolute send time for this variant (send-time tests). */
+  sendAt?: string;
+  opens: number;
+  clicks: number;
+  deliveries: number;
+  openRate: number;
+  clickRate: number;
+}
+
+/** A single past A/B test as returned by the history endpoint. */
+export interface AbHistoryTest {
+  issueNumber: number;
+  dimension: AbTestDimension;
+  winMetric: AbTestWinMetric;
+  status?: AbTestStatus;
+  winnerVariantId?: VariantId | null;
+  significant: boolean;
+  confidence?: number;
+  /** Winner vs control on the win metric, in percentage points. */
+  lift?: number;
+  decidedAt?: string;
+  variants: AbHistoryVariant[];
+}
+
+/** A winning send hour (UTC) and the number of tests it won. */
+export interface SendHourWins {
+  hourUtc: number;
+  wins: number;
+}
+
+/** Headline aggregates across a tenant's A/B test history. */
+export interface AbHistoryAggregates {
+  totalTests: number;
+  significantTests: number;
+  subjectTests: number;
+  sendTimeTests: number;
+  /** Average lift over significant winners (percentage points). */
+  avgWinningLift?: number;
+  /** Top winning send hours (UTC) from significant send-time tests. */
+  topSendHoursUtc: SendHourWins[];
+}
+
+/** Response payload for GET /ab-test/history. */
+export interface AbHistoryResponse {
+  tests: AbHistoryTest[];
+  aggregates: AbHistoryAggregates;
+}

--- a/functions/src/api/controllers/issues.rs
+++ b/functions/src/api/controllers/issues.rs
@@ -388,6 +388,13 @@ pub async fn get_trends(event: Request) -> Result<Response<Body>, Error> {
     }
 }
 
+pub async fn get_ab_history(event: Request) -> Result<Response<Body>, Error> {
+    match handle_get_ab_history(event).await {
+        Ok(response) => Ok(response),
+        Err(e) => Ok(response::format_error_response(&e)),
+    }
+}
+
 pub async fn create_issue(event: Request) -> Result<Response<Body>, Error> {
     match handle_create_issue(event).await {
         Ok(response) => Ok(response),
@@ -651,6 +658,266 @@ async fn handle_get_trends(event: Request) -> Result<Response<Body>, AppError> {
     response::format_response(200, trends)
 }
 
+// ---------------------------------------------------------------------------
+// A/B test history (cross-issue)
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+pub struct AbHistoryVariant {
+    #[serde(rename = "variantId")]
+    variant_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    subject: Option<String>,
+    #[serde(rename = "sendAt", skip_serializing_if = "Option::is_none")]
+    send_at: Option<String>,
+    opens: i64,
+    clicks: i64,
+    deliveries: i64,
+    #[serde(rename = "openRate")]
+    open_rate: f64,
+    #[serde(rename = "clickRate")]
+    click_rate: f64,
+}
+
+#[derive(Serialize)]
+pub struct AbHistoryTest {
+    #[serde(rename = "issueNumber")]
+    issue_number: i64,
+    dimension: String,
+    #[serde(rename = "winMetric")]
+    win_metric: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    status: Option<String>,
+    #[serde(rename = "winnerVariantId", skip_serializing_if = "Option::is_none")]
+    winner_variant_id: Option<String>,
+    significant: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    confidence: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    lift: Option<f64>,
+    #[serde(rename = "decidedAt", skip_serializing_if = "Option::is_none")]
+    decided_at: Option<String>,
+    variants: Vec<AbHistoryVariant>,
+}
+
+#[derive(Serialize)]
+pub struct SendHourWins {
+    #[serde(rename = "hourUtc")]
+    hour_utc: u32,
+    wins: i64,
+}
+
+#[derive(Serialize)]
+pub struct AbHistoryAggregates {
+    #[serde(rename = "totalTests")]
+    total_tests: i64,
+    #[serde(rename = "significantTests")]
+    significant_tests: i64,
+    #[serde(rename = "subjectTests")]
+    subject_tests: i64,
+    #[serde(rename = "sendTimeTests")]
+    send_time_tests: i64,
+    #[serde(rename = "avgWinningLift", skip_serializing_if = "Option::is_none")]
+    avg_winning_lift: Option<f64>,
+    #[serde(rename = "topSendHoursUtc")]
+    top_send_hours_utc: Vec<SendHourWins>,
+}
+
+#[derive(Serialize)]
+pub struct AbHistoryResponse {
+    tests: Vec<AbHistoryTest>,
+    aggregates: AbHistoryAggregates,
+}
+
+async fn handle_get_ab_history(event: Request) -> Result<Response<Body>, AppError> {
+    let user_context = auth::get_user_context(&event)?;
+    let tenant_id = user_context
+        .tenant_id
+        .ok_or_else(|| AppError::Unauthorized("Tenant access required".to_string()))?;
+
+    let tests = query_ab_history(&tenant_id).await?;
+    let aggregates = compute_ab_history_aggregates(&tests);
+
+    response::format_response(200, AbHistoryResponse { tests, aggregates })
+}
+
+/// Reads the tenant's A/B history partition (pk = `${tenantId}#abhistory`,
+/// sk begins_with `test#`), newest issue first.
+async fn query_ab_history(tenant_id: &str) -> Result<Vec<AbHistoryTest>, AppError> {
+    let ddb_client = aws_clients::get_dynamodb_client().await;
+    let table_name = std::env::var("TABLE_NAME")
+        .map_err(|_| AppError::InternalError("TABLE_NAME not set".to_string()))?;
+
+    let pk = format!("{}#abhistory", tenant_id);
+    let mut tests = Vec::new();
+    let mut last_key: Option<HashMap<String, AttributeValue>> = None;
+
+    loop {
+        let mut builder = ddb_client
+            .query()
+            .table_name(&table_name)
+            .key_condition_expression("pk = :pk AND begins_with(sk, :prefix)")
+            .expression_attribute_values(":pk", AttributeValue::S(pk.clone()))
+            .expression_attribute_values(":prefix", AttributeValue::S("test#".to_string()))
+            .scan_index_forward(false);
+
+        if let Some(start) = last_key.take() {
+            builder = builder.set_exclusive_start_key(Some(start));
+        }
+
+        let result = builder.send().await?;
+        for item in result.items() {
+            if let Some(test) = parse_ab_history_item(item) {
+                tests.push(test);
+            }
+        }
+
+        match result.last_evaluated_key() {
+            Some(key) if !key.is_empty() => last_key = Some(key.clone()),
+            _ => break,
+        }
+    }
+
+    Ok(tests)
+}
+
+fn parse_ab_history_item(item: &HashMap<String, AttributeValue>) -> Option<AbHistoryTest> {
+    let num = |key: &str| -> Option<f64> {
+        item.get(key)
+            .and_then(|v| v.as_n().ok())
+            .and_then(|s| s.parse::<f64>().ok())
+    };
+    let text = |key: &str| -> Option<String> {
+        item.get(key)
+            .and_then(|v| v.as_s().ok())
+            .map(|s| s.to_string())
+    };
+
+    let dimension = text("dimension")?;
+    let win_metric = text("winMetric").unwrap_or_else(|| "openRate".to_string());
+    let issue_number = num("issueNumber").unwrap_or(0.0) as i64;
+
+    let variants = item
+        .get("variants")
+        .and_then(|v| v.as_l().ok())
+        .map(|list| {
+            list.iter()
+                .filter_map(|entry| entry.as_m().ok())
+                .map(parse_ab_history_variant)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    Some(AbHistoryTest {
+        issue_number,
+        dimension,
+        win_metric,
+        status: text("status"),
+        winner_variant_id: text("winnerVariantId"),
+        significant: item
+            .get("significant")
+            .and_then(|v| v.as_bool().ok())
+            .copied()
+            .unwrap_or(false),
+        confidence: num("confidence"),
+        lift: num("lift"),
+        decided_at: text("decidedAt"),
+        variants,
+    })
+}
+
+fn parse_ab_history_variant(m: &HashMap<String, AttributeValue>) -> AbHistoryVariant {
+    let num = |key: &str| -> f64 {
+        m.get(key)
+            .and_then(|v| v.as_n().ok())
+            .and_then(|s| s.parse::<f64>().ok())
+            .unwrap_or(0.0)
+    };
+    let text = |key: &str| -> Option<String> {
+        m.get(key)
+            .and_then(|v| v.as_s().ok())
+            .map(|s| s.to_string())
+    };
+
+    AbHistoryVariant {
+        variant_id: text("variantId").unwrap_or_default(),
+        subject: text("subject"),
+        send_at: text("sendAt"),
+        opens: num("opens") as i64,
+        clicks: num("clicks") as i64,
+        deliveries: num("deliveries") as i64,
+        open_rate: num("openRate"),
+        click_rate: num("clickRate"),
+    }
+}
+
+fn compute_ab_history_aggregates(tests: &[AbHistoryTest]) -> AbHistoryAggregates {
+    use chrono::Timelike;
+
+    let total_tests = tests.len() as i64;
+    let mut significant_tests = 0i64;
+    let mut subject_tests = 0i64;
+    let mut send_time_tests = 0i64;
+    let mut lift_sum = 0.0;
+    let mut lift_count = 0i64;
+    let mut hour_wins: HashMap<u32, i64> = HashMap::new();
+
+    for test in tests {
+        if test.dimension == AB_DIMENSION_SENDTIME {
+            send_time_tests += 1;
+        } else if test.dimension == AB_DIMENSION_SUBJECT {
+            subject_tests += 1;
+        }
+
+        if test.significant {
+            significant_tests += 1;
+            if let Some(lift) = test.lift {
+                lift_sum += lift;
+                lift_count += 1;
+            }
+
+            // Tally winning send hour (UTC) for significant send-time tests.
+            if test.dimension == AB_DIMENSION_SENDTIME {
+                if let Some(winner_id) = &test.winner_variant_id {
+                    if let Some(send_at) = test
+                        .variants
+                        .iter()
+                        .find(|v| &v.variant_id == winner_id)
+                        .and_then(|v| v.send_at.as_deref())
+                    {
+                        if let Ok(parsed) = chrono::DateTime::parse_from_rfc3339(send_at) {
+                            let hour = parsed.with_timezone(&chrono::Utc).hour();
+                            *hour_wins.entry(hour).or_insert(0) += 1;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    let mut top_send_hours_utc: Vec<SendHourWins> = hour_wins
+        .into_iter()
+        .map(|(hour_utc, wins)| SendHourWins { hour_utc, wins })
+        .collect();
+    top_send_hours_utc.sort_by(|a, b| b.wins.cmp(&a.wins).then(a.hour_utc.cmp(&b.hour_utc)));
+    top_send_hours_utc.truncate(3);
+
+    let avg_winning_lift = if lift_count > 0 {
+        Some(((lift_sum / lift_count as f64) * 100.0).round() / 100.0)
+    } else {
+        None
+    };
+
+    AbHistoryAggregates {
+        total_tests,
+        significant_tests,
+        subject_tests,
+        send_time_tests,
+        avg_winning_lift,
+        top_send_hours_utc,
+    }
+}
+
 async fn handle_create_issue(event: Request) -> Result<Response<Body>, AppError> {
     let user_context = auth::get_user_context(&event)?;
     let tenant_id = user_context
@@ -822,8 +1089,7 @@ async fn handle_update_issue(
 
     let is_publishing = body.status.as_deref() == Some("published");
 
-    let updated =
-        update_issue_record(&tenant_id, &issue_id, &body, ab_test, clear_ab_test).await?;
+    let updated = update_issue_record(&tenant_id, &issue_id, &body, ab_test, clear_ab_test).await?;
 
     if is_publishing {
         let published_at = chrono::Utc::now().to_rfc3339();
@@ -2939,7 +3205,76 @@ mod tests {
         // Omitted, empty, or a real object => not a clear.
         assert!(!ab_test_explicitly_cleared(b"{\"subject\":\"x\"}"));
         assert!(!ab_test_explicitly_cleared(b""));
-        assert!(!ab_test_explicitly_cleared(b"{\"abTest\":{\"dimension\":\"subject\"}}"));
+        assert!(!ab_test_explicitly_cleared(
+            b"{\"abTest\":{\"dimension\":\"subject\"}}"
+        ));
+    }
+
+    fn ab_history_test(
+        dimension: &str,
+        significant: bool,
+        winner: Option<&str>,
+        lift: Option<f64>,
+        winner_send_at: Option<&str>,
+    ) -> AbHistoryTest {
+        let variants = match winner {
+            Some(id) => vec![AbHistoryVariant {
+                variant_id: id.to_string(),
+                subject: None,
+                send_at: winner_send_at.map(|s| s.to_string()),
+                opens: 0,
+                clicks: 0,
+                deliveries: 0,
+                open_rate: 0.0,
+                click_rate: 0.0,
+            }],
+            None => vec![],
+        };
+        AbHistoryTest {
+            issue_number: 1,
+            dimension: dimension.to_string(),
+            win_metric: "openRate".to_string(),
+            status: Some(if significant { "sent" } else { "inconclusive" }.to_string()),
+            winner_variant_id: winner.map(|s| s.to_string()),
+            significant,
+            confidence: Some(0.95),
+            lift,
+            decided_at: Some("2026-06-01T00:00:00Z".to_string()),
+            variants,
+        }
+    }
+
+    #[test]
+    fn test_ab_history_aggregates() {
+        let tests = vec![
+            ab_history_test("subject", true, Some("b"), Some(10.0), None),
+            ab_history_test("subject", false, None, None, None),
+            ab_history_test(
+                "sendTime",
+                true,
+                Some("a"),
+                Some(6.0),
+                Some("2026-06-01T09:30:00Z"),
+            ),
+            ab_history_test(
+                "sendTime",
+                true,
+                Some("b"),
+                Some(8.0),
+                Some("2026-06-08T09:00:00Z"),
+            ),
+        ];
+
+        let agg = compute_ab_history_aggregates(&tests);
+        assert_eq!(agg.total_tests, 4);
+        assert_eq!(agg.significant_tests, 3);
+        assert_eq!(agg.subject_tests, 2);
+        assert_eq!(agg.send_time_tests, 2);
+        // avg lift over the 3 significant winners: (10 + 6 + 8) / 3 = 8.0
+        assert_eq!(agg.avg_winning_lift, Some(8.0));
+        // Both significant send-time winners landed in the 09:00 UTC hour.
+        assert_eq!(agg.top_send_hours_utc[0].hour_utc, 9);
+        assert_eq!(agg.top_send_hours_utc[0].wins, 2);
     }
 
     #[test]

--- a/functions/src/api/router.rs
+++ b/functions/src/api/router.rs
@@ -83,6 +83,7 @@ pub async fn route_request(event: Request) -> Result<Response<Body>, Error> {
         // Issues endpoints
         (&Method::GET, "/issues") => issues::list_issues(event).await,
         (&Method::GET, "/issues/trends") => issues::get_trends(event).await,
+        (&Method::GET, "/ab-test/history") => issues::get_ab_history(event).await,
         (&Method::POST, "/issues") => issues::create_issue(event).await,
         (&Method::POST, path)
             if path.starts_with("/issues/") && path.ends_with("/analytics/rebuild") =>
@@ -388,6 +389,7 @@ fn is_valid_api_path(path: &str) -> bool {
         // Issues paths
         || path == "/issues"
         || path == "/issues/trends"
+        || path == "/ab-test/history"
         || path.starts_with("/issues/")
         // Reports paths
         || path == "/reports"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1538,6 +1538,27 @@ paths:
         "500":
           $ref: "#/components/responses/UnknownError"
 
+  /ab-test/history:
+    get:
+      summary: Get A/B test history
+      description: >-
+        Retrieves the authenticated tenant's completed A/B tests (newest issue
+        first) along with aggregate statistics. For an empty tenant, returns an
+        empty tests array and zeroed aggregates with an empty topSendHoursUtc list.
+      tags:
+        - Issues
+      responses:
+        "200":
+          description: A/B test history and aggregate statistics
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AbHistoryResponse"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/UnknownError"
+
   /issues/{id}:
     parameters:
       - name: id
@@ -4329,3 +4350,155 @@ components:
           enum: [a, b]
           description: The variant to declare as the winner
       additionalProperties: false
+
+    AbHistoryResponse:
+      type: object
+      required:
+        - tests
+        - aggregates
+      properties:
+        tests:
+          type: array
+          items:
+            $ref: "#/components/schemas/AbHistoryTest"
+          description: Completed A/B tests, newest issue first (empty when the tenant has no tests)
+        aggregates:
+          $ref: "#/components/schemas/AbHistoryAggregates"
+          description: Aggregate statistics across all returned tests
+
+    AbHistoryTest:
+      type: object
+      required:
+        - issueNumber
+        - dimension
+        - winMetric
+        - significant
+        - variants
+      properties:
+        issueNumber:
+          type: integer
+          description: The issue number this A/B test belongs to
+        dimension:
+          type: string
+          enum: [subject, sendTime]
+          description: >-
+            The dimension that was tested. "subject" tests differ by subject line;
+            "sendTime" tests differ by send time.
+        winMetric:
+          type: string
+          enum: [openRate, clickRate]
+          description: Metric used to determine the winner
+        status:
+          type: string
+          description: Final state of the A/B test (e.g. "sent", "inconclusive")
+        winnerVariantId:
+          type: string
+          enum: [a, b]
+          nullable: true
+          description: The winning variant, or null when no winner was determined
+        significant:
+          type: boolean
+          description: Whether the result was statistically significant
+        confidence:
+          type: number
+          nullable: true
+          description: Statistical confidence threshold applied during evaluation
+        lift:
+          type: number
+          nullable: true
+          description: Lift of the winner versus control on the win metric, in percentage points
+        decidedAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: ISO 8601 timestamp when the winner was decided
+        variants:
+          type: array
+          items:
+            $ref: "#/components/schemas/AbHistoryVariant"
+          description: Per-variant statistics for this test
+
+    AbHistoryVariant:
+      type: object
+      required:
+        - variantId
+        - opens
+        - clicks
+        - deliveries
+        - openRate
+        - clickRate
+      properties:
+        variantId:
+          type: string
+          enum: [a, b]
+          description: Variant identifier these stats belong to
+        subject:
+          type: string
+          description: Subject line for this variant (present for subject-dimension tests)
+        sendAt:
+          type: string
+          format: date-time
+          description: Scheduled send time for this variant (present for send-time tests)
+        opens:
+          type: integer
+          description: Number of email opens for this variant
+        clicks:
+          type: integer
+          description: Number of link clicks for this variant
+        deliveries:
+          type: integer
+          description: Number of successful deliveries for this variant
+        openRate:
+          type: number
+          description: Open rate percentage (0-100)
+        clickRate:
+          type: number
+          description: Click rate percentage (0-100)
+
+    AbHistoryAggregates:
+      type: object
+      required:
+        - totalTests
+        - significantTests
+        - subjectTests
+        - sendTimeTests
+        - topSendHoursUtc
+      properties:
+        totalTests:
+          type: integer
+          description: Total number of A/B tests returned
+        significantTests:
+          type: integer
+          description: Number of tests with a statistically significant result
+        subjectTests:
+          type: integer
+          description: Number of subject-dimension tests
+        sendTimeTests:
+          type: integer
+          description: Number of send-time-dimension tests
+        avgWinningLift:
+          type: number
+          nullable: true
+          description: Average lift over significant winners, in percentage points
+        topSendHoursUtc:
+          type: array
+          items:
+            $ref: "#/components/schemas/SendHourWins"
+          description: >-
+            Winning send hours (UTC) from significant send-time tests, top 3
+            (empty when there are none)
+
+    SendHourWins:
+      type: object
+      required:
+        - hourUtc
+        - wins
+      properties:
+        hourUtc:
+          type: integer
+          minimum: 0
+          maximum: 23
+          description: Hour of day in UTC (0-23)
+        wins:
+          type: integer
+          description: Number of winning send-time tests at this hour


### PR DESCRIPTION
Closes #303 (part of epic #300). Exposes the cross-issue A/B history written in #302 (merged) via an API and surfaces it in the dashboard.

## API (Rust)
- **`GET /ab-test/history`** (tenant-scoped) — reads the `${tenantId}#abhistory` partition (newest issue first) and returns:
  - `tests[]`: each completed test — dimension, win metric, status, winner, lift, significance, decidedAt, and per-variant subject/sendAt + opens/clicks/deliveries + open/click rates.
  - `aggregates`: total & significant counts, subject vs send-time split, avg winning lift, and `topSendHoursUtc` (winning send hours from significant send-time tests).
- Cheap single-partition query; empty tenant ⇒ empty `tests` + zeroed aggregates.
- Wired in `router.rs` (+ `is_valid_api_path`); `openapi.yaml` documents the endpoint and the `AbHistory*` schemas.

## Dashboard
- `types/issues.ts` (`AbHistory*`), `issuesService.getAbHistory()`, and a new **`AbTestHistory`** panel — headline aggregates + a past-tests list (winner/lift/significance + per-variant rates), Apple MPP caveat, and loading/error/empty states.
- Surfaced on the **DashboardPage** analytics view (lazy-loaded, refresh-aware).

## Testing
- Rust: new aggregates unit test; full `api-router` suite **413 passing**; `rustfmt` clean; `clippy` clean (only the pre-existing `start_issue_schedule` arg-count warning).
- Dashboard: `tsc`/ESLint clean; full vitest **973 passing** (5 new `AbTestHistory` cases).
- `openapi.yaml` validates; endpoint present.

Part of #300. Built on #302. Independent of #304/#305.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KEvcSBGrCS6wBQBW7ALRax)_