### PR TITLE
Add TTL support for auto-deleting draft issues

### DIFF
--- a/functions/__tests__/delete-expired-draft.test.mjs
+++ b/functions/__tests__/delete-expired-draft.test.mjs
@@ -1,0 +1,78 @@
+import { jest } from '@jest/globals';
+
+const { DynamoDBClient, DeleteItemCommand } = await import('@aws-sdk/client-dynamodb');
+const { handler } = await import('../delete-expired-draft.mjs');
+
+describe('delete-expired-draft', () => {
+  let mockSend;
+  let originalTableName;
+
+  beforeEach(() => {
+    originalTableName = process.env.TABLE_NAME;
+    process.env.TABLE_NAME = 'newsletter-table';
+    mockSend = jest.fn();
+    DynamoDBClient.prototype.send = mockSend;
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.env.TABLE_NAME = originalTableName;
+  });
+
+  test('conditionally deletes the draft for the given tenant/issue', async () => {
+    mockSend.mockResolvedValue({});
+
+    const result = await handler({
+      detail: { tenantId: 'tenant-123', issueNumber: 42 }
+    });
+
+    expect(result).toEqual({ deleted: true, tenantId: 'tenant-123', issueNumber: 42 });
+    expect(mockSend).toHaveBeenCalledTimes(1);
+
+    const command = mockSend.mock.calls[0][0];
+    expect(command).toBeInstanceOf(DeleteItemCommand);
+    expect(command.input.TableName).toBe('newsletter-table');
+    expect(command.input.Key.pk.S).toBe('tenant-123#42');
+    expect(command.input.Key.sk.S).toBe('newsletter');
+    expect(command.input.ConditionExpression).toBe('#status = :draft');
+    expect(command.input.ExpressionAttributeValues[':draft'].S).toBe('draft');
+  });
+
+  test('treats issueNumber 0 as a valid issue', async () => {
+    mockSend.mockResolvedValue({});
+
+    const result = await handler({
+      detail: { tenantId: 'tenant-123', issueNumber: 0 }
+    });
+
+    expect(result.deleted).toBe(true);
+    expect(mockSend.mock.calls[0][0].input.Key.pk.S).toBe('tenant-123#0');
+  });
+
+  test('skips deletion when the issue is no longer a draft', async () => {
+    const err = new Error('conditional check failed');
+    err.name = 'ConditionalCheckFailedException';
+    mockSend.mockRejectedValue(err);
+
+    const result = await handler({
+      detail: { tenantId: 'tenant-123', issueNumber: 42 }
+    });
+
+    expect(result).toEqual({ deleted: false, reason: 'not-draft' });
+  });
+
+  test('returns without calling DynamoDB when parameters are missing', async () => {
+    const result = await handler({ detail: { tenantId: 'tenant-123' } });
+
+    expect(result).toEqual({ deleted: false, reason: 'missing-parameters' });
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  test('rethrows unexpected DynamoDB errors', async () => {
+    mockSend.mockRejectedValue(new Error('throttled'));
+
+    await expect(handler({
+      detail: { tenantId: 'tenant-123', issueNumber: 42 }
+    })).rejects.toThrow('throttled');
+  });
+});

--- a/functions/delete-expired-draft.mjs
+++ b/functions/delete-expired-draft.mjs
@@ -1,0 +1,43 @@
+import { DynamoDBClient, DeleteItemCommand } from '@aws-sdk/client-dynamodb';
+import { marshall } from '@aws-sdk/util-dynamodb';
+
+const ddb = new DynamoDBClient();
+
+/**
+ * Deletes a draft issue once its ttlSeconds has expired. Triggered by a
+ * one-time EventBridge schedule (created by POST /issues) that emits a
+ * DELETE_EXPIRED_DRAFT event. The delete is conditional on the issue still
+ * being a draft, so an issue that was published or scheduled before expiry is
+ * left untouched.
+ */
+export const handler = async (event) => {
+  const detail = event?.detail || {};
+  const { tenantId, issueNumber } = detail;
+
+  if (!tenantId || issueNumber === undefined || issueNumber === null) {
+    console.error('Missing required parameters', { tenantId, issueNumber });
+    return { deleted: false, reason: 'missing-parameters' };
+  }
+
+  const pk = `${tenantId}#${issueNumber}`;
+
+  try {
+    await ddb.send(new DeleteItemCommand({
+      TableName: process.env.TABLE_NAME,
+      Key: marshall({ pk, sk: 'newsletter' }),
+      ConditionExpression: '#status = :draft',
+      ExpressionAttributeNames: { '#status': 'status' },
+      ExpressionAttributeValues: marshall({ ':draft': 'draft' }),
+    }));
+
+    console.log('Deleted expired draft', { tenantId, issueNumber });
+    return { deleted: true, tenantId, issueNumber };
+  } catch (err) {
+    if (err.name === 'ConditionalCheckFailedException') {
+      console.log('Draft no longer eligible for deletion (status changed or already removed)', { tenantId, issueNumber });
+      return { deleted: false, reason: 'not-draft' };
+    }
+    console.error('Failed to delete expired draft', { tenantId, issueNumber, error: err.message });
+    throw err;
+  }
+};

--- a/functions/src/api/controllers/issues.rs
+++ b/functions/src/api/controllers/issues.rs
@@ -63,6 +63,12 @@ pub struct CreateIssueRequest {
     /// string) and a templateId is required.
     #[serde(rename = "contentType", skip_serializing_if = "Option::is_none")]
     content_type: Option<String>,
+    /// Optional time-to-live, in seconds, after which the draft is
+    /// automatically deleted. Only valid for drafts (the default action). A
+    /// one-time EventBridge schedule performs the deletion, so the actual
+    /// removal happens within roughly an hour of expiry.
+    #[serde(rename = "ttlSeconds", skip_serializing_if = "Option::is_none")]
+    ttl_seconds: Option<i64>,
 }
 
 #[derive(Deserialize, Serialize, Copy, Clone, PartialEq, Eq)]
@@ -75,6 +81,10 @@ enum CreateIssueAction {
 // Default value persisted/used when no contentType is supplied.
 const CONTENT_TYPE_MARKDOWN: &str = "markdown";
 const CONTENT_TYPE_JSON: &str = "json";
+
+// Upper bound for a draft's ttlSeconds (one year). Guards against absurd
+// far-future schedules while still allowing long-lived drafts.
+const MAX_TTL_SECONDS: i64 = 365 * 24 * 60 * 60;
 
 /// Normalizes a caller-supplied contentType into "markdown" or "json".
 /// Absent / empty / unknown values fall back to "markdown" for backwards
@@ -1266,6 +1276,15 @@ async fn handle_create_issue(event: Request) -> Result<Response<Body>, AppError>
     }
 
     let action = body.action.unwrap_or(CreateIssueAction::Draft);
+
+    // A ttlSeconds only makes sense for drafts — a scheduled issue is on its
+    // way to being published, so auto-expiring it would be surprising.
+    if body.ttl_seconds.is_some() && action != CreateIssueAction::Draft {
+        return Err(AppError::BadRequest(
+            "ttlSeconds is only valid for draft issues".to_string(),
+        ));
+    }
+
     let idempotency_key = get_idempotency_key(&event);
 
     let normalized_scheduled_at = normalize_scheduled_at(body.scheduled_at.as_deref())?;
@@ -1340,6 +1359,8 @@ async fn handle_create_issue(event: Request) -> Result<Response<Body>, AppError>
             &body.subject,
         )
         .await?;
+    } else if let Some(ttl_seconds) = body.ttl_seconds {
+        schedule_draft_deletion(&tenant_id, issue_number, ttl_seconds).await?;
     }
 
     if let (Some(key), Some(hash)) = (idempotency_key.as_deref(), payload_hash.as_deref()) {
@@ -1758,6 +1779,20 @@ fn validate_create_request(body: &CreateIssueRequest) -> Result<(), AppError> {
             return Err(AppError::BadRequest(
                 "A templateId is required when contentType is \"json\"".to_string(),
             ));
+        }
+    }
+
+    if let Some(ttl_seconds) = body.ttl_seconds {
+        if ttl_seconds < 1 {
+            return Err(AppError::BadRequest(
+                "ttlSeconds must be a positive integer".to_string(),
+            ));
+        }
+        if ttl_seconds > MAX_TTL_SECONDS {
+            return Err(AppError::BadRequest(format!(
+                "ttlSeconds must not exceed {} seconds",
+                MAX_TTL_SECONDS
+            )));
         }
     }
 
