### PR TITLE
Add robotVoice shortcode + generalize body shortcodes into the snippet system

### DIFF
--- a/dashboard-ui/src/components/issues/MarkdownWysiwygEditor.tsx
+++ b/dashboard-ui/src/components/issues/MarkdownWysiwygEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react';
 import {
   MDXEditor,
   type MDXEditorMethods,
@@ -20,6 +20,11 @@ import {
 } from '@mdxeditor/editor';
 import '@mdxeditor/editor/style.css';
 import { cn } from '../../utils/cn';
+
+export interface MarkdownWysiwygEditorHandle {
+  /** Insert markdown at the current cursor position (used by the snippet inserter). */
+  insert: (markdown: string) => void;
+}
 
 export interface MarkdownWysiwygEditorProps {
   /** Current markdown value (used to seed the editor). */
@@ -71,16 +76,28 @@ const useDocumentTheme = (): 'light' | 'dark' => {
  * document and external value changes (e.g. loading an issue for edit) are
  * pushed in through the imperative ref.
  */
-export const MarkdownWysiwygEditor: React.FC<MarkdownWysiwygEditorProps> = ({
+export const MarkdownWysiwygEditor = forwardRef<
+  MarkdownWysiwygEditorHandle,
+  MarkdownWysiwygEditorProps
+>(({
   value,
   onChange,
   onBlur,
   disabled = false,
   placeholder = 'Write your newsletter content…',
   id,
-}) => {
+}, ref) => {
   const editorRef = useRef<MDXEditorMethods>(null);
   const theme = useDocumentTheme();
+
+  useImperativeHandle(ref, () => ({
+    insert: (markdown: string) => {
+      const editor = editorRef.current;
+      if (!editor) return;
+      editor.focus();
+      editor.insertMarkdown(markdown);
+    },
+  }));
 
   // Keep the editor in sync when the value is replaced from outside (initial
   // load, programmatic reset) without clobbering in-progress typing.
@@ -137,6 +154,6 @@ export const MarkdownWysiwygEditor: React.FC<MarkdownWysiwygEditorProps> = ({
       />
     </div>
   );
-};
+});
 
 MarkdownWysiwygEditor.displayName = 'MarkdownWysiwygEditor';

--- a/dashboard-ui/src/components/issues/SnippetShortcodeInserter.tsx
+++ b/dashboard-ui/src/components/issues/SnippetShortcodeInserter.tsx
@@ -1,0 +1,152 @@
+import { useCallback, useRef, useState } from 'react';
+import { Code2 } from 'lucide-react';
+import { Button } from '@/components/ui/Button';
+import { cn } from '@/utils/cn';
+import { snippetService } from '@/services/snippetService';
+import type { SnippetSummary } from '@/types/api';
+import { buildShortcodeInsertion, filterSnippetsByName } from './snippetShortcode';
+
+interface SnippetShortcodeInserterProps {
+  /** Called with the shortcode text to insert at the editor cursor. */
+  onInsert: (text: string) => void;
+  disabled?: boolean;
+}
+
+/**
+ * A small "Insert snippet" control for the issue body editor. It lists the
+ * tenant's snippets and, on selection, inserts a Hugo-style shortcode
+ * (`{{< name param="..." >}}`) scaffolded from the snippet's parameters at the
+ * editor cursor.
+ *
+ * The snippet list is fetched lazily the first time the panel is opened, so the
+ * issue form pays no cost (or network call) unless the author reaches for it.
+ */
+export function SnippetShortcodeInserter({ onInsert, disabled }: SnippetShortcodeInserterProps) {
+  const [open, setOpen] = useState(false);
+  const [snippets, setSnippets] = useState<SnippetSummary[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState('');
+  const loadingRef = useRef(false);
+
+  const loadSnippets = useCallback(async () => {
+    if (loadingRef.current) return;
+    loadingRef.current = true;
+    setLoading(true);
+    setError(null);
+    const response = await snippetService.listSnippets();
+    if (response.success) {
+      setSnippets(response.data?.snippets ?? []);
+    } else {
+      setError(response.error ?? 'Failed to load snippets');
+    }
+    setLoading(false);
+    setLoaded(true);
+    loadingRef.current = false;
+  }, []);
+
+  const toggleOpen = useCallback(() => {
+    setOpen((prev) => {
+      const next = !prev;
+      if (next && !loaded) {
+        void loadSnippets();
+      }
+      return next;
+    });
+  }, [loaded, loadSnippets]);
+
+  const handleSelect = useCallback(
+    async (summary: SnippetSummary) => {
+      // Fetch the full snippet so the inserted shortcode can scaffold its
+      // declared parameters; fall back to a bare shortcode if that read fails.
+      const response = await snippetService.getSnippet(summary.snippetId);
+      const text = response.success && response.data
+        ? buildShortcodeInsertion(response.data)
+        : buildShortcodeInsertion({ name: summary.name });
+      onInsert(text);
+      setOpen(false);
+      setQuery('');
+    },
+    [onInsert],
+  );
+
+  const filtered = filterSnippetsByName(snippets, query);
+
+  return (
+    <div className="relative">
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        onClick={toggleOpen}
+        disabled={disabled}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+      >
+        <Code2 className="w-4 h-4 mr-2" />
+        Insert snippet
+      </Button>
+
+      {open && (
+        <div
+          className={cn(
+            'absolute right-0 z-20 mt-1 w-72 rounded-md border border-border',
+            'bg-background shadow-lg',
+          )}
+        >
+          <div className="border-b border-border p-2">
+            <input
+              type="text"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search snippets…"
+              aria-label="Search snippets"
+              className={cn(
+                'w-full rounded border border-border bg-background px-2 py-1.5 text-sm',
+                'focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500',
+              )}
+            />
+          </div>
+          <div className="max-h-56 overflow-auto p-2">
+            {loading ? (
+              <p className="px-1 py-2 text-sm text-muted-foreground">Loading snippets…</p>
+            ) : error ? (
+              <p className="px-1 py-2 text-sm text-error-600" role="alert">{error}</p>
+            ) : snippets.length === 0 ? (
+              <p className="px-1 py-2 text-sm text-muted-foreground">
+                No snippets yet. Create snippets to reuse blocks in your content with{' '}
+                <code className="font-mono">{'{{< name >}}'}</code>.
+              </p>
+            ) : filtered.length === 0 ? (
+              <p className="px-1 py-2 text-sm text-muted-foreground">No snippets match “{query}”.</p>
+            ) : (
+              <ul className="space-y-1">
+                {filtered.map((snippet) => (
+                  <li key={snippet.snippetId}>
+                    <button
+                      type="button"
+                      onClick={() => void handleSelect(snippet)}
+                      title={snippet.description}
+                      className={cn(
+                        'flex w-full flex-col items-start rounded px-2 py-1.5 text-left',
+                        'hover:bg-primary-50 focus:bg-primary-50 focus:outline-none',
+                      )}
+                    >
+                      <span className="font-mono text-sm text-foreground">{snippet.name}</span>
+                      {snippet.description && (
+                        <span className="truncate text-xs text-muted-foreground">
+                          {snippet.description}
+                        </span>
+                      )}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard-ui/src/components/issues/__tests__/SnippetShortcodeInserter.test.tsx
+++ b/dashboard-ui/src/components/issues/__tests__/SnippetShortcodeInserter.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { SnippetShortcodeInserter } from '../SnippetShortcodeInserter';
+import { snippetService } from '@/services/snippetService';
+
+vi.mock('@/services/snippetService', () => ({
+  snippetService: {
+    listSnippets: vi.fn(),
+    getSnippet: vi.fn(),
+  },
+}));
+
+const mockedList = vi.mocked(snippetService.listSnippets);
+const mockedGet = vi.mocked(snippetService.getSnippet);
+
+const summary = (name: string, snippetId = name) => ({
+  snippetId,
+  name,
+  version: 1,
+  createdAt: '',
+  updatedAt: '',
+});
+
+describe('SnippetShortcodeInserter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not fetch snippets until the panel is opened', () => {
+    render(<SnippetShortcodeInserter onInsert={vi.fn()} />);
+    expect(mockedList).not.toHaveBeenCalled();
+  });
+
+  it('lazily loads the snippet list on first open', async () => {
+    mockedList.mockResolvedValue({ success: true, data: { snippets: [summary('robotVoice')], total: 1 } });
+    render(<SnippetShortcodeInserter onInsert={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /insert snippet/i }));
+
+    expect(await screen.findByText('robotVoice')).toBeInTheDocument();
+    expect(mockedList).toHaveBeenCalledTimes(1);
+  });
+
+  it('inserts a parameter-scaffolded shortcode for the chosen snippet', async () => {
+    mockedList.mockResolvedValue({ success: true, data: { snippets: [summary('robotVoice')], total: 1 } });
+    mockedGet.mockResolvedValue({
+      success: true,
+      data: {
+        snippetId: 'robotVoice',
+        name: 'robotVoice',
+        version: 1,
+        createdAt: '',
+        updatedAt: '',
+        content: '<aside>{{ text }}</aside>',
+        parameters: [{ name: 'text', type: 'textarea', required: true }],
+      },
+    });
+    const onInsert = vi.fn();
+    render(<SnippetShortcodeInserter onInsert={onInsert} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /insert snippet/i }));
+    fireEvent.click(await screen.findByText('robotVoice'));
+
+    await waitFor(() => expect(onInsert).toHaveBeenCalledWith('{{< robotVoice text="" >}}'));
+  });
+
+  it('falls back to a bare shortcode when the full snippet read fails', async () => {
+    mockedList.mockResolvedValue({ success: true, data: { snippets: [summary('divider')], total: 1 } });
+    mockedGet.mockResolvedValue({ success: false, error: 'boom' });
+    const onInsert = vi.fn();
+    render(<SnippetShortcodeInserter onInsert={onInsert} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /insert snippet/i }));
+    fireEvent.click(await screen.findByText('divider'));
+
+    await waitFor(() => expect(onInsert).toHaveBeenCalledWith('{{< divider >}}'));
+  });
+
+  it('filters the list by the search query', async () => {
+    mockedList.mockResolvedValue({
+      success: true,
+      data: { snippets: [summary('robotVoice'), summary('callout')], total: 2 },
+    });
+    render(<SnippetShortcodeInserter onInsert={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /insert snippet/i }));
+    await screen.findByText('robotVoice');
+
+    fireEvent.change(screen.getByLabelText('Search snippets'), { target: { value: 'call' } });
+
+    expect(screen.getByText('callout')).toBeInTheDocument();
+    expect(screen.queryByText('robotVoice')).not.toBeInTheDocument();
+  });
+
+  it('shows an empty state when the tenant has no snippets', async () => {
+    mockedList.mockResolvedValue({ success: true, data: { snippets: [], total: 0 } });
+    render(<SnippetShortcodeInserter onInsert={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /insert snippet/i }));
+
+    expect(await screen.findByText(/No snippets yet/i)).toBeInTheDocument();
+  });
+});

--- a/dashboard-ui/src/components/issues/__tests__/snippetShortcode.test.ts
+++ b/dashboard-ui/src/components/issues/__tests__/snippetShortcode.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { buildShortcodeInsertion, filterSnippetsByName } from '../snippetShortcode';
+import type { SnippetParameter } from '@/types/api';
+
+const param = (over: Partial<SnippetParameter> & { name: string }): SnippetParameter => ({
+  type: 'string',
+  required: false,
+  ...over,
+});
+
+describe('filterSnippetsByName', () => {
+  const snippets = [
+    { name: 'robotVoice' },
+    { name: 'callout' },
+    { name: 'codeBlock' },
+  ];
+
+  it('returns everything for an empty query', () => {
+    expect(filterSnippetsByName(snippets, '')).toHaveLength(3);
+    expect(filterSnippetsByName(snippets, '   ')).toHaveLength(3);
+  });
+
+  it('matches a case-insensitive substring on the name', () => {
+    // 'l' appears in caLLout and codeBLock but not robotVoice; order preserved.
+    expect(filterSnippetsByName(snippets, 'l')).toEqual([
+      { name: 'callout' },
+      { name: 'codeBlock' },
+    ]);
+    expect(filterSnippetsByName(snippets, 'VOICE')).toEqual([{ name: 'robotVoice' }]);
+  });
+
+  it('returns an empty list when nothing matches', () => {
+    expect(filterSnippetsByName(snippets, 'zzz')).toEqual([]);
+  });
+});
+
+describe('buildShortcodeInsertion', () => {
+  it('inserts a bare shortcode when there are no parameters', () => {
+    expect(buildShortcodeInsertion({ name: 'divider' })).toBe('{{< divider >}}');
+    expect(buildShortcodeInsertion({ name: 'divider', parameters: [] })).toBe('{{< divider >}}');
+  });
+
+  it('scaffolds every declared parameter as an empty attribute', () => {
+    const out = buildShortcodeInsertion({
+      name: 'robotVoice',
+      parameters: [param({ name: 'text', type: 'textarea', required: true })],
+    });
+    expect(out).toBe('{{< robotVoice text="" >}}');
+  });
+
+  it('seeds attributes with default values when present', () => {
+    const out = buildShortcodeInsertion({
+      name: 'callout',
+      parameters: [
+        param({ name: 'label', defaultValue: 'Note' }),
+        param({ name: 'body', required: true }),
+      ],
+    });
+    expect(out).toBe('{{< callout label="Note" body="" >}}');
+  });
+
+  it('stringifies non-string default values', () => {
+    const out = buildShortcodeInsertion({
+      name: 'spacer',
+      parameters: [param({ name: 'size', type: 'number', defaultValue: 3 })],
+    });
+    expect(out).toBe('{{< spacer size="3" >}}');
+  });
+});

--- a/dashboard-ui/src/components/issues/snippetShortcode.ts
+++ b/dashboard-ui/src/components/issues/snippetShortcode.ts
@@ -1,0 +1,58 @@
+/**
+ * Logic for inserting snippet references into the issue body as Hugo-style
+ * shortcodes (`{{< name param="..." >}}`).
+ *
+ * The issue body is Markdown, so snippets are referenced with the shortcode
+ * idiom (not the Handlebars `{{> name }}` partial syntax used inside templates).
+ * The backend body-snippet bridge resolves these at publish time. These are pure
+ * functions so they can be unit tested without a DOM.
+ */
+
+import type { Snippet, SnippetParameter, SnippetSummary } from '@/types/api';
+
+/**
+ * Filter snippet summaries by a free-text query (case-insensitive substring on
+ * the name). An empty query returns the list unchanged.
+ */
+export function filterSnippetsByName<T extends { name: string }>(
+  snippets: T[],
+  query: string,
+): T[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return snippets;
+  return snippets.filter((snippet) => snippet.name.toLowerCase().includes(q));
+}
+
+/** A snippet's default value rendered as the string that seeds an attribute. */
+function defaultAttrValue(parameter: SnippetParameter): string {
+  const { defaultValue } = parameter;
+  if (defaultValue === undefined || defaultValue === null) return '';
+  return String(defaultValue);
+}
+
+/**
+ * Build the shortcode text to insert for a snippet. Every declared parameter is
+ * scaffolded as an attribute (so the author sees the available knobs), seeded
+ * with its default value when present, otherwise left empty to fill in. A
+ * snippet with no parameters inserts as a bare `{{< name >}}`.
+ *
+ * @example
+ *   buildShortcodeInsertion({ name: 'robotVoice',
+ *     parameters: [{ name: 'text', type: 'textarea', required: true }] })
+ *   // => '{{< robotVoice text="" >}}'
+ */
+export function buildShortcodeInsertion(
+  snippet: Pick<Snippet, 'name' | 'parameters'>,
+): string {
+  const parameters = snippet.parameters ?? [];
+  if (parameters.length === 0) {
+    return `{{< ${snippet.name} >}}`;
+  }
+  const attrs = parameters
+    .map((parameter) => `${parameter.name}="${defaultAttrValue(parameter)}"`)
+    .join(' ');
+  return `{{< ${snippet.name} ${attrs} >}}`;
+}
+
+/** Narrowing helper so callers can pass either summaries or full snippets. */
+export type InsertableSnippet = SnippetSummary | Snippet;

--- a/dashboard-ui/src/pages/issues/IssueFormPage.tsx
+++ b/dashboard-ui/src/pages/issues/IssueFormPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { Eye, EyeOff, FileText, FileJson } from 'lucide-react';
 import { Input } from '@/components/ui/Input';
@@ -6,7 +6,11 @@ import { Button } from '@/components/ui/Button';
 import { useToast } from '@/components/ui/Toast';
 import { ConfirmationDialog } from '@/components/ui/ConfirmationDialog';
 import { MarkdownPreview } from '@/components/issues/MarkdownPreview';
-import { MarkdownWysiwygEditor } from '@/components/issues/MarkdownWysiwygEditor';
+import {
+  MarkdownWysiwygEditor,
+  type MarkdownWysiwygEditorHandle,
+} from '@/components/issues/MarkdownWysiwygEditor';
+import { SnippetShortcodeInserter } from '@/components/issues/SnippetShortcodeInserter';
 import { TemplateJsonEditor } from '@/components/issues/TemplateJsonEditor';
 import {
   AbTestConfig,
@@ -110,6 +114,7 @@ export const IssueFormPage: React.FC = () => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isLoadingSample, setIsLoadingSample] = useState(false);
   const [showPreview, setShowPreview] = useState(false);
+  const editorRef = useRef<MarkdownWysiwygEditorHandle>(null);
   const [showCancelDialog, setShowCancelDialog] = useState(false);
   const [existingIssue, setExistingIssue] = useState<Issue | null>(null);
   const [isFormDisabled, setIsFormDisabled] = useState(false);
@@ -742,29 +747,37 @@ export const IssueFormPage: React.FC = () => {
                   <label htmlFor="content-editor" className="block text-sm font-medium text-foreground">
                     Content *
                   </label>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => setShowPreview(!showPreview)}
-                    disabled={isFormDisabled}
-                    aria-label={showPreview ? 'Hide markdown preview' : 'Show markdown preview'}
-                    aria-pressed={showPreview}
-                  >
-                    {showPreview ? (
-                      <>
-                        <EyeOff className="w-4 h-4 mr-2" />
-                        <span className="hidden sm:inline">Hide Preview</span>
-                        <span className="sm:hidden">Hide</span>
-                      </>
-                    ) : (
-                      <>
-                        <Eye className="w-4 h-4 mr-2" />
-                        <span className="hidden sm:inline">Show Preview</span>
-                        <span className="sm:hidden">Preview</span>
-                      </>
+                  <div className="flex items-center gap-1">
+                    {!showPreview && (
+                      <SnippetShortcodeInserter
+                        onInsert={(text) => editorRef.current?.insert(text)}
+                        disabled={isFormDisabled}
+                      />
                     )}
-                  </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setShowPreview(!showPreview)}
+                      disabled={isFormDisabled}
+                      aria-label={showPreview ? 'Hide markdown preview' : 'Show markdown preview'}
+                      aria-pressed={showPreview}
+                    >
+                      {showPreview ? (
+                        <>
+                          <EyeOff className="w-4 h-4 mr-2" />
+                          <span className="hidden sm:inline">Hide Preview</span>
+                          <span className="sm:hidden">Hide</span>
+                        </>
+                      ) : (
+                        <>
+                          <Eye className="w-4 h-4 mr-2" />
+                          <span className="hidden sm:inline">Show Preview</span>
+                          <span className="sm:hidden">Preview</span>
+                        </>
+                      )}
+                    </Button>
+                  </div>
                 </div>
 
                 {showPreview ? (
@@ -779,6 +792,7 @@ export const IssueFormPage: React.FC = () => {
                   </div>
                 ) : (
                   <MarkdownWysiwygEditor
+                    ref={editorRef}
                     id="content-editor"
                     placeholder="Write your newsletter content…"
                     value={formData.content}

--- a/docs/reusable-content-components.md
+++ b/docs/reusable-content-components.md
@@ -1,0 +1,162 @@
+# Reusable Content Components (Snippets in Templates and Issue Bodies)
+
+**Status:** Proposed
+**Date:** 2026-06-25
+**Context:** Generalizing one-off body shortcodes (e.g. `robotVoice`) into the
+existing snippet system so reusable blocks can be authored once and used by any
+tenant — including future third-party customers.
+
+## Background
+
+The service renders newsletter HTML from two distinct layers:
+
+- **The template** — the email skeleton (header, the sections loop, the sponsor
+  block, footer). It is Handlebars, customizable per tenant, and edited in the
+  dashboard template builder.
+- **The issue body** — the per-issue Markdown an author writes. It is converted
+  to HTML in `functions/parse-md-to-json.mjs` (showdown) and injected into the
+  template as raw `{{{ this.text }}}`.
+
+Two reuse mechanisms have grown up across these layers:
+
+| | Authored in | Rendered | Repeatable inline? | Managed how |
+|---|---|---|---|---|
+| **Snippet** (`{{> name }}`) | The template skeleton | Once at publish, against issue `data` | No — fixed slots | Dashboard UI (CRUD, typed params, versioning) |
+| **Shortcode** (`{{< name attr="x" >}}`) | The issue body Markdown | In `parse-md-to-json`, before the template renders | Yes — 0..N, author-supplied | Hardcoded transforms in `parse-md-to-json.mjs` |
+
+Snippets are the mature mechanism: tenant-scoped Handlebars partials with a typed
+parameter schema (`string | number | boolean | select | textarea | url`, each
+with `required`, `defaultValue`, `options`, `description`), CRUD API
+(`functions/src/api/controllers/snippets.rs`), storage, a builder UI with
+autocomplete, and a JS-send / Rust-preview parity harness
+(`__tests__/fixtures/render-conformance.json`).
+
+Shortcodes are the immature mechanism: each block type (sponsor, social, vote,
+and now `robotVoice`) is a bespoke transform compiled into the parser. Adding a
+block requires a code change and deploy.
+
+`robotVoice` (`{{< robotVoice text="..." >}}`) is the trigger for this doc. It is
+inherently a **body** concern — an author sprinkles it through their prose 0..N
+times, with different text each time — which is exactly what the shortcode layer
+does and exactly what the snippet layer, today, does not.
+
+## The problem, stated precisely
+
+We want reusable, parameterized blocks like `robotVoice` to be **defined once in
+the UI** (no code deploy per block) and **usable inline in issue bodies**, 0..N
+times. The snippet model already supports "defined once in the UI with typed
+parameters." What it does not support is invocation from the issue body: the body
+is converted to HTML and injected as raw `{{{ text }}}`, and Handlebars does not
+recursively process data values, so a `{{> robotVoice }}` placed in body content
+renders literally.
+
+So the missing capability is **a bridge that lets the issue body invoke
+snippets** — not a new component model.
+
+A secondary question surfaced while scoping this: the body shortcode syntax
+(`{{< name >}}`) and the template partial syntax (`{{> name }}`) differ. Since
+one is a trivial transform of the other, should we unify on one, or support both?
+
+## Decision
+
+### 1. The snippet is the one durable concept; syntax is a thin front-end
+
+A "reusable component" is a **snippet** — tenant-defined, parameterized,
+versioned. That is the asset a user (including a future third-party customer)
+learns once. The `{{< >}}` vs `{{> }}` syntax is just a parser front-end that
+compiles down to "render snippet X with params Y." We already built the durable,
+expensive part (the typed-parameter schema). Syntax is cheap.
+
+### 2. Each surface uses its own native idiom — not two idioms per surface
+
+We will **not** offer two interchangeable syntaxes on the same surface. Instead,
+each surface references the same snippet using the idiom native to that surface:
+
+- **Templates** are Handlebars (`{{#each}}`, `{{#if}}`, `{{ title }}`). There,
+  `{{> snippet }}` is native. We do not add a second syntax to templates.
+- **Issue bodies** are Markdown/prose. There, a shortcode
+  `{{< snippet param="..." >}}` is native — friendly, CMS-flavored
+  (Hugo/WordPress/MDX all look like this), and it does not leak the templating
+  engine to a non-technical author.
+
+This is not "two competing syntaxes for one thing." It is one component concept
+referenced idiomatically per surface, because the surfaces are genuinely
+different languages. The mental model stays clean: *components live in one place;
+in the template you reference them the Handlebars way, in the body the shortcode
+way, because the body is prose.* We build exactly one transform — shortcode →
+snippet render — because templates already speak snippets.
+
+We may quietly accept `{{> name }}` in the body as a lenient alias for
+copy-paste, but it is **not** documented as a parallel path.
+
+### 3. Parameter resolution happens once, centrally — this is the real work
+
+The syntax choice is not load-bearing. The decision that matters for a
+third-party user is **parameter semantics at render time**: applying
+`defaultValue`, enforcing `required`, and coercing by `type` (number/boolean/
+select). Today the parameter schema is only builder metadata; the renderer
+ignores it. We will implement parameter resolution **once, centrally**, so a
+snippet behaves identically whether invoked from a template or a body shortcode.
+
+### 4. Hugo-website parity stays a perk, not a constraint
+
+The owner's body Markdown is also published to a Hugo site, where `{{< robotVoice >}}`
+is a real Hugo shortcode. Keeping `{{< >}}` as the body idiom makes website +
+email authoring identical — but that is a *free benefit* of choosing the
+Markdown-native idiom, not a requirement a third-party customer inherits.
+
+## Consequences
+
+### Forward-compatible with a no-code builder
+
+Mass-market newsletter tools (Beehiiv, Substack, Mailchimp) insert blocks via UI
+and store a structured tree — users type no syntax at all. The typed-parameter
+snippet schema is already the metadata such an inserter needs: a `select` param
+becomes a dropdown, a `textarea` a text box, `required`/`default` drive
+validation. A future visual builder sits **on top of** the snippet model, with
+the text syntax as the escape hatch / interchange format. Whatever syntax we pick
+now is therefore not locked in.
+
+### What needs to be built (backend-light)
+
+1. **Thread `tenantId` into the parser.** `ParseMdToJson`'s payload in
+   `state-machines/stage-issue.asl.json` does not pass it today; `$$.Execution.Input.tenant.id`
+   is already available (the Publish step uses it). One-line ASL change.
+2. **Load the tenant's snippets** in `parse-md-to-json` — reuse the existing
+   `snippet#{tenantId}` GSI1 query from `publish-issue.mjs` / `snippets.rs`.
+3. **Resolve body shortcodes against snippets.** Scan each section for
+   `{{< name attr="..." >}}`; if `name` matches a snippet, parse attrs into a
+   data object, apply the central parameter resolution (defaults / required /
+   coercion), and render the snippet via the shared `renderWithSnippets` so it
+   matches the rest of the pipeline. Use a placeholder swap so showdown does not
+   mangle the injected HTML (same technique as the current `robotVoice` block).
+4. **Migrate `robotVoice` to a seeded snippet**, keeping the hardcoded block as a
+   fallback when no same-named tenant snippet exists. New block types then need
+   zero code deploys.
+
+### Rendering boundaries / parity
+
+Body shortcodes render only in the JS path (`parse-md-to-json`); the Hugo site is
+the website's renderer. There is no Rust preview of *body* content, so this does
+not disturb the template preview/parity harness (`template_render.rs` ⇄
+`render-conformance.json`), which covers template rendering only.
+
+### What we explicitly avoid
+
+- Two interchangeable syntaxes on the same surface (doc burden, "which is
+  canonical?" support load).
+- Treating the syntax transform as the important decision. It is incidental; the
+  parameter-resolution layer and the schema are the assets.
+
+## Open questions for v1 scope
+
+- **Override model:** does a tenant snippet *override* a same-named hardcoded
+  block, or do we fully replace hardcoded blocks (sponsor included) with seeded
+  system snippets?
+- **v1 surface area:** ship just `robotVoice`-style param blocks, or the general
+  "any snippet usable in body" bridge (which also lets us retire the per-shortcode
+  code in `parse-md-to-json`)?
+- **Content-editor autocomplete:** the current autocomplete
+  (`dashboard-ui/src/pages/templates/builder/autocomplete.ts`) targets the
+  template builder. A body/issue editor would want its own shortcode
+  autocomplete sourced from the same snippet list.

--- a/docs/reusable-content-components.md
+++ b/docs/reusable-content-components.md
@@ -1,6 +1,6 @@
 # Reusable Content Components (Snippets in Templates and Issue Bodies)
 
-**Status:** Proposed
+**Status:** Accepted (v1 scope decided 2026-06-25)
 **Date:** 2026-06-25
 **Context:** Generalizing one-off body shortcodes (e.g. `robotVoice`) into the
 existing snippet system so reusable blocks can be authored once and used by any
@@ -86,8 +86,9 @@ in the template you reference them the Handlebars way, in the body the shortcode
 way, because the body is prose.* We build exactly one transform — shortcode →
 snippet render — because templates already speak snippets.
 
-We may quietly accept `{{> name }}` in the body as a lenient alias for
-copy-paste, but it is **not** documented as a parallel path.
+The body accepts **only** `{{< name param="..." >}}`. A `{{> name }}` placed in
+body content is not resolved (it is not the body idiom) — there is one obvious
+way to reference a snippet from prose. (Decided: strict, no lenient alias.)
 
 ### 3. Parameter resolution happens once, centrally — this is the real work
 
@@ -148,15 +149,27 @@ not disturb the template preview/parity harness (`template_render.rs` ⇄
 - Treating the syntax transform as the important decision. It is incidental; the
   parameter-resolution layer and the schema are the assets.
 
-## Open questions for v1 scope
+## Resolved decisions (v1)
 
-- **Override model:** does a tenant snippet *override* a same-named hardcoded
-  block, or do we fully replace hardcoded blocks (sponsor included) with seeded
-  system snippets?
-- **v1 surface area:** ship just `robotVoice`-style param blocks, or the general
-  "any snippet usable in body" bridge (which also lets us retire the per-shortcode
-  code in `parse-md-to-json`)?
-- **Content-editor autocomplete:** the current autocomplete
-  (`dashboard-ui/src/pages/templates/builder/autocomplete.ts`) targets the
-  template builder. A body/issue editor would want its own shortcode
-  autocomplete sourced from the same snippet list.
+These were settled on 2026-06-25 and define the v1 build:
+
+- **Surface area — general bridge.** Build the generic "any snippet usable in
+  body" resolver in `parse-md-to-json` and migrate `robotVoice` onto it.
+  `sponsor` / `social` / `vote` remain as bespoke transforms for now but can be
+  retired onto the bridge later. (Avoids a throwaway `robotVoice`-only path.)
+- **Override model — override with fallback.** A tenant snippet whose name
+  matches a block overrides it; when no such snippet exists, the hardcoded block
+  renders. Nothing breaks for tenants who have not defined snippets, and the
+  committed `robotVoice` HTML becomes the seeded default.
+- **Body syntax — `{{< >}}` only, strict.** No lenient `{{> }}` alias in the
+  body (see decision #2 above).
+- **Content-editor autocomplete — in v1.** The issue/body editor gets its own
+  shortcode autocomplete sourced from the snippet list, alongside the rendering
+  bridge. Mirrors the template builder's autocomplete
+  (`dashboard-ui/src/pages/templates/builder/autocomplete.ts`) but for the
+  `{{< >}}` body idiom.
+
+## Still to decide (later)
+
+- Whether and when to retire `sponsor` / `social` / `vote` onto the bridge once
+  the general resolver has proven out.

--- a/functions/__tests__/parse-md-to-json.test.mjs
+++ b/functions/__tests__/parse-md-to-json.test.mjs
@@ -1,0 +1,121 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+
+// parse-md-to-json reads sponsor/author via GetItem and snippets via Query on
+// GSI1. We mock the DynamoDB client so the handler runs without AWS, returning
+// the snippet set per test via the Query branch.
+
+let handler;
+let ddbSend;
+
+const loadIsolated = async (snippets = []) => {
+  await jest.isolateModulesAsync(async () => {
+    ddbSend = jest.fn((command) => {
+      if (command.__type === 'Query') {
+        return Promise.resolve({ Items: snippets.map((s) => ({ __snippet: s })) });
+      }
+      // GetItem for sponsor/author — not exercised by these tests.
+      return Promise.resolve({});
+    });
+
+    jest.unstable_mockModule('@aws-sdk/client-dynamodb', () => ({
+      DynamoDBClient: jest.fn(() => ({ send: ddbSend })),
+      GetItemCommand: jest.fn((params) => ({ __type: 'GetItem', ...params })),
+      QueryCommand: jest.fn((params) => ({ __type: 'Query', ...params })),
+    }));
+
+    jest.unstable_mockModule('@aws-sdk/util-dynamodb', () => ({
+      marshall: jest.fn((obj) => obj),
+      // Items are wrapped as { __snippet } so unmarshall just unwraps them.
+      unmarshall: jest.fn((item) => item.__snippet ?? item),
+    }));
+
+    ({ handler } = await import('../parse-md-to-json.mjs'));
+  });
+};
+
+const md = (body) => [
+  '---',
+  'title: Test Issue',
+  'date: 2026-06-25',
+  '---',
+  '',
+  '### A Section',
+  body,
+  '',
+].join('\n');
+
+const sectionText = async (result) => result.data.content.sections[0].text;
+
+describe('parse-md-to-json body snippet bridge', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it('renders robotVoice from the hardcoded fallback when no snippet exists', async () => {
+    await loadIsolated([]);
+    const result = await handler({
+      content: md('Intro.\n\n{{< robotVoice text="A *dry* summary." >}}\n\nOutro.'),
+      issueId: 5,
+      tenantId: 'tenant-1',
+    });
+    const text = await sectionText(result);
+    expect(text).toContain('robot voice');
+    expect(text).toContain('404 &middot; personality not found');
+    // Inline markdown inside the attribute is rendered.
+    expect(text).toContain('<em>dry</em>');
+    expect(text).not.toContain('{{<');
+  });
+
+  it('lets a tenant snippet override the hardcoded block', async () => {
+    await loadIsolated([
+      {
+        name: 'robotVoice',
+        content: '<aside class="rv">{{ text }}</aside>',
+        parameters: [{ name: 'text', type: 'textarea', required: true }],
+      },
+    ]);
+    const result = await handler({
+      content: md('{{< robotVoice text="hello" >}}'),
+      issueId: 5,
+      tenantId: 'tenant-1',
+    });
+    const text = await sectionText(result);
+    expect(text).toContain('<aside class="rv">hello</aside>');
+    // The hardcoded version is not used.
+    expect(text).not.toContain('404 &middot; personality not found');
+  });
+
+  it('renders an arbitrary tenant snippet used 0..N times with resolved params', async () => {
+    await loadIsolated([
+      {
+        name: 'callout',
+        content: '<div class="c">{{ label }}: {{ body }}</div>',
+        parameters: [
+          { name: 'label', type: 'string', defaultValue: 'Note' },
+          { name: 'body', type: 'string', required: true },
+        ],
+      },
+    ]);
+    const result = await handler({
+      content: md('{{< callout body="first" >}}\n\nmiddle\n\n{{< callout label="Tip" body="second" >}}'),
+      issueId: 5,
+      tenantId: 'tenant-1',
+    });
+    const text = await sectionText(result);
+    // First uses the default label; second overrides it.
+    expect(text).toContain('<div class="c">Note: first</div>');
+    expect(text).toContain('<div class="c">Tip: second</div>');
+  });
+
+  it('leaves unknown shortcodes untouched and works with no tenantId', async () => {
+    await loadIsolated([]);
+    const result = await handler({
+      content: md('Body with {{< unknownThing foo="bar" >}} inline.'),
+      issueId: 5,
+    });
+    const text = await sectionText(result);
+    expect(text).toContain('{{< unknownThing foo="bar" >}}');
+    // No snippet query is issued when there is no tenant.
+    expect(ddbSend).not.toHaveBeenCalledWith(expect.objectContaining({ __type: 'Query' }));
+  });
+});

--- a/functions/__tests__/render-parity.test.mjs
+++ b/functions/__tests__/render-parity.test.mjs
@@ -1,0 +1,80 @@
+import { jest, describe, it, expect } from '@jest/globals';
+import { renderWithSnippets } from '../utils/render-template.mjs';
+import { resolveParameters } from '../utils/snippet-parameters.mjs';
+
+// Parity guard: a snippet invoked from the issue BODY (the `{{< name >}}`
+// shortcode bridge in parse-md-to-json) must render identically to the same
+// snippet invoked from a TEMPLATE (`{{> name }}` via renderWithSnippets), given
+// the same resolved parameters. This is the body-side analogue of the
+// JS-send / Rust-preview conformance harness, locking the "one component,
+// idiomatic per surface" guarantee for issue-body usage.
+
+let handler;
+
+const loadIsolated = async (snippets = []) => {
+  await jest.isolateModulesAsync(async () => {
+    const ddbSend = jest.fn((command) => {
+      if (command.__type === 'Query') {
+        return Promise.resolve({ Items: snippets.map((s) => ({ __snippet: s })) });
+      }
+      return Promise.resolve({});
+    });
+
+    jest.unstable_mockModule('@aws-sdk/client-dynamodb', () => ({
+      DynamoDBClient: jest.fn(() => ({ send: ddbSend })),
+      GetItemCommand: jest.fn((params) => ({ __type: 'GetItem', ...params })),
+      QueryCommand: jest.fn((params) => ({ __type: 'Query', ...params })),
+    }));
+
+    jest.unstable_mockModule('@aws-sdk/util-dynamodb', () => ({
+      marshall: jest.fn((obj) => obj),
+      unmarshall: jest.fn((item) => item.__snippet ?? item),
+    }));
+
+    ({ handler } = await import('../parse-md-to-json.mjs'));
+  });
+};
+
+const md = (body) => [
+  '---',
+  'title: Parity',
+  'date: 2026-06-25',
+  '---',
+  '',
+  '### Section',
+  body,
+  '',
+].join('\n');
+
+const snippet = {
+  name: 'callout',
+  content: '<div class="c"><strong>{{ label }}</strong>: {{ body }}</div>',
+  parameters: [
+    { name: 'label', type: 'string', defaultValue: 'Note' },
+    { name: 'body', type: 'string', required: true },
+  ],
+};
+
+describe('body / template snippet render parity', () => {
+  it('renders the same HTML from the body bridge and the template path', async () => {
+    await loadIsolated([snippet]);
+
+    // Body path: the shortcode (with `label` omitted so the default applies).
+    const result = await handler({
+      content: md('{{< callout body="hello" >}}'),
+      issueId: 9,
+      tenantId: 'tenant-1',
+    });
+    const bodyHtml = result.data.content.sections[0].text;
+
+    // Template path: the same snippet invoked as a partial, against the same
+    // parameters resolved by the shared resolver.
+    const { values } = resolveParameters(snippet.parameters, { body: 'hello' });
+    const templateHtml = renderWithSnippets('{{> callout }}', values, [snippet]);
+
+    // The template path produces exactly the snippet block...
+    expect(templateHtml).toBe('<div class="c"><strong>Note</strong>: hello</div>');
+    // ...and the body path embeds that identical block in the section.
+    expect(bodyHtml).toContain(templateHtml);
+  });
+});

--- a/functions/parse-md-to-json.mjs
+++ b/functions/parse-md-to-json.mjs
@@ -90,11 +90,27 @@ const processSection = (section, sponsor) => {
   const newlineIndex = section.indexOf('\n');
   const header = section.substring(0, newlineIndex);
   let content = section.substring(newlineIndex + 1).trim();
+
+  // Pull robotVoice shortcodes out before markdown conversion so the inline
+  // markdown in the `text` attribute isn't mangled. Each occurrence (0..N) is
+  // swapped for an inert placeholder that survives showdown, then expanded
+  // after the rest of the section has been converted to HTML.
+  const robotVoices = [];
+  content = content.replace(/\{\{<\s*robotVoice\s+text="([^"]+)"(?:\s+[^>]*)?>\}\}/g, (_match, text) => {
+    const placeholder = `%%ROBOTVOICE${robotVoices.length}%%`;
+    robotVoices.push(text);
+    return placeholder;
+  });
+
   content = content.replace(/\n/g, '<br>');
   let html = convertToHtml(content);
   if (html.includes('{{< sponsor >}}')) {
     html = html.replace(/\{\{< sponsor >\}\}/g, formatSponsorAd(sponsor.ad));
   }
+
+  robotVoices.forEach((text, index) => {
+    html = html.replace(`%%ROBOTVOICE${index}%%`, formatRobotVoice(text));
+  });
 
   return {
     header,
@@ -140,6 +156,21 @@ const convertToHtml = (data, removeOuterParagraph = false) => {
   }
 
   return html;
+};
+
+const formatRobotVoice = (text) => {
+  const formattedText = convertToHtml(text, true);
+  return `<div style="margin:24px 0;border:1px solid #CFD6DC;border-radius:5px;padding:16px;background:#FFFFFF;font-family:ui-monospace,'SF Mono','Cascadia Code',Consolas,'Courier New',monospace;">
+  <div style="margin:-27px 0 8px 0;">
+    <span style="background:#FFFFFF;padding:0 8px;font-size:10px;letter-spacing:.18em;text-transform:uppercase;color:#8A929A;">robot voice</span>
+  </div>
+  <div style="font-size:14px;line-height:1.6;color:#54606A;">
+    ${formattedText}
+  </div>
+  <div style="text-align:right;margin:8px 0 -28px 0;">
+    <span style="background:#FFFFFF;padding:0 8px;font-size:11px;letter-spacing:.03em;color:#9099A1;">404 &middot; personality not found</span>
+  </div>
+</div>`;
 };
 
 const formatSponsorAd = (ad) => {

--- a/functions/parse-md-to-json.mjs
+++ b/functions/parse-md-to-json.mjs
@@ -1,16 +1,37 @@
 
 import showdown from 'showdown';
 import frontmatter from '@github-docs/frontmatter';
-import { DynamoDBClient, GetItemCommand } from '@aws-sdk/client-dynamodb';
+import { DynamoDBClient, GetItemCommand, QueryCommand } from '@aws-sdk/client-dynamodb';
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
+import { renderWithSnippets } from './utils/render-template.mjs';
+import { resolveParameters } from './utils/snippet-parameters.mjs';
 
 const ddb = new DynamoDBClient();
 const converter = new showdown.Converter();
+
+// Body shortcodes that are handled by their own bespoke transforms elsewhere
+// (sponsor inline, social in tip-of-the-week, vote injected upstream) are NOT
+// routed through the generic snippet bridge.
+const RESERVED_SHORTCODES = new Set(['sponsor', 'social', 'vote']);
+
+// Hardcoded body blocks that render even when a tenant has not defined a snippet
+// of the same name. A matching tenant snippet overrides these (see the decision
+// doc: docs/reusable-content-components.md).
+const HARDCODED_BODY_BLOCKS = new Set(['robotVoice']);
+
+// Matches a body shortcode `{{< name attr="x" attr2="y" >}}`, capturing the
+// snippet name and its (well-formed) attribute list. The name follows the same
+// rule as snippet names (start with a letter; letters, digits, _ and -).
+const BODY_SHORTCODE_RE =
+  /\{\{<\s*([a-zA-Z][a-zA-Z0-9_-]*)((?:\s+[a-zA-Z][a-zA-Z0-9_-]*="[^"]*")*)\s*>\}\}/g;
+const ATTRIBUTE_RE = /([a-zA-Z][a-zA-Z0-9_-]*)="([^"]*)"/g;
 
 export const handler = async (state) => {
   const newsletter = frontmatter(state.content);
   const sponsor = await getSponsorDetails(newsletter.data.sponsor, newsletter.data.sponsor_description);
   const author = await getAuthor(newsletter.data.author);
+  const snippets = await getSnippets(state.tenantId);
+  const snippetsByName = new Map(snippets.filter(s => s.name).map(s => [s.name, s]));
   const issueNumber = Number(state.issueId);
 
   if (!Number.isFinite(issueNumber) || issueNumber < 1) {
@@ -18,7 +39,7 @@ export const handler = async (state) => {
   }
 
   let sections = newsletter.content.split('### ');
-  sections = sections.map(s => processSection(s, sponsor));
+  sections = sections.map(s => processSection(s, sponsor, snippets, snippetsByName));
   sections = sections.filter(ps => ps.header);
 
   if (sponsor) {
@@ -86,37 +107,89 @@ export const handler = async (state) => {
   };
 };
 
-const processSection = (section, sponsor) => {
+const processSection = (section, sponsor, snippets = [], snippetsByName = new Map()) => {
   const newlineIndex = section.indexOf('\n');
   const header = section.substring(0, newlineIndex);
-  let content = section.substring(newlineIndex + 1).trim();
+  const rawContent = section.substring(newlineIndex + 1).trim().replace(/\n/g, '<br>');
 
-  // Pull robotVoice shortcodes out before markdown conversion so the inline
-  // markdown in the `text` attribute isn't mangled. Each occurrence (0..N) is
-  // swapped for an inert placeholder that survives showdown, then expanded
-  // after the rest of the section has been converted to HTML.
-  const robotVoices = [];
-  content = content.replace(/\{\{<\s*robotVoice\s+text="([^"]+)"(?:\s+[^>]*)?>\}\}/g, (_match, text) => {
-    const placeholder = `%%ROBOTVOICE${robotVoices.length}%%`;
-    robotVoices.push(text);
+  // Pull body shortcodes (`{{< name attr="x" >}}`, 0..N) out before markdown
+  // conversion so inline markdown inside attribute values isn't mangled. Each is
+  // swapped for an inert placeholder that survives showdown, then expanded after
+  // the rest of the section converts to HTML. A separate working copy is used so
+  // `raw` stays clean for callers that re-render from it (tip-of-the-week,
+  // last words).
+  const blocks = [];
+  const working = rawContent.replace(BODY_SHORTCODE_RE, (match, name, attrString) => {
+    if (RESERVED_SHORTCODES.has(name)) return match;
+    if (!snippetsByName.has(name) && !HARDCODED_BODY_BLOCKS.has(name)) return match;
+    const placeholder = `%%BODYBLOCK${blocks.length}%%`;
+    blocks.push({ name, attrs: parseAttributes(attrString) });
     return placeholder;
   });
 
-  content = content.replace(/\n/g, '<br>');
-  let html = convertToHtml(content);
+  let html = convertToHtml(working);
   if (html.includes('{{< sponsor >}}')) {
     html = html.replace(/\{\{< sponsor >\}\}/g, formatSponsorAd(sponsor.ad));
   }
 
-  robotVoices.forEach((text, index) => {
-    html = html.replace(`%%ROBOTVOICE${index}%%`, formatRobotVoice(text));
+  blocks.forEach((block, index) => {
+    html = html.replace(`%%BODYBLOCK${index}%%`, renderBodyBlock(block, snippets, snippetsByName));
   });
 
   return {
     header,
     html: html,
-    raw: content
+    raw: rawContent
   };
+};
+
+/**
+ * Parse the attribute list of a body shortcode into a `{ name: value }` map of
+ * raw strings.
+ * @param {string} attrString - e.g. ` text="hello" tone="dry"`.
+ * @returns {Record<string, string>}
+ */
+const parseAttributes = (attrString) => {
+  const attrs = {};
+  let match;
+  ATTRIBUTE_RE.lastIndex = 0;
+  while ((match = ATTRIBUTE_RE.exec(attrString)) !== null) {
+    attrs[match[1]] = match[2];
+  }
+  return attrs;
+};
+
+/**
+ * Render a single body block. A tenant snippet whose name matches the shortcode
+ * wins; its parameters are resolved (defaults / required / type coercion) and it
+ * is rendered through the shared snippet renderer so the output matches the rest
+ * of the pipeline. When no snippet exists, a hardcoded block (e.g. robotVoice)
+ * is the fallback.
+ * @param {{name: string, attrs: Record<string,string>}} block
+ * @param {Array<{name?: string, content?: string, parameters?: Array}>} snippets
+ * @param {Map<string, object>} snippetsByName
+ * @returns {string} Rendered HTML (empty string on failure).
+ */
+const renderBodyBlock = (block, snippets, snippetsByName) => {
+  const snippet = snippetsByName.get(block.name);
+  if (snippet) {
+    const { values, errors } = resolveParameters(snippet.parameters ?? [], block.attrs);
+    if (errors.length) {
+      console.warn(`Snippet '${block.name}' parameter issues: ${errors.map(e => e.message).join('; ')}`);
+    }
+    try {
+      return renderWithSnippets(snippet.content ?? '', values, snippets);
+    } catch (err) {
+      console.error(`Failed to render snippet '${block.name}': ${err.message}`);
+      return '';
+    }
+  }
+
+  if (block.name === 'robotVoice') {
+    return formatRobotVoice(block.attrs.text ?? '');
+  }
+
+  return '';
 };
 
 const processTipOfTheWeek = (section) => {
@@ -221,6 +294,29 @@ const getAuthor = async (metadataAuthor) => {
   }
 
   return null;
+};
+
+/**
+ * Loads all snippets for a tenant via GSI1 (mirrors the read in publish-issue).
+ * Returns an empty list when no tenant is supplied so the body bridge falls back
+ * to hardcoded blocks only — keeping older invocations and the default template
+ * path working unchanged.
+ * @param {string} [tenantId] - Tenant identifier.
+ * @returns {Promise<Array<{name?: string, content?: string, parameters?: Array}>>}
+ */
+const getSnippets = async (tenantId) => {
+  if (!tenantId) return [];
+
+  const result = await ddb.send(new QueryCommand({
+    TableName: process.env.TABLE_NAME,
+    IndexName: 'GSI1',
+    KeyConditionExpression: 'GSI1PK = :gsi1pk',
+    ExpressionAttributeValues: marshall({
+      ':gsi1pk': `snippet#${tenantId}`
+    })
+  }));
+
+  return (result.Items ?? []).map(item => unmarshall(item));
 };
 
 const getSponsor = async (sponsorName) => {

--- a/functions/parse-md-to-json.mjs
+++ b/functions/parse-md-to-json.mjs
@@ -160,16 +160,34 @@ const convertToHtml = (data, removeOuterParagraph = false) => {
 
 const formatRobotVoice = (text) => {
   const formattedText = convertToHtml(text, true);
+  // The labels use negative margins to sit on the card's border (the "notch").
+  // Apple Mail / web clients honor this; Gmail strips the negative margins and
+  // degrades cleanly to a flat label. Outlook's Word engine *does* apply them
+  // and would clip the label, so it gets a flat version via an MSO conditional.
   return `<div style="margin:24px 0;border:1px solid #CFD6DC;border-radius:5px;padding:16px;background:#FFFFFF;font-family:ui-monospace,'SF Mono','Cascadia Code',Consolas,'Courier New',monospace;">
+  <!--[if !mso]><!-->
   <div style="margin:-27px 0 8px 0;">
     <span style="background:#FFFFFF;padding:0 8px;font-size:10px;letter-spacing:.18em;text-transform:uppercase;color:#8A929A;">robot voice</span>
   </div>
+  <!--<![endif]-->
+  <!--[if mso]>
+  <div style="margin:0 0 8px 0;">
+    <span style="background:#FFFFFF;padding:0 8px;font-size:10px;letter-spacing:.18em;text-transform:uppercase;color:#8A929A;">robot voice</span>
+  </div>
+  <![endif]-->
   <div style="font-size:14px;line-height:1.6;color:#54606A;">
     ${formattedText}
   </div>
+  <!--[if !mso]><!-->
   <div style="text-align:right;margin:8px 0 -28px 0;">
     <span style="background:#FFFFFF;padding:0 8px;font-size:11px;letter-spacing:.03em;color:#9099A1;">404 &middot; personality not found</span>
   </div>
+  <!--<![endif]-->
+  <!--[if mso]>
+  <div style="text-align:right;margin:8px 0 0 0;">
+    <span style="background:#FFFFFF;padding:0 8px;font-size:11px;letter-spacing:.03em;color:#9099A1;">404 &middot; personality not found</span>
+  </div>
+  <![endif]-->
 </div>`;
 };
 

--- a/functions/utils/__tests__/snippet-parameters.test.mjs
+++ b/functions/utils/__tests__/snippet-parameters.test.mjs
@@ -1,0 +1,71 @@
+import { describe, it, expect } from '@jest/globals';
+import { resolveParameters } from '../snippet-parameters.mjs';
+
+describe('resolveParameters', () => {
+  it('passes undeclared attributes through as strings', () => {
+    const { values, errors } = resolveParameters([], { text: 'hello', extra: 'x' });
+    expect(values).toEqual({ text: 'hello', extra: 'x' });
+    expect(errors).toEqual([]);
+  });
+
+  it('applies defaultValue when a parameter is missing', () => {
+    const params = [{ name: 'tone', type: 'string', defaultValue: 'dry' }];
+    const { values, errors } = resolveParameters(params, {});
+    expect(values.tone).toBe('dry');
+    expect(errors).toEqual([]);
+  });
+
+  it('applies defaultValue when a parameter is provided but empty', () => {
+    const params = [{ name: 'tone', type: 'string', defaultValue: 'dry' }];
+    const { values } = resolveParameters(params, { tone: '' });
+    expect(values.tone).toBe('dry');
+  });
+
+  it('reports an error for a missing required parameter and omits it', () => {
+    const params = [{ name: 'text', type: 'textarea', required: true }];
+    const { values, errors } = resolveParameters(params, {});
+    expect(values).not.toHaveProperty('text');
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({ name: 'text' });
+  });
+
+  it('coerces number parameters', () => {
+    const params = [{ name: 'count', type: 'number' }];
+    expect(resolveParameters(params, { count: '3' }).values.count).toBe(3);
+  });
+
+  it('errors on a non-numeric number, keeping the raw string', () => {
+    const params = [{ name: 'count', type: 'number' }];
+    const { values, errors } = resolveParameters(params, { count: 'abc' });
+    expect(values.count).toBe('abc');
+    expect(errors).toHaveLength(1);
+  });
+
+  it('coerces boolean parameters', () => {
+    const params = [{ name: 'flag', type: 'boolean' }];
+    expect(resolveParameters(params, { flag: 'true' }).values.flag).toBe(true);
+    expect(resolveParameters(params, { flag: 'false' }).values.flag).toBe(false);
+    expect(resolveParameters(params, { flag: 'nope' }).errors).toHaveLength(1);
+  });
+
+  it('validates select options', () => {
+    const params = [{ name: 'tone', type: 'select', options: ['dry', 'warm'] }];
+    expect(resolveParameters(params, { tone: 'dry' }).errors).toEqual([]);
+    expect(resolveParameters(params, { tone: 'spicy' }).errors).toHaveLength(1);
+  });
+
+  it('treats url/textarea/string as plain strings', () => {
+    const params = [
+      { name: 'href', type: 'url' },
+      { name: 'body', type: 'textarea' },
+      { name: 'label', type: 'string' }
+    ];
+    const { values, errors } = resolveParameters(params, {
+      href: 'https://x.io',
+      body: '*hi*',
+      label: 'Go'
+    });
+    expect(values).toMatchObject({ href: 'https://x.io', body: '*hi*', label: 'Go' });
+    expect(errors).toEqual([]);
+  });
+});

--- a/functions/utils/snippet-parameters.mjs
+++ b/functions/utils/snippet-parameters.mjs
@@ -1,0 +1,104 @@
+/**
+ * Central resolution of snippet parameters.
+ *
+ * A snippet declares a typed parameter schema (see the `parameters` field on a
+ * snippet record: `string | number | boolean | select | textarea | url`, each
+ * with `required`, `defaultValue`, `options`). When a snippet is invoked, the
+ * caller supplies raw string attributes (e.g. parsed from a `{{< name a="b" >}}`
+ * body shortcode). This module turns those raw strings into the typed data
+ * object the snippet's Handlebars content renders against: it applies defaults,
+ * enforces `required`, and coerces by `type`.
+ *
+ * It is pure and side-effect free so it can be unit tested and shared by the
+ * body resolver (`parse-md-to-json`) and, later, the template render path — so a
+ * snippet behaves identically no matter where it is invoked from.
+ */
+
+/**
+ * @typedef {Object} SnippetParameter
+ * @property {string} name
+ * @property {string} type - one of string|number|boolean|select|textarea|url
+ * @property {boolean} [required]
+ * @property {*} [defaultValue]
+ * @property {string[]} [options] - allowed values for `select`
+ */
+
+/**
+ * Coerce a single raw string value to the parameter's declared type.
+ * Returns `{ value }` on success or `{ error }` with a human-readable message.
+ * @param {string} raw
+ * @param {SnippetParameter} param
+ */
+const coerce = (raw, param) => {
+  switch (param.type) {
+    case 'number': {
+      const n = Number(raw);
+      return Number.isFinite(n)
+        ? { value: n }
+        : { error: `Parameter "${param.name}" must be a number` };
+    }
+    case 'boolean': {
+      if (raw === 'true') return { value: true };
+      if (raw === 'false') return { value: false };
+      return { error: `Parameter "${param.name}" must be "true" or "false"` };
+    }
+    case 'select': {
+      if (Array.isArray(param.options) && param.options.length > 0 && !param.options.includes(raw)) {
+        return { error: `Parameter "${param.name}" must be one of: ${param.options.join(', ')}` };
+      }
+      return { value: raw };
+    }
+    case 'url':
+    case 'string':
+    case 'textarea':
+    default:
+      return { value: raw };
+  }
+};
+
+/**
+ * Resolve raw string attributes against a snippet's parameter schema.
+ *
+ * Undeclared attributes pass through as-is (strings), so a snippet may use
+ * attributes it does not formally declare. Declared parameters get defaults,
+ * required-enforcement, and type coercion. On a coercion or required error the
+ * issue is collected in `errors` (the caller decides whether to hard-fail or
+ * render best-effort); a coercion error keeps the raw string so the block can
+ * still render something.
+ *
+ * @param {SnippetParameter[]} [parameters] - The snippet's declared parameters.
+ * @param {Record<string,string>} [rawAttrs] - Raw attributes supplied at the call site.
+ * @returns {{ values: Record<string, *>, errors: Array<{name: string, message: string}> }}
+ */
+export const resolveParameters = (parameters = [], rawAttrs = {}) => {
+  const values = { ...rawAttrs };
+  const errors = [];
+
+  for (const param of parameters) {
+    const hasValue =
+      Object.prototype.hasOwnProperty.call(rawAttrs, param.name) && rawAttrs[param.name] !== '';
+
+    if (!hasValue) {
+      if (param.defaultValue !== undefined && param.defaultValue !== null) {
+        values[param.name] = param.defaultValue;
+      } else {
+        if (param.required) {
+          errors.push({ name: param.name, message: `Missing required parameter "${param.name}"` });
+        }
+        // Don't pass a declared-but-empty parameter through as "".
+        delete values[param.name];
+      }
+      continue;
+    }
+
+    const { value, error } = coerce(rawAttrs[param.name], param);
+    if (error) {
+      errors.push({ name: param.name, message: error });
+      values[param.name] = rawAttrs[param.name];
+    } else {
+      values[param.name] = value;
+    }
+  }
+
+  return { values, errors };
+};

--- a/state-machines/stage-issue.asl.json
+++ b/state-machines/stage-issue.asl.json
@@ -288,7 +288,8 @@
             "fileName.$": "$$.Execution.Input.fileName",
             "isPreview.$": "$$.Execution.Input.isPreview",
             "votingOptions.$": "$votingOptions",
-            "issueId.$": "$$.Execution.Input.issueId"
+            "issueId.$": "$$.Execution.Input.issueId",
+            "tenantId.$": "$$.Execution.Input.tenant.id"
           }
         },
               "Retry": [


### PR DESCRIPTION
## Summary

Adds the `robotVoice` body shortcode and then generalizes the one-off body-shortcode mechanism into the existing **snippet** system, so reusable parameterized blocks can be defined once in the dashboard and used inline in issue bodies (0..N times) with no code deploy per block.

Closes #313.

This started as "add a robotVoice shortcode like sponsor/social" and grew, by design, into the body-snippet bridge after a decision discussion (captured in `docs/reusable-content-components.md`).

## What's here (in commit order)

1. **`robotVoice` shortcode** — `{{< robotVoice text="..." >}}` renders the "robot voice" card, expandable 0..N times per section. Tokens are pulled from raw markdown before showdown conversion so inline markdown in `text` is rendered inline (mirrors Hugo's `RenderString` display=inline) rather than mangled.
2. **Outlook fallback** — the notch labels use negative margins (Apple Mail / web honor them; Gmail strips them cleanly). Outlook's Word engine *applies* them and would clip the label, so it gets a flat version via an MSO conditional.
3. **Decision doc** — `docs/reusable-content-components.md`: the snippet is the one durable component concept, referenced idiomatically per surface (`{{> }}` in templates, `{{< >}}` in bodies), with parameter resolution centralized. Records the four settled v1 decisions.
4. **Backend bridge** — `parse-md-to-json` loads tenant snippets and resolves `{{< name attr="x" >}}` against them via the shared `renderWithSnippets`; a tenant snippet overrides a same-named hardcoded block, else the hardcoded block (robotVoice) is the fallback. Reserved shortcodes (sponsor/social/vote) keep their bespoke transforms; unknown shortcodes pass through untouched. `tenantId` is threaded into the `ParseMdToJson` step.
   - **`snippet-parameters.mjs`** — central, pure parameter resolution (defaults, required-enforcement, type coercion) so a snippet behaves identically wherever it's invoked.
5. **Body-editor inserter** — since the issue body editor is MDXEditor (WYSIWYG), an inline type-ahead is impractical; this mirrors the template builder's snippet-insert pattern: an "Insert snippet" control that lazily loads the snippet list, searches it, and inserts a parameter-scaffolded `{{< name param="..." >}}` at the cursor (`MarkdownWysiwygEditor` gains a `forwardRef` `insert()`).
6. **Parity test** — a snippet invoked via the body `{{< name >}}` bridge renders identically to the same snippet invoked as a template `{{> name }}` partial, given the same resolved params (body-side analogue of the JS-send / Rust-preview conformance harness).

## Testing

- Backend (Jest): **25** bridge-related tests pass — parameter resolver, body bridge (hardcoded fallback, snippet override, arbitrary snippet used 0..N with defaults, unknown-shortcode passthrough, no-tenant), body/template parity, and the existing render-conformance / publish-issue / parse-json suites (no regressions). Rust untouched.
- Frontend (Vitest): **17** tests pass — pure shortcode helpers, the `SnippetShortcodeInserter` component, and the existing `IssueFormPage` suite. `tsc --noEmit` and eslint clean on changed files.

## Notes for review

- **Manual smoke test worth doing:** I verified the inserter's logic and component in isolation (MDXEditor is mocked in the repo's tests) but could not drive the real MDXEditor `insertMarkdown` end-to-end here. Suggest a quick check: open an issue → Insert snippet → confirm the shortcode lands at the cursor.
- **Deliberately out of scope (follow-ups):** retiring sponsor/social/vote onto the bridge; applying the central parameter resolver on the *template* invocation path too (today it's body-side); body-editor inline type-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014MkizNAdQdkajoAoF2n2B6