### PR TITLE
Add AI A/B test suggestions to dashboard config UI (#305)

### DIFF
--- a/dashboard-ui/src/components/issues/AbTestConfig.tsx
+++ b/dashboard-ui/src/components/issues/AbTestConfig.tsx
@@ -1,13 +1,15 @@
 /* eslint-disable react-refresh/only-export-components */
-import React, { useCallback } from 'react';
-import { Mail, Clock } from 'lucide-react';
+import React, { useCallback, useState } from 'react';
+import { Mail, Clock, Sparkles, Loader2, AlertCircle } from 'lucide-react';
 import { Input } from '@/components/ui/Input';
+import { issuesService } from '@/services/issuesService';
 import type {
   AbTest,
   AbTestDimension,
   AbTestWinMetric,
   AbTestVariant,
   VariantId,
+  AbSuggestionResponse,
 } from '@/types/issues';
 
 // Defaults for a newly-enabled A/B test.
@@ -84,6 +86,31 @@ function getVariant(value: AbTest, id: VariantId): AbTestVariant {
   return (
     value.variants.find((v) => v.variantId === id) ?? { variantId: id }
   );
+}
+
+/** Formats a Date as the `YYYY-MM-DDTHH:mm` string a datetime-local expects (local time). */
+function toDatetimeLocal(date: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(
+    date.getDate()
+  )}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+/**
+ * Computes the next future occurrence of a given UTC hour as a local
+ * `datetime-local` string. Picks today if that UTC hour is still ahead of
+ * `now`, otherwise tomorrow. `now` is injectable for testing.
+ */
+export function nextOccurrenceOfUtcHour(
+  hourUtc: number,
+  now: Date = new Date()
+): string {
+  const candidate = new Date(now);
+  candidate.setUTCHours(hourUtc, 0, 0, 0);
+  if (candidate.getTime() <= now.getTime()) {
+    candidate.setUTCDate(candidate.getUTCDate() + 1);
+  }
+  return toDatetimeLocal(candidate);
 }
 
 /**
@@ -201,9 +228,18 @@ export const AbTestConfig: React.FC<AbTestConfigProps> = ({
 }) => {
   const enabled = value !== null;
 
+  // --- AI suggestions ------------------------------------------------------
+  const [suggestLoading, setSuggestLoading] = useState(false);
+  const [suggestError, setSuggestError] = useState<string | null>(null);
+  const [suggestions, setSuggestions] = useState<AbSuggestionResponse | null>(
+    null
+  );
+
   const handleToggle = useCallback(() => {
     if (disabled) return;
     if (enabled) {
+      setSuggestions(null);
+      setSuggestError(null);
       onChange(null);
     } else {
       onChange(makeDefaultAbTest('subject', scheduledAtLocal));
@@ -211,13 +247,16 @@ export const AbTestConfig: React.FC<AbTestConfigProps> = ({
   }, [disabled, enabled, onChange, scheduledAtLocal]);
 
   const handleDimensionChange = useCallback(
-    (dimension: AbTestDimension) => {
-      if (!value || value.dimension === dimension) return;
+    (nextDimension: AbTestDimension) => {
+      if (!value || value.dimension === nextDimension) return;
       // Reset variants for the new dimension but keep the test parameters.
-      const fresh = makeDefaultAbTest(dimension, scheduledAtLocal);
+      const fresh = makeDefaultAbTest(nextDimension, scheduledAtLocal);
+      // Drop any stale suggestions / errors from the previous dimension.
+      setSuggestions(null);
+      setSuggestError(null);
       onChange({
         ...value,
-        dimension,
+        dimension: nextDimension,
         variants: fresh.variants,
       });
     },
@@ -242,6 +281,43 @@ export const AbTestConfig: React.FC<AbTestConfigProps> = ({
     },
     [value, onChange]
   );
+
+  const dimension = value?.dimension;
+
+  const handleSuggest = useCallback(async () => {
+    if (!value || disabled) return;
+    setSuggestLoading(true);
+    setSuggestError(null);
+    try {
+      const a = getVariant(value, 'a');
+      const response =
+        value.dimension === 'subject'
+          ? await issuesService.getAbSuggestions({
+              dimension: 'subject',
+              subject: (a.subject ?? '').trim() || undefined,
+            })
+          : await issuesService.getAbSuggestions({ dimension: 'sendTime' });
+
+      if (response.success && response.data) {
+        setSuggestions(response.data);
+      } else {
+        setSuggestions(null);
+        setSuggestError(
+          response.error || 'Could not load suggestions. Please try again.'
+        );
+      }
+    } catch {
+      setSuggestions(null);
+      setSuggestError('Could not load suggestions. Please try again.');
+    } finally {
+      setSuggestLoading(false);
+    }
+  }, [value, disabled]);
+
+  // Suggestions are dimension-specific; clear stale ones when the dimension
+  // changes so a subject list never lingers under a send-time test.
+  const suggestionsForDimension =
+    suggestions && suggestions.dimension === dimension ? suggestions : null;
 
   // Informational minimum list size for a conclusive test.
   const minSample = value?.minSamplePerVariant ?? DEFAULT_MIN_SAMPLE_PER_VARIANT;
@@ -445,6 +521,118 @@ export const AbTestConfig: React.FC<AbTestConfigProps> = ({
                 )}
               </div>
             </div>
+
+            {/* Suggest with AI */}
+            <div className="mt-3">
+              <button
+                type="button"
+                onClick={handleSuggest}
+                disabled={disabled || suggestLoading}
+                aria-busy={suggestLoading}
+                className="inline-flex items-center gap-1.5 rounded-md border border-primary-300 bg-primary-50 px-3 py-1.5 text-xs font-medium text-primary-700 transition-colors hover:bg-primary-100 focus:outline-none focus:ring-2 focus:ring-primary-500 disabled:opacity-50 disabled:cursor-not-allowed dark:border-primary-700 dark:bg-primary-900/20 dark:text-primary-200 dark:hover:bg-primary-900/40"
+              >
+                {suggestLoading ? (
+                  <Loader2 className="w-3.5 h-3.5 animate-spin" aria-hidden="true" />
+                ) : (
+                  <Sparkles className="w-3.5 h-3.5" aria-hidden="true" />
+                )}
+                {suggestLoading
+                  ? 'Getting suggestions…'
+                  : value.dimension === 'subject'
+                    ? 'Suggest subjects with AI'
+                    : 'Suggest send times with AI'}
+              </button>
+
+              {suggestError && (
+                <div
+                  className="mt-2 flex items-start gap-2 rounded-lg border border-error-200 bg-error-50 p-3 dark:border-error-500/50 dark:bg-error-900/20"
+                  role="alert"
+                  aria-live="assertive"
+                >
+                  <AlertCircle
+                    className="w-4 h-4 mt-0.5 text-error-500 flex-shrink-0"
+                    aria-hidden="true"
+                  />
+                  <p className="text-xs text-error-700 dark:text-error-300">
+                    {suggestError}
+                  </p>
+                </div>
+              )}
+
+              {suggestionsForDimension && (
+                <div
+                  className="mt-2 rounded-lg border border-border bg-muted/40 p-3"
+                  aria-label="AI suggestions"
+                >
+                  <p className="text-xs text-muted-foreground mb-2">
+                    {suggestionsForDimension.rationale}
+                  </p>
+
+                  {suggestionsForDimension.dimension === 'subject' &&
+                  suggestionsForDimension.subjects &&
+                  suggestionsForDimension.subjects.length > 0 ? (
+                    <ul className="space-y-1.5" aria-label="Suggested subject lines">
+                      {suggestionsForDimension.subjects.map((subject, i) => (
+                        <li
+                          key={`${i}-${subject}`}
+                          className="flex items-center justify-between gap-2 rounded-md border border-border bg-background px-2 py-1.5"
+                        >
+                          <span className="text-xs text-foreground break-words">
+                            {subject}
+                          </span>
+                          <button
+                            type="button"
+                            onClick={() => updateVariant('b', { subject })}
+                            disabled={disabled}
+                            className="shrink-0 rounded-md border border-primary-300 px-2 py-0.5 text-xs font-medium text-primary-700 transition-colors hover:bg-primary-50 focus:outline-none focus:ring-2 focus:ring-primary-500 disabled:opacity-50 disabled:cursor-not-allowed dark:border-primary-700 dark:text-primary-200 dark:hover:bg-primary-900/20"
+                          >
+                            Use
+                          </button>
+                        </li>
+                      ))}
+                    </ul>
+                  ) : suggestionsForDimension.dimension === 'sendTime' &&
+                    suggestionsForDimension.sendTimes &&
+                    suggestionsForDimension.sendTimes.length > 0 ? (
+                    <ul className="space-y-1.5" aria-label="Suggested send times">
+                      {suggestionsForDimension.sendTimes.map((st, i) => (
+                        <li
+                          key={`${i}-${st.hourUtc}`}
+                          className="flex items-center justify-between gap-2 rounded-md border border-border bg-background px-2 py-1.5"
+                        >
+                          <span className="text-xs text-foreground break-words">
+                            {st.label}
+                          </span>
+                          <button
+                            type="button"
+                            onClick={() =>
+                              updateVariant('b', {
+                                sendAt: nextOccurrenceOfUtcHour(st.hourUtc),
+                              })
+                            }
+                            disabled={disabled}
+                            className="shrink-0 rounded-md border border-primary-300 px-2 py-0.5 text-xs font-medium text-primary-700 transition-colors hover:bg-primary-50 focus:outline-none focus:ring-2 focus:ring-primary-500 disabled:opacity-50 disabled:cursor-not-allowed dark:border-primary-700 dark:text-primary-200 dark:hover:bg-primary-900/20"
+                          >
+                            Use
+                          </button>
+                        </li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <p className="text-xs text-muted-foreground">
+                      No suggestions were returned. Try again later.
+                    </p>
+                  )}
+
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    {suggestionsForDimension.usedHistory
+                      ? 'Based on your past A/B tests.'
+                      : 'Based on general best practices — run more tests to personalize this.'}
+                  </p>
+                </div>
+              )}
+            </div>
+
             {errors.general && (
               <p
                 className="mt-2 text-sm text-error-600 dark:text-error-400"

--- a/dashboard-ui/src/components/issues/__tests__/AbTestConfig.test.tsx
+++ b/dashboard-ui/src/components/issues/__tests__/AbTestConfig.test.tsx
@@ -1,11 +1,21 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import {
   AbTestConfig,
   validateAbTest,
   hasAbTestErrors,
+  nextOccurrenceOfUtcHour,
 } from '../AbTestConfig';
-import type { AbTest } from '@/types/issues';
+import { issuesService } from '@/services/issuesService';
+import type { AbTest, AbSuggestionResponse } from '@/types/issues';
+
+vi.mock('@/services/issuesService', () => ({
+  issuesService: {
+    getAbSuggestions: vi.fn(),
+  },
+}));
+
+const mockedGetAbSuggestions = vi.mocked(issuesService.getAbSuggestions);
 
 const futureLocal = (offsetMinutes: number): string => {
   const d = new Date(Date.now() + offsetMinutes * 60_000);
@@ -33,6 +43,7 @@ describe('AbTestConfig', () => {
 
   beforeEach(() => {
     onChange.mockClear();
+    mockedGetAbSuggestions.mockReset();
   });
 
   it('renders the enable toggle off by default and shows no config', () => {
@@ -85,6 +96,135 @@ describe('AbTestConfig', () => {
     render(<AbTestConfig value={subjectTest()} onChange={onChange} />);
     // 2 * 500 / 0.2 = 5000
     expect(screen.getByText(/5,000/)).toBeInTheDocument();
+  });
+
+  it('requests subject suggestions and renders them with rationale + history note', async () => {
+    const response: AbSuggestionResponse = {
+      dimension: 'subject',
+      rationale: 'Shorter, curiosity-driven subjects tend to perform better.',
+      subjects: ['Subject idea one', 'Subject idea two'],
+      usedHistory: true,
+    };
+    mockedGetAbSuggestions.mockResolvedValue({ success: true, data: response });
+
+    render(<AbTestConfig value={subjectTest()} onChange={onChange} />);
+    fireEvent.click(screen.getByRole('button', { name: /suggest subjects with ai/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText('Subject idea one')).toBeInTheDocument()
+    );
+    expect(mockedGetAbSuggestions).toHaveBeenCalledWith({
+      dimension: 'subject',
+      subject: 'Hello A',
+    });
+    expect(screen.getByText(/curiosity-driven/i)).toBeInTheDocument();
+    expect(screen.getByText(/based on your past a\/b tests/i)).toBeInTheDocument();
+  });
+
+  it('accepts a subject suggestion into variant B via the Use action', async () => {
+    const response: AbSuggestionResponse = {
+      dimension: 'subject',
+      rationale: 'Try these.',
+      subjects: ['Accepted subject'],
+      usedHistory: false,
+    };
+    mockedGetAbSuggestions.mockResolvedValue({ success: true, data: response });
+
+    render(<AbTestConfig value={subjectTest()} onChange={onChange} />);
+    fireEvent.click(screen.getByRole('button', { name: /suggest subjects with ai/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText('Accepted subject')).toBeInTheDocument()
+    );
+    // Sparse-history note shows best-practices phrasing.
+    expect(screen.getByText(/general best practices/i)).toBeInTheDocument();
+
+    onChange.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: /^use$/i }));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const next = onChange.mock.calls[0][0] as AbTest;
+    const variantB = next.variants.find((v) => v.variantId === 'b');
+    expect(variantB?.subject).toBe('Accepted subject');
+    // Variant A is never overwritten.
+    const variantA = next.variants.find((v) => v.variantId === 'a');
+    expect(variantA?.subject).toBe('Hello A');
+  });
+
+  it('shows an inline error when the suggestions request fails', async () => {
+    mockedGetAbSuggestions.mockResolvedValue({
+      success: false,
+      error: 'Service unavailable',
+    });
+
+    render(<AbTestConfig value={subjectTest()} onChange={onChange} />);
+    fireEvent.click(screen.getByRole('button', { name: /suggest subjects with ai/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/service unavailable/i)
+    );
+    expect(screen.queryByLabelText(/ai suggestions/i)).not.toBeInTheDocument();
+  });
+
+  it('prefills variant B send time from a send-time suggestion', async () => {
+    const response: AbSuggestionResponse = {
+      dimension: 'sendTime',
+      rationale: 'Mornings perform well.',
+      sendTimes: [{ label: '9:00 AM ET', hourUtc: 13 }],
+      usedHistory: false,
+    };
+    mockedGetAbSuggestions.mockResolvedValue({ success: true, data: response });
+
+    const sendTimeTest: AbTest = {
+      dimension: 'sendTime',
+      variants: [
+        { variantId: 'a', sendAt: '' },
+        { variantId: 'b', sendAt: '' },
+      ],
+      winMetric: 'openRate',
+      confidence: 0.95,
+      testFraction: 0.2,
+      evaluateAfterMinutes: 240,
+      minSamplePerVariant: 500,
+    };
+
+    render(<AbTestConfig value={sendTimeTest} onChange={onChange} />);
+    fireEvent.click(
+      screen.getByRole('button', { name: /suggest send times with ai/i })
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText('9:00 AM ET')).toBeInTheDocument()
+    );
+    expect(mockedGetAbSuggestions).toHaveBeenCalledWith({ dimension: 'sendTime' });
+
+    onChange.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: /^use$/i }));
+
+    const next = onChange.mock.calls[0][0] as AbTest;
+    const variantB = next.variants.find((v) => v.variantId === 'b');
+    expect(variantB?.sendAt).toBe(nextOccurrenceOfUtcHour(13));
+    // The prefilled value is a valid datetime-local string in the future.
+    expect(variantB?.sendAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/);
+    expect(new Date(variantB!.sendAt!).getTime()).toBeGreaterThan(Date.now());
+  });
+});
+
+describe('nextOccurrenceOfUtcHour', () => {
+  it('picks today when the UTC hour is still ahead', () => {
+    const now = new Date('2026-06-23T05:00:00Z');
+    const result = nextOccurrenceOfUtcHour(13, now);
+    expect(new Date(result).getUTCHours()).toBe(13);
+    expect(new Date(result).getTime()).toBeGreaterThan(now.getTime());
+    // Same UTC day.
+    expect(new Date(result).getUTCDate()).toBe(23);
+  });
+
+  it('rolls to tomorrow when the UTC hour has already passed', () => {
+    const now = new Date('2026-06-23T18:00:00Z');
+    const result = nextOccurrenceOfUtcHour(13, now);
+    expect(new Date(result).getUTCHours()).toBe(13);
+    expect(new Date(result).getUTCDate()).toBe(24);
   });
 });
 

--- a/dashboard-ui/src/services/issuesService.ts
+++ b/dashboard-ui/src/services/issuesService.ts
@@ -10,6 +10,8 @@ import type {
   ListIssuesParams,
   VariantId,
   AbHistoryResponse,
+  AbSuggestionRequest,
+  AbSuggestionResponse,
 } from '@/types/issues';
 import type { ApiResponse } from '@/types';
 import { calculateCompositeScore } from '@/utils/analyticsCalculations';
@@ -164,6 +166,20 @@ class IssuesService {
    */
   async getAbHistory(): Promise<ApiResponse<AbHistoryResponse>> {
     return apiClient.get<AbHistoryResponse>('/ab-test/history');
+  }
+
+  /**
+   * Requests AI-generated A/B test suggestions for the given dimension. For
+   * subject tests the response carries candidate `subjects`; for send-time
+   * tests it carries candidate `sendTimes`. The `usedHistory` flag indicates
+   * whether suggestions were personalized from the tenant's past tests.
+   * @param body - The dimension plus optional subject/content context
+   * @returns Promise resolving to the suggestion response
+   */
+  async getAbSuggestions(
+    body: AbSuggestionRequest
+  ): Promise<ApiResponse<AbSuggestionResponse>> {
+    return apiClient.post<AbSuggestionResponse>('/ab-test/suggestions', body);
   }
 
   /**

--- a/dashboard-ui/src/types/issues.ts
+++ b/dashboard-ui/src/types/issues.ts
@@ -392,3 +392,35 @@ export interface AbHistoryResponse {
   tests: AbHistoryTest[];
   aggregates: AbHistoryAggregates;
 }
+
+// ---------------------------------------------------------------------------
+// A/B test AI suggestions (POST /ab-test/suggestions)
+// ---------------------------------------------------------------------------
+
+/** Request payload for POST /ab-test/suggestions. */
+export interface AbSuggestionRequest {
+  dimension: AbTestDimension;
+  /** Current/control subject line, used to seed subject-dimension suggestions. */
+  subject?: string;
+  /** Short summary of the issue's content, used to ground subject suggestions. */
+  contentSummary?: string;
+}
+
+/** A suggested send time: a human label plus its UTC hour. */
+export interface SendTimeSuggestion {
+  label: string;
+  hourUtc: number;
+}
+
+/** Response payload for POST /ab-test/suggestions. */
+export interface AbSuggestionResponse {
+  dimension: AbTestDimension;
+  /** Human-readable explanation for the suggestions. */
+  rationale: string;
+  /** Suggested subject lines (subject dimension). */
+  subjects?: string[];
+  /** Suggested send times (sendTime dimension). */
+  sendTimes?: SendTimeSuggestion[];
+  /** Whether suggestions were personalized from the tenant's past A/B tests. */
+  usedHistory: boolean;
+}


### PR DESCRIPTION
## Summary

Wires the dashboard A/B test config UI to the `POST /ab-test/suggestions` endpoint (added in #304 / PR #309) so editors can request AI-generated subject lines or send times for the dimension they are testing. This is the final sub-issue of Round-2 epic #300.

## Changes

- **`services/issuesService.ts`** — `getAbSuggestions(body)` → `POST /ab-test/suggestions`, returning `AbSuggestionResponse`.
- **`types/issues.ts`** — `AbSuggestionRequest`, `SendTimeSuggestion`, `AbSuggestionResponse`.
- **`components/issues/AbTestConfig.tsx`** — a "Suggest with AI" affordance that fetches suggestions for the active dimension:
  - Subject suggestions populate variant B's subject.
  - Send-time suggestions are converted to the next occurrence of the suggested UTC hour via the exported `nextOccurrenceOfUtcHour(hourUtc, now)` helper and formatted for the `datetime-local` input.
  - "Use" only ever fills variant B and never auto-overwrites an existing value.
- **`components/issues/__tests__/AbTestConfig.test.tsx`** — extended for the suggestion flow and the `nextOccurrenceOfUtcHour` helper.

## Testing

- `npx vitest run` → 91 files / 979 tests passing.
- `tsc` and `eslint` clean.

Closes #305.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KEvcSBGrCS6wBQBW7ALRax)_