@@ -2547,6 +2582,7 @@ fn compute_idempotency_hash(
         "metadata": body.metadata.clone(),
         "templateId": body.template_id.clone(),
         "contentType": normalize_content_type(body.content_type.as_deref()),
+        "ttlSeconds": body.ttl_seconds,
     });
 
     let mut hasher = Sha256::new();
@@ -2756,6 +2792,80 @@ async fn start_issue_schedule(
         .map_err(|e| AppError::AwsError(format!("Failed to start schedule workflow: {}", e)))?;
 
     Ok(())
+}
+
+/// Creates a one-time EventBridge schedule that deletes the draft once its
+/// ttlSeconds elapses. The schedule fires a `DELETE_EXPIRED_DRAFT` event onto
+/// the default bus (via the universal putEvents target) which the
+/// delete-expired-draft Lambda consumes; the schedule deletes itself after
+/// firing. The deletion is conditional on the issue still being a draft, so a
+/// draft that gets published or scheduled before expiry is left untouched.
+async fn schedule_draft_deletion(
+    tenant_id: &str,
+    issue_number: i32,
+    ttl_seconds: i64,
+) -> Result<(), AppError> {
+    let scheduler = aws_clients::get_scheduler_client().await;
+    let role_arn = std::env::var("SCHEDULER_ROLE_ARN")
+        .map_err(|_| AppError::InternalError("SCHEDULER_ROLE_ARN not set".to_string()))?;
+
+    let run_at = chrono::Utc::now() + chrono::Duration::seconds(ttl_seconds);
+    let schedule_expression = format!("at({})", run_at.format("%Y-%m-%dT%H:%M:%S"));
+    let schedule_name = build_draft_ttl_schedule_name(tenant_id, issue_number);
+
+    let detail = serde_json::json!({
+        "tenantId": tenant_id,
+        "issueNumber": issue_number
+    });
+    let input = serde_json::json!({
+        "Entries": [{
+            "Source": "newsletter-service",
+            "DetailType": "DELETE_EXPIRED_DRAFT",
+            "Detail": detail.to_string(),
+            "EventBusName": "default"
+        }]
+    });
+
+    scheduler
+        .create_schedule()
+        .name(&schedule_name)
+        .group_name("newsletter")
+        .schedule_expression(&schedule_expression)
+        .action_after_completion(aws_sdk_scheduler::types::ActionAfterCompletion::Delete)
+        .flexible_time_window(
+            aws_sdk_scheduler::types::FlexibleTimeWindow::builder()
+                .mode(aws_sdk_scheduler::types::FlexibleTimeWindowMode::Off)
+                .build()
+                .map_err(|e| {
+                    AppError::InternalError(format!("Failed to build time window: {}", e))
+                })?,
+        )
+        .target(
+            aws_sdk_scheduler::types::Target::builder()
+                .arn("arn:aws:scheduler:::aws-sdk:eventbridge:putEvents")
+                .role_arn(&role_arn)
+                .input(input.to_string())
+                .build()
+                .map_err(|e| AppError::InternalError(format!("Failed to build target: {}", e)))?,
+        )
+        .send()
+        .await
+        .map_err(|e| AppError::AwsError(format!("Failed to schedule draft deletion: {}", e)))?;
+
+    Ok(())
+}
+
+/// Builds a schedule name within EventBridge Scheduler's constraints
+/// (<= 64 chars, `[0-9a-zA-Z-_.]`). The tenant id is sanitized and truncated
+/// and a millisecond timestamp keeps repeated drafts from colliding.
+fn build_draft_ttl_schedule_name(tenant_id: &str, issue_number: i32) -> String {
+    let tenant_prefix: String = tenant_id
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_')
+        .take(16)
+        .collect();
+    let suffix = chrono::Utc::now().timestamp_millis();
+    format!("draft-ttl-{}-{}-{}", tenant_prefix, issue_number, suffix)
 }
 
 async fn get_next_issue_number(tenant_id: &str) -> Result<i32, AppError> {
@@ -3304,6 +3414,7 @@ mod tests {
             metadata: None,
             template_id: template.map(|t| t.to_string()),
             content_type: content_type.map(|c| c.to_string()),
+            ttl_seconds: None,
         }
     }
 
@@ -4097,6 +4208,7 @@ mod tests {
             metadata: None,
             template_id: None,
             content_type: None,
+            ttl_seconds: None,
         };
 
         let result = validate_create_request(&request);
@@ -4114,6 +4226,7 @@ mod tests {
             metadata: None,
             template_id: None,
             content_type: None,
+            ttl_seconds: None,
         };
 
         let result = validate_create_request(&request);
@@ -4132,11 +4245,69 @@ mod tests {
             metadata: None,
             template_id: None,
             content_type: None,
+            ttl_seconds: None,
         };
 
         let result = validate_create_request(&request);
         assert!(result.is_err());
         assert!(matches!(result.unwrap_err(), AppError::BadRequest(_)));
+    }
+
+    #[test]
+    fn test_validate_create_request_ttl_seconds_valid() {
+        let mut request = create_request("# Test Content", None, None);
+        request.ttl_seconds = Some(3600);
+
+        assert!(validate_create_request(&request).is_ok());
+    }
+
+    #[test]
+    fn test_validate_create_request_ttl_seconds_zero_rejected() {
+        let mut request = create_request("# Test Content", None, None);
+        request.ttl_seconds = Some(0);
+
+        let result = validate_create_request(&request);
+        assert!(matches!(result.unwrap_err(), AppError::BadRequest(_)));
+    }
+
+    #[test]
+    fn test_validate_create_request_ttl_seconds_negative_rejected() {
+        let mut request = create_request("# Test Content", None, None);
+        request.ttl_seconds = Some(-5);
+
+        let result = validate_create_request(&request);
+        assert!(matches!(result.unwrap_err(), AppError::BadRequest(_)));
+    }
+
+    #[test]
+    fn test_validate_create_request_ttl_seconds_too_large_rejected() {
+        let mut request = create_request("# Test Content", None, None);
+        request.ttl_seconds = Some(MAX_TTL_SECONDS + 1);
+
+        let result = validate_create_request(&request);
+        assert!(matches!(result.unwrap_err(), AppError::BadRequest(_)));
+    }
+
+    #[test]
+    fn test_build_draft_ttl_schedule_name_is_valid() {
+        let name = build_draft_ttl_schedule_name("tenant-abc_123", 42);
+
+        assert!(name.starts_with("draft-ttl-tenant-abc_123-42-"));
+        assert!(name.len() <= 64);
+        assert!(name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.'));
+    }
+
+    #[test]
+    fn test_build_draft_ttl_schedule_name_sanitizes_tenant() {
+        // Characters outside the allowed scheduler-name set are stripped.
+        let name = build_draft_ttl_schedule_name("ten@nt/with#bad chars", 7);
+
+        assert!(name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.'));
+        assert!(name.contains("tenntwithbad"));
     }
 
     #[test]
@@ -4150,6 +4321,7 @@ mod tests {
             metadata: None,
             template_id: None,
             content_type: None,
+            ttl_seconds: None,
         };
 
         let result = validate_create_request(&request);
@@ -4678,6 +4850,7 @@ mod tests {
                 metadata: None,
                 template_id: None,
             content_type: None,
+                ttl_seconds: None,
             };
 
             let now = chrono::Utc::now().to_rfc3339();
@@ -4745,6 +4918,7 @@ mod tests {
                 metadata: None,
                 template_id: None,
             content_type: None,
+                ttl_seconds: None,
             };
 
             let result = validate_create_request(&request);
@@ -4765,6 +4939,7 @@ mod tests {
                 metadata: None,
                 template_id: None,
             content_type: None,
+                ttl_seconds: None,
             };
 
             let result = validate_create_request(&request);
@@ -4785,6 +4960,7 @@ mod tests {
                 metadata: None,
                 template_id: None,
             content_type: None,
+                ttl_seconds: None,
             };
 
             let result = validate_create_request(&request);

--- a/functions/src/shared/admin/aws_clients.rs
+++ b/functions/src/shared/admin/aws_clients.rs
@@ -3,6 +3,7 @@ use aws_sdk_dynamodb::Client as DynamoDbClient;
 use aws_sdk_eventbridge::Client as EventBridgeClient;
 use aws_sdk_lambda::Client as LambdaClient;
 use aws_sdk_s3::Client as S3Client;
+use aws_sdk_scheduler::Client as SchedulerClient;
 use aws_sdk_sfn::Client as SfnClient;
 use tokio::sync::OnceCell;
 
@@ -12,6 +13,7 @@ static LAMBDA_CLIENT: OnceCell<LambdaClient> = OnceCell::const_new();
 static S3_CLIENT: OnceCell<S3Client> = OnceCell::const_new();
 static EVENTBRIDGE_CLIENT: OnceCell<EventBridgeClient> = OnceCell::const_new();
 static SFN_CLIENT: OnceCell<SfnClient> = OnceCell::const_new();
+static SCHEDULER_CLIENT: OnceCell<SchedulerClient> = OnceCell::const_new();
 
 pub async fn get_dynamodb_client() -> &'static DynamoDbClient {
     DYNAMODB_CLIENT
@@ -63,6 +65,15 @@ pub async fn get_lambda_client() -> &'static LambdaClient {
         .get_or_init(|| async {
             let config = aws_config::load_from_env().await;
             LambdaClient::new(&config)
+        })
+        .await
+}
+
+pub async fn get_scheduler_client() -> &'static SchedulerClient {
+    SCHEDULER_CLIENT
+        .get_or_init(|| async {
+            let config = aws_config::load_from_env().await;
+            SchedulerClient::new(&config)
         })
         .await
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3265,6 +3265,16 @@ components:
         templateId:
           type: string
           description: Optional identifier of the template to render this issue with. When omitted, the default template is used. Required when contentType is "json".
+        ttlSeconds:
+          type: integer
+          minimum: 1
+          maximum: 31536000
+          description: >-
+            Optional time-to-live, in seconds, after which the draft is
+            automatically deleted. Only valid for drafts (the default action);
+            providing it alongside action "schedule" is rejected. Deletion is
+            performed by a one-time EventBridge schedule, so the draft is
+            removed within roughly an hour of expiry.
         abTest:
           $ref: "#/components/schemas/AbTest"
 

--- a/template.yaml
+++ b/template.yaml
@@ -1229,7 +1229,9 @@ Resources:
                 - scheduler:CreateSchedule
                 - scheduler:UpdateSchedule
                 - scheduler:DeleteSchedule
-              Resource: !Sub "arn:${AWS::Partition}:scheduler:${AWS::Region}:${AWS::AccountId}:schedule/default/sender-check-*"
+              Resource:
+                - !Sub "arn:${AWS::Partition}:scheduler:${AWS::Region}:${AWS::AccountId}:schedule/default/sender-check-*"
+                - !Sub "arn:${AWS::Partition}:scheduler:${AWS::Region}:${AWS::AccountId}:schedule/newsletter/draft-ttl-*"
             - Effect: Allow
               Action:
                 - iam:PassRole
@@ -4392,6 +4394,39 @@ Resources:
                 - newsletter-service
               detail-type:
                 - ISSUE_PUBLISHED
+
+  DeleteExpiredDraftFunction:
+    Type: AWS::Serverless::Function
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        <<: *esbuild-properties
+        EntryPoints:
+          - delete-expired-draft.mjs
+    Properties:
+      Runtime: nodejs24.x
+      CodeUri: functions
+      Handler: delete-expired-draft.handler
+      Policies:
+        - AWSLambdaBasicExecutionRole
+        - Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action: dynamodb:DeleteItem
+              Resource: !GetAtt NewsletterTable.Arn
+      Environment:
+        Variables:
+          AWS_NODEJS_CONNECTION_REUSE_ENABLED: 1
+          TABLE_NAME: !Ref NewsletterTable
+      Events:
+        DraftExpiredEvent:
+          Type: EventBridgeRule
+          Properties:
+            Pattern:
+              source:
+                - newsletter-service
+              detail-type:
+                - DELETE_EXPIRED_DRAFT
 
   CalculatePricingFunction:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
## Summary
This PR adds support for automatically deleting draft issues after a specified time-to-live (TTL) period. When creating a draft issue, callers can now provide an optional `ttlSeconds` parameter that triggers automatic deletion via an EventBridge schedule.

## Key Changes

- **API Enhancement**: Added `ttlSeconds` field to `CreateIssueRequest` struct with validation:
  - Only valid for draft issues (rejected if used with scheduled/published actions)
  - Must be a positive integer between 1 and 31,536,000 seconds (1 year)
  - Included in OpenAPI schema documentation

- **Scheduling Logic**: Implemented `schedule_draft_deletion()` function that:
  - Creates a one-time EventBridge Scheduler schedule to trigger deletion at the specified time
  - Uses EventBridge Scheduler's built-in deletion capability to clean up the schedule after firing
  - Generates sanitized schedule names with tenant ID, issue number, and timestamp to avoid collisions

- **Deletion Handler**: Created new Lambda function `delete-expired-draft` that:
  - Consumes `DELETE_EXPIRED_DRAFT` events from EventBridge
  - Conditionally deletes the draft only if it still has `status = 'draft'`
  - Gracefully handles cases where the issue was published/scheduled before expiry
  - Includes comprehensive error handling and logging

- **Infrastructure Updates**:
  - Updated IAM policies to allow scheduler operations on `draft-ttl-*` schedules
  - Added new Lambda function with DynamoDB DeleteItem permissions
  - Configured EventBridge rule to route deletion events to the new handler

- **Testing**: Added comprehensive test coverage for:
  - TTL validation (positive values, upper bounds)
  - Schedule name generation and sanitization
  - Conditional deletion behavior
  - Missing parameter handling

## Implementation Details

- Schedule names are constrained to EventBridge Scheduler's 64-character limit with alphanumeric, dash, underscore, and dot characters
- Tenant IDs are sanitized and truncated to 16 characters to fit naming constraints
- Deletion is conditional on the issue remaining in draft status, ensuring published/scheduled issues are never auto-deleted
- The actual deletion happens within roughly an hour of the scheduled time due to EventBridge Scheduler's execution model

https://claude.ai/code/session_01VL8Km1hmqjGYSweDKtQZhY