### PR TITLE
Migrate JS agent flows to Strands

### DIFF
--- a/functions/__tests__/setup-voting-options.test.mjs
+++ b/functions/__tests__/setup-voting-options.test.mjs
@@ -1,0 +1,106 @@
+import { jest } from '@jest/globals';
+import { unmarshall } from '@aws-sdk/util-dynamodb';
+
+const mockDdbSend = jest.fn();
+const mockInvoke = jest.fn();
+const mockAgent = jest.fn(() => ({ invoke: mockInvoke }));
+const mockBedrockModel = jest.fn();
+const mockPutItemCommand = jest.fn((input) => ({ input }));
+
+jest.unstable_mockModule('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: jest.fn(() => ({ send: mockDdbSend })),
+  PutItemCommand: mockPutItemCommand
+}));
+
+jest.unstable_mockModule('@strands-agents/sdk', () => ({
+  Agent: mockAgent,
+  BedrockModel: mockBedrockModel
+}));
+
+const { handler } = await import('../setup-voting-options.mjs');
+
+describe('setup-voting-options handler', () => {
+  let originalEnv;
+
+  beforeEach(() => {
+    originalEnv = {
+      TABLE_NAME: process.env.TABLE_NAME,
+      MODEL_ID: process.env.MODEL_ID
+    };
+    process.env.TABLE_NAME = 'test-table';
+    process.env.MODEL_ID = 'test-model';
+    mockDdbSend.mockResolvedValue({});
+    mockInvoke.mockResolvedValue({
+      structuredOutput: {
+        options: [
+          { description: 'DSQL vs Aurora' },
+          { description: 'Cloud locally' },
+          { description: 'AI task failures' },
+          { description: 'Edge performance' }
+        ]
+      }
+    });
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.env.TABLE_NAME = originalEnv.TABLE_NAME;
+    process.env.MODEL_ID = originalEnv.MODEL_ID;
+  });
+
+  test('generates, stores, and returns four normalized voting options', async () => {
+    const result = await handler({
+      tenant: { id: 'tenant123' },
+      issueId: '  ISSUE-42 ',
+      content: '# Newsletter content'
+    });
+
+    expect(result).toEqual([
+      { id: 'issue-42-0', description: 'DSQL vs Aurora' },
+      { id: 'issue-42-1', description: 'Cloud locally' },
+      { id: 'issue-42-2', description: 'AI task failures' },
+      { id: 'issue-42-3', description: 'Edge performance' }
+    ]);
+
+    expect(mockBedrockModel).toHaveBeenCalledWith(expect.objectContaining({
+      modelId: 'test-model'
+    }));
+    expect(mockInvoke).toHaveBeenCalledWith(expect.stringContaining('# Newsletter content'), expect.objectContaining({
+      limits: expect.objectContaining({ turns: 1 })
+    }));
+
+    expect(mockPutItemCommand).toHaveBeenCalledWith(expect.objectContaining({
+      TableName: 'test-table'
+    }));
+    const item = unmarshall(mockPutItemCommand.mock.calls[0][0].Item);
+    expect(item).toEqual({
+      pk: 'tenant123#issue-42',
+      sk: 'votes',
+      options: result,
+      'issue-42-0': 0,
+      'issue-42-1': 0,
+      'issue-42-2': 0,
+      'issue-42-3': 0
+    });
+    expect(mockDdbSend).toHaveBeenCalledTimes(1);
+  });
+
+  test('retries generation and returns empty array when no valid options are produced', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    mockInvoke.mockResolvedValue({ structuredOutput: { options: [] } });
+
+    const result = await handler({
+      tenant: { id: 'tenant123' },
+      issueId: '42',
+      content: '# Newsletter content'
+    });
+
+    expect(result).toEqual([]);
+    expect(mockAgent).toHaveBeenCalledTimes(3);
+    expect(mockDdbSend).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+    consoleSpy.mockRestore();
+  });
+});

--- a/functions/__tests__/update-link-tracking-handler.test.mjs
+++ b/functions/__tests__/update-link-tracking-handler.test.mjs
@@ -1,17 +1,17 @@
 import { jest } from '@jest/globals';
 import { DynamoDBClient, GetItemCommand, PutItemCommand, UpdateItemCommand } from '@aws-sdk/client-dynamodb';
-import { BedrockRuntimeClient } from '@aws-sdk/client-bedrock-runtime';
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
-import { handler } from '../update-link-tracking.mjs';
 
-const textResponse = (text) => ({ output: { message: { content: [{ text }] } } });
-const toolUseResponse = (name, input) => ({
-  output: { message: { content: [{ toolUse: { name, toolUseId: 't1', input } }] } }
-});
+const mockClassifyLinkWithLlm = jest.fn();
+
+jest.unstable_mockModule('../utils/llm-link-classifier.mjs', () => ({
+  classifyLinkWithLlm: mockClassifyLinkWithLlm
+}));
+
+const { handler } = await import('../update-link-tracking.mjs');
 
 describe('update-link-tracking handler', () => {
   let mockSend;
-  let mockBedrockSend;
   let originalEnv;
 
   beforeEach(() => {
@@ -27,16 +27,14 @@ describe('update-link-tracking handler', () => {
     // No existing records by default; writes succeed.
     mockSend = jest.fn().mockResolvedValue({});
     DynamoDBClient.prototype.send = mockSend;
-
-    // Default: model produces no tool call (link stored without classification).
-    mockBedrockSend = jest.fn().mockResolvedValue(textResponse('ok'));
-    BedrockRuntimeClient.prototype.send = mockBedrockSend;
+    mockClassifyLinkWithLlm.mockResolvedValue(null);
   });
 
   afterEach(() => {
     process.env.TABLE_NAME = originalEnv.TABLE_NAME;
     process.env.REDIRECT_URL = originalEnv.REDIRECT_URL;
     process.env.MODEL_ID = originalEnv.MODEL_ID;
+    jest.clearAllMocks();
   });
 
   test('rewrites links with issue cid and position parameters', async () => {
@@ -53,19 +51,12 @@ describe('update-link-tracking handler', () => {
   });
 
   test('stores the LLM topic classification and summary on the link record', async () => {
-    let bedrockCall = 0;
-    mockBedrockSend.mockImplementation(() => {
-      bedrockCall += 1;
-      // converse() loops: first response asks for the tool, second ends with text.
-      if (bedrockCall % 2 === 1) {
-        return Promise.resolve(toolUseResponse('submit_link_classification', {
-          primaryTopic: 'ai',
-          secondaryTopics: ['serverless'],
-          summary: 'A deep dive into running LLMs on Lambda.',
-          confidence: 0.9
-        }));
-      }
-      return Promise.resolve(textResponse('done'));
+    mockClassifyLinkWithLlm.mockResolvedValue({
+      primaryTopic: 'ai',
+      secondaryTopics: ['serverless'],
+      summary: 'A deep dive into running LLMs on Lambda.',
+      confidence: 0.9,
+      classifiedBy: 'llm'
     });
 
     await handler({
@@ -86,6 +77,7 @@ describe('update-link-tracking handler', () => {
     expect(item.confidence).toBe(0.9);
     expect(item.classifiedBy).toBe('llm');
     expect(item.position).toBe(1);
+    expect(mockClassifyLinkWithLlm).toHaveBeenCalledTimes(1);
   });
 
   test('skips classification and write when the link record is already classified', async () => {
@@ -105,7 +97,7 @@ describe('update-link-tracking handler', () => {
     // Link is still rewritten...
     expect(result.content).toContain('cid=tenant123%2342');
     // ...but no LLM call and no write happen for an already-classified record.
-    expect(mockBedrockSend).not.toHaveBeenCalled();
+    expect(mockClassifyLinkWithLlm).not.toHaveBeenCalled();
     const writes = mockSend.mock.calls.filter(
       call => call[0] instanceof PutItemCommand || call[0] instanceof UpdateItemCommand
     );
@@ -121,18 +113,12 @@ describe('update-link-tracking handler', () => {
       return Promise.resolve({});
     });
 
-    let bedrockCall = 0;
-    mockBedrockSend.mockImplementation(() => {
-      bedrockCall += 1;
-      if (bedrockCall % 2 === 1) {
-        return Promise.resolve(toolUseResponse('submit_link_classification', {
-          primaryTopic: 'security',
-          secondaryTopics: [],
-          summary: 'A guide to zero-trust auth.',
-          confidence: 0.8
-        }));
-      }
-      return Promise.resolve(textResponse('done'));
+    mockClassifyLinkWithLlm.mockResolvedValue({
+      primaryTopic: 'security',
+      secondaryTopics: [],
+      summary: 'A guide to zero-trust auth.',
+      confidence: 0.8,
+      classifiedBy: 'llm'
     });
 
     await handler({
@@ -152,22 +138,11 @@ describe('update-link-tracking handler', () => {
 
     const putCalls = mockSend.mock.calls.filter(call => call[0] instanceof PutItemCommand);
     expect(putCalls).toHaveLength(0);
+    expect(mockClassifyLinkWithLlm).toHaveBeenCalledTimes(1);
   });
 
   test('does not store low-confidence classifications', async () => {
-    let bedrockCall = 0;
-    mockBedrockSend.mockImplementation(() => {
-      bedrockCall += 1;
-      if (bedrockCall % 2 === 1) {
-        return Promise.resolve(toolUseResponse('submit_link_classification', {
-          primaryTopic: 'ai',
-          secondaryTopics: [],
-          summary: 'Ambiguous link.',
-          confidence: 0.2
-        }));
-      }
-      return Promise.resolve(textResponse('done'));
-    });
+    mockClassifyLinkWithLlm.mockResolvedValue(null);
 
     await handler({
       tenantId: 'tenant123',
@@ -185,8 +160,7 @@ describe('update-link-tracking handler', () => {
   });
 
   test('still creates the link record when classification fails', async () => {
-    mockBedrockSend.mockRejectedValue(new Error('bedrock unavailable'));
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockClassifyLinkWithLlm.mockResolvedValue(null);
 
     await handler({
       tenantId: 'tenant123',
@@ -202,7 +176,41 @@ describe('update-link-tracking handler', () => {
     const item = unmarshall(putCmd.input.Item);
     expect(item.url).toBe('https://example.com/resilient');
     expect(item.primaryTopic).toBeUndefined();
+  });
 
-    consoleSpy.mockRestore();
+  test('waits for link enrichment writes before returning', async () => {
+    let resolveWrite;
+    const pendingWrite = new Promise((resolve) => {
+      resolveWrite = resolve;
+    });
+    let handlerResolved = false;
+
+    mockSend.mockImplementation((command) => {
+      if (command instanceof GetItemCommand) {
+        return Promise.resolve({});
+      }
+      if (command instanceof PutItemCommand) {
+        return pendingWrite;
+      }
+      return Promise.resolve({});
+    });
+
+    const handlerPromise = handler({
+      tenantId: 'tenant123',
+      issueId: '42',
+      content: 'One [first](https://aws.amazon.com/lambda)'
+    }).then((result) => {
+      handlerResolved = true;
+      return result;
+    });
+
+    await Promise.resolve();
+    expect(handlerResolved).toBe(false);
+
+    resolveWrite({});
+    const result = await handlerPromise;
+
+    expect(result.content).toContain('https://redirect.example.com');
+    expect(mockSend.mock.calls.some(([command]) => command instanceof PutItemCommand)).toBe(true);
   });
 });

--- a/functions/setup-voting-options.mjs
+++ b/functions/setup-voting-options.mjs
@@ -1,10 +1,29 @@
-import { BedrockRuntimeClient, ConverseCommand } from '@aws-sdk/client-bedrock-runtime';
 import { DynamoDBClient, PutItemCommand } from '@aws-sdk/client-dynamodb';
 import { marshall } from '@aws-sdk/util-dynamodb';
+import { Agent, BedrockModel } from '@strands-agents/sdk';
+import { z } from 'zod';
 
-const bedrock = new BedrockRuntimeClient();
 const ddb = new DynamoDBClient();
 const MAX_ATTEMPTS = 3;
+
+const votingOptionsSchema = z.object({
+  options: z.array(z.object({
+    description: z.string().describe('A 3-5 word friendly description of the article')
+  })).length(4)
+});
+
+const systemPrompt = 'You are a seasoned content editor in tune with your tech audience. You know what engages them and how to pull the most exciting content for maximum reach.';
+
+const buildUserPrompt = (content) => `Choose the top 4 most exciting articles based on the newsletter content below. You are tasked with coming up with the options for a vote for "best content". Select a 3-5 word friendly description for each one. Don't select the superhero as an option and make the descriptions unambiguous and feel like a complete thought.
+---
+EXAMPLES
+DSQL vs. Aurora
+Emulating the cloud locally
+AI Agents failing tasks
+
+---
+CONTENT
+${content}`;
 
 export const handler = async (state) => {
   try {
@@ -14,70 +33,7 @@ export const handler = async (state) => {
       throw new Error('Missing issueId');
     }
 
-    let options = [];
-    for (let attempts = 0; attempts < MAX_ATTEMPTS; attempts++) {
-      const response = await bedrock.send(new ConverseCommand({
-        modelId: process.env.MODEL_ID,
-        system: [{ text: 'You are a seasoned content editor in tune with your tech audience. You know what engages them and how to pull the most exciting content for maximum reach' }],
-        messages: [
-          {
-            role: 'user',
-            content: [{
-              text: `Choose the top 4 most exciting articles based on the newsletter content below. You are tasked with coming up with the options for a vote for "best content". Select a 3-5 word friendly description for each one. Don't select the superhero as an option and make the descriptions unambiguous and feel like a complete thought. Use the 'format_vote' tool to generate the options you decide.
----
-EXAMPLES
-DSQL vs. Aurora
-Emulating the cloud locally
-AI Agents failing tasks
-
----
-CONTENT
-${content}`
-            }]
-          }
-        ],
-        toolConfig: {
-          toolChoice: { tool: { name: 'format_vote' } },
-          tools: [
-            {
-              toolSpec: {
-                name: 'format_vote',
-                description: 'Format the vote options for the newsletter',
-                inputSchema: {
-                  json: {
-                    type: 'object',
-                    properties: {
-                      options: {
-                        type: 'array',
-                        minItems: 4,
-                        maxItems: 4,
-                        items: {
-                          type: 'object',
-                          properties: {
-                            description: {
-                              type: 'string',
-                              description: 'A 3-5 word friendly description of the article'
-                            }
-                          },
-                          required: ['description']
-                        }
-                      }
-                    },
-                    required: ['options']
-                  }
-                }
-              }
-            }
-          ]
-        }
-      }));
-
-      const contentBlock = response.output.message?.content?.find(c => c.toolUse);
-      if (!contentBlock) continue;
-
-      options = getFormattedOptions(normalizedIssueId, contentBlock.toolUse.input.options);
-      break;
-    }
+    const options = await generateVotingOptions(content, normalizedIssueId);
     if (!options?.length) {
       throw new Error('Could not generate voting options');
     }
@@ -103,6 +59,45 @@ ${content}`
     return [];
   }
 };
+
+async function generateVotingOptions(content, issueId) {
+  for (let attempts = 0; attempts < MAX_ATTEMPTS; attempts++) {
+    try {
+      const agent = new Agent({
+        model: new BedrockModel({
+          modelId: process.env.MODEL_ID,
+          maxTokens: 800,
+          temperature: 0.3,
+          stream: false
+        }),
+        systemPrompt,
+        structuredOutputSchema: votingOptionsSchema,
+        printer: false
+      });
+
+      const result = await agent.invoke(buildUserPrompt(content), {
+        structuredOutputSchema: votingOptionsSchema,
+        limits: {
+          turns: 1,
+          totalTokens: 5000
+        },
+        cancelSignal: AbortSignal.timeout(10000)
+      });
+
+      const options = result.structuredOutput?.options;
+      if (options?.length === 4) {
+        return getFormattedOptions(issueId, options);
+      }
+    } catch (err) {
+      console.warn('Failed to generate voting options', {
+        attempt: attempts + 1,
+        error: err.message
+      });
+    }
+  }
+
+  return [];
+}
 
 const getFormattedOptions = (issueId, options) => {
   const newOptions = options.map((option, index) => {

--- a/functions/update-link-tracking.mjs
+++ b/functions/update-link-tracking.mjs
@@ -9,6 +9,7 @@ const ddb = new DynamoDBClient();
 // events with a 90-day TTL). Interest scoring reads topics off this record on
 // click, so it must outlive the period in which clicks can still arrive.
 const LINK_EXPIRATION_DAYS = 90;
+const LINK_PROCESSING_CONCURRENCY = 3;
 const MAX_CONTEXT_LENGTH = 600;
 
 /**
@@ -67,28 +68,43 @@ export const handler = async (state) => {
   let linkPosition = 0;
 
   let updatedContent = state.content;
+  const linkTasks = [];
   for (const { url, anchorText, context } of links) {
     linkPosition += 1;
+    linkTasks.push({ url, anchorText, context, position: linkPosition });
     updatedContent = updatedContent.replace(
       url,
       `${process.env.REDIRECT_URL}?u=${encodeURI(url)}&cid=${encodeURIComponent(`${state.tenantId}#${state.issueId}`)}&p=${encodeURIComponent(linkPosition)}&s=__EMAIL_HASH__`
     );
-    await enrichLinkRecord(state.tenantId, state.issueId, url, anchorText, context, linkPosition);
   }
+
+  await processLinks(linkTasks, state.tenantId, state.issueId);
 
   return { content: updatedContent };
 };
+
+async function processLinks(links, tenantId, issueId) {
+  const workers = Array.from(
+    { length: Math.min(LINK_PROCESSING_CONCURRENCY, links.length) },
+    async (_, workerIndex) => {
+      for (let index = workerIndex; index < links.length; index += LINK_PROCESSING_CONCURRENCY) {
+        const { url, anchorText, context, position } = links[index];
+        await enrichLinkRecord(tenantId, issueId, url, anchorText, context, position);
+      }
+    }
+  );
+
+  await Promise.all(workers);
+}
 
 /**
  * Creates the link tracking record for an issue link, enriched with an LLM
  * topic classification and summary derived from the author's paragraph.
  *
  * Skips the LLM call only when the record is already classified, so re-runs
- * and preview sends don't re-classify needlessly — but a record that exists
- * without topics (e.g. created by a preview where classification failed) is
- * re-classified, since interest scoring reads topics off this record on click.
- * Enrichment is best-effort: a classification failure still creates the base
- * tracking record so click counting keeps working.
+ * and preview sends don't re-classify needlessly. Enrichment is best-effort:
+ * a classification failure still creates the base tracking record so click
+ * counting keeps working.
  *
  * @param {string} tenantId
  * @param {string} issueId
@@ -113,7 +129,7 @@ const enrichLinkRecord = async (tenantId, issueId, url, anchorText, context, pos
     console.error('Failed to check existing link record', { pk, sk, error: err.message });
   }
 
-  // Already classified — nothing to do (and no wasted LLM call).
+  // Already classified: nothing to do and no wasted LLM call.
   if (existing?.primaryTopic) {
     return;
   }
@@ -121,7 +137,7 @@ const enrichLinkRecord = async (tenantId, issueId, url, anchorText, context, pos
   const classification = await classifyLinkWithLlm(url, anchorText, context);
 
   if (existing) {
-    // Base record exists but has no topics yet — backfill the classification
+    // Base record exists but has no topics yet. Backfill the classification
     // if we got one this time. Without topics there is nothing to write.
     if (classification) {
       await applyClassification(pk, sk, classification);
@@ -174,7 +190,7 @@ const applyClassification = async (pk, sk, classification) => {
       })
     }));
   } catch (err) {
-    // Another run classified it first (or the record vanished) — that's fine.
+    // Another run classified it first (or the record vanished). That's fine.
     if (err.name !== 'ConditionalCheckFailedException') {
       throw err;
     }

--- a/functions/utils/agents.mjs
+++ b/functions/utils/agents.mjs
@@ -1,149 +1,44 @@
-import { z } from 'zod';
-import { Logger } from '@aws-lambda-powertools/logger';
-import { BedrockRuntimeClient, ConverseCommand } from "@aws-sdk/client-bedrock-runtime";
+import { Agent, BedrockModel, tool } from '@strands-agents/sdk';
 
-const logger = new Logger({ serviceName: 'utils' });
-const bedrock = new BedrockRuntimeClient();
-const MAX_ITERATIONS = 10;
-const MAX_TOKENS = 10000;
+const DEFAULT_MODEL_MAX_TOKENS = 4096;
 
-export const converse = async (model, systemPrompt, userPrompt, toolDefs, options) => {
-  let conversation = [];
-  const messages = [{ role: 'user', content: [{ text: userPrompt }] }];
-  let finalResponse = '';
-  let iteration = 0;
+export const converse = async (model, systemPrompt, userPrompt, toolDefs = [], options = {}) => {
+  const agent = new Agent({
+    model: new BedrockModel({
+      modelId: model,
+      maxTokens: options.maxTokens ?? DEFAULT_MODEL_MAX_TOKENS,
+      temperature: options.temperature ?? 0.2,
+      stream: false
+    }),
+    systemPrompt,
+    tools: toolDefs.map(toolDef => toStrandsTool(toolDef, options)),
+    toolExecutor: 'sequential',
+    printer: false
+  });
 
-  const tools = convertToBedrockTools(toolDefs || []);
-  while (iteration < MAX_ITERATIONS) {
-    iteration++;
-    try {
-      const command = new ConverseCommand({
-        modelId: model,
-        system: [{ text: systemPrompt }],
-        messages: [...conversation, ...messages],
-        ...tools.length && { toolConfig: { tools: tools.map(t => { return { toolSpec: t.spec }; }) } },
-        inferenceConfig: { maxTokens: MAX_TOKENS }
-      });
+  const result = await agent.invoke(userPrompt, {
+    limits: {
+      turns: options.maxTurns ?? (toolDefs.length ? 1 : 3),
+      totalTokens: options.maxTotalTokens
+    },
+    cancelSignal: options.timeoutMs ? AbortSignal.timeout(options.timeoutMs) : undefined
+  });
 
-      const response = await bedrock.send(command);
+  return result.toString();
+};
 
-      if (!response.output?.message?.content) {
-        logger.warn('No message output on iteration', {
-          iteration: iteration + 1,
-          response: JSON.stringify(response, null, 2)
-        });
-        break;
-      }
-
-      const messageContent = response.output.message.content;
-      messages.push({ role: 'assistant', content: messageContent });
-
-      // Check if we have tool use or just text
-      const toolUseItems = messageContent.filter(item => 'toolUse' in item && !!item.toolUse);
-      const textItems = messageContent.filter(item => 'text' in item && !!item.text);
-
-      if (toolUseItems.length) {
-        const message = { role: 'user', content: [] };
-        for (const toolUseItem of toolUseItems) {
-          const { toolUse } = toolUseItem;
-          const { name: toolName, input: toolInput, toolUseId } = toolUse;
-
-          logger.info('Tool called', {
-            iteration: iteration + 1,
-            toolName,
-            toolInput,
-            toolUseId
-          });
-
-          let toolResult;
-          try {
-            const tool = tools.find(t => t.spec.name === toolName);
-            if (!tool) {
-              throw new Error(`Unknown tool: ${toolName}`);
-            }
-
-            // Never allow an LLM to provide a tenant id!! Instead infer it from the code for security purposes
-            if (options?.tenantId && tool.isMultiTenant) {
-              const context = {
-                tenantId: options.tenantId,
-                ...options.userId && { userId: options.userId }
-              };
-              toolResult = await tool.handler(context, toolInput);
-            } else {
-              toolResult = await tool.handler(toolInput);
-            }
-          } catch (toolError) {
-            toolResult = { error: toolError.message };
-          }
-          logger.info('Tool result', { toolName, toolResult });
-          const toolResultBlock = {
-            toolUseId,
-            content: [{ text: JSON.stringify(toolResult) }]
-          };
-
-          message.content.push({ toolResult: toolResultBlock });
-        }
-        messages.push(message);
-      } else if (textItems.length > 0) {
-        finalResponse = textItems.map(item => item.text).join('');
-        break;
-      } else {
-        logger.warn('Unexpected content structure', {
-          iteration: iteration + 1,
-          messageContent
-        });
-        finalResponse = 'Received unexpected response type from model';
-        break;
-      }
-    } catch (error) {
-      logger.error('Error on iteration', {
-        iteration,
-        error: error.message,
-        stack: error.stack
-      });
-      throw error;
+const toStrandsTool = (toolDef, options) => tool({
+  name: toolDef.name,
+  description: toolDef.description,
+  inputSchema: toolDef.schema,
+  callback: async (input) => {
+    if (options?.tenantId && toolDef.isMultiTenant) {
+      return toolDef.handler({
+        tenantId: options.tenantId,
+        ...(options.userId && { userId: options.userId })
+      }, input);
     }
+
+    return toolDef.handler(input);
   }
-
-  if (!finalResponse && iteration >= MAX_ITERATIONS) {
-    logger.warn('Stopped due to iteration limit', {
-      maxIterations: MAX_ITERATIONS
-    });
-  }
-
-  if (!finalResponse && messages.length > 1) {
-    const lastAssistantMessage = [...messages].reverse().find(m => m.role === 'assistant');
-    if (lastAssistantMessage?.content) {
-      const textContent = lastAssistantMessage.content
-        .filter(item => 'text' in item && !!item.text)
-        .map(item => item.text)
-        .join('');
-      if (textContent) {
-        finalResponse = textContent;
-      }
-    }
-  }
-
-  return sanitizeResponse(finalResponse, { preserveThinkingTags: false }) || 'No response generated';
-};
-
-const sanitizeResponse = (text, options = {}) => {
-  if (options?.preserveThinkingTags) {
-    return text.trim();
-  }
-  return text.replace(/<thinking>[\s\S]*?<\/thinking>\s*/g, '').trim();
-};
-
-const convertToBedrockTools = (toolDefs) => {
-  return toolDefs?.map(toolDef => {
-    return {
-      isMultiTenant: toolDef.isMultiTenant,
-      spec: {
-        name: toolDef.name,
-        description: toolDef.description,
-        inputSchema: { json: z.toJSONSchema(toolDef.schema) }
-      },
-      handler: toolDef.handler
-    };
-  }) ?? [];
-};
+});

--- a/functions/utils/llm-link-classifier.mjs
+++ b/functions/utils/llm-link-classifier.mjs
@@ -1,13 +1,16 @@
+import { Agent, BedrockModel } from '@strands-agents/sdk';
+import { httpRequest } from '@strands-agents/sdk/vended-tools/http-request';
 import { z } from 'zod';
-import { converse } from './agents.mjs';
 import { VALID_TOPICS, TOPICS, getTopicDisplayName } from './topic-taxonomy.mjs';
 
 const MODEL_ID = process.env.MODEL_ID || 'us.amazon.nova-pro-v1:0';
+const SUMMARY_MAX_LENGTH = 280;
+const CONFIDENCE_THRESHOLD = 0.5;
 
 /** Fixed taxonomy labels the model must choose from. */
 const TOPIC_LABELS = Object.keys(TOPICS);
 
-/** Structured output contract for the classification tool. */
+/** Structured output contract for the classification assessment. */
 const classificationSchema = z.object({
   primaryTopic: z.enum(TOPIC_LABELS),
   secondaryTopics: z.array(z.enum(TOPIC_LABELS)).max(2).optional(),
@@ -15,20 +18,16 @@ const classificationSchema = z.object({
   confidence: z.number().min(0).max(1)
 });
 
-const SUMMARY_MAX_LENGTH = 280;
-
-/** Minimum confidence required to store a classification (drives segmentation). */
-const CONFIDENCE_THRESHOLD = 0.5;
-
 const systemPrompt = [
   'Role: You categorize links inside a developer newsletter so readers can be auto-segmented by interest.',
   'You will be given a link URL, its anchor text, and the paragraph the author wrote around it.',
+  'You may use httpRequest to inspect the URL when the provided context is ambiguous, but do not request unrelated URLs.',
   'Task:',
   `1. Choose the single best primaryTopic for the link from this fixed taxonomy (use the lowercase label): ${TOPIC_LABELS.map(t => `${t} (${getTopicDisplayName(t)})`).join(', ')}.`,
   '2. Optionally add up to 2 secondaryTopics from the same taxonomy when the link clearly spans more than one. Never repeat the primaryTopic.',
-  '3. Write a one-sentence summary (max ~40 words) of what the link is about, grounded in the provided paragraph and anchor text.',
+  '3. Write a one-sentence summary (max ~40 words) of what the link is about, grounded in the provided paragraph, anchor text, and any fetched page metadata.',
   '4. Set confidence between 0 and 1 reflecting how sure you are of the primaryTopic.',
-  'Only the listed topic labels are valid. Call the submit_link_classification tool exactly once and produce no free-text output.'
+  'Return only the structured classification.'
 ].join('\n');
 
 const buildUserPrompt = (url, anchorText, context) => [
@@ -38,10 +37,10 @@ const buildUserPrompt = (url, anchorText, context) => [
 ].join('\n');
 
 /**
- * Classifies a newsletter link against the fixed topic taxonomy using the
- * author's surrounding paragraph as context, returning the topics plus a
- * short summary. Best-effort: returns null on any model/validation failure
- * so the link-tracking pipeline can proceed without enrichment.
+ * Classifies a newsletter link against the fixed topic taxonomy using Strands.
+ * The agent may use the vended HTTP request tool to inspect ambiguous links,
+ * and returns validated structured output. Best-effort: returns null on any
+ * model/tool/validation failure so link tracking can proceed without enrichment.
  *
  * @param {string} url - The original link URL
  * @param {string} anchorText - The link's anchor text from the markdown
@@ -49,46 +48,59 @@ const buildUserPrompt = (url, anchorText, context) => [
  * @returns {Promise<{ primaryTopic: string, secondaryTopics: string[], summary: string, confidence: number, classifiedBy: string } | null>}
  */
 export async function classifyLinkWithLlm(url, anchorText, context) {
-  let captured = null;
-  const toolDefs = [{
-    name: 'submit_link_classification',
-    description: 'Submit the topic classification and summary for the link.',
-    schema: classificationSchema,
-    handler: (input) => { captured = input; return { success: true }; }
-  }];
-
   try {
-    await converse(MODEL_ID, systemPrompt, buildUserPrompt(url, anchorText, context), toolDefs);
+    const agent = new Agent({
+      model: new BedrockModel({
+        modelId: MODEL_ID,
+        maxTokens: 1200,
+        temperature: 0.1,
+        stream: false
+      }),
+      systemPrompt,
+      tools: [httpRequest],
+      structuredOutputSchema: classificationSchema,
+      toolExecutor: 'sequential',
+      printer: false
+    });
+
+    const result = await agent.invoke(buildUserPrompt(url, anchorText, context), {
+      structuredOutputSchema: classificationSchema,
+      limits: {
+        turns: 3,
+        totalTokens: 6000
+      },
+      cancelSignal: AbortSignal.timeout(10000)
+    });
+
+    return normalizeClassification(result.structuredOutput);
   } catch (err) {
     console.error('LLM link classification failed', { url, error: err.message });
     return null;
   }
+}
 
-  if (!captured) {
-    console.warn('LLM link classification returned no result', { url });
+function normalizeClassification(output) {
+  if (!output) {
     return null;
   }
 
-  const primaryTopic = VALID_TOPICS.has(captured.primaryTopic) ? captured.primaryTopic : null;
+  const primaryTopic = VALID_TOPICS.has(output.primaryTopic) ? output.primaryTopic : null;
   if (!primaryTopic) {
     return null;
   }
 
-  const secondaryTopics = (captured.secondaryTopics ?? [])
-    .filter(topic => VALID_TOPICS.has(topic) && topic !== primaryTopic)
-    .slice(0, 2);
-
-  const summary = typeof captured.summary === 'string'
-    ? captured.summary.trim().slice(0, SUMMARY_MAX_LENGTH)
-    : '';
-
-  const confidence = typeof captured.confidence === 'number' ? captured.confidence : 1;
-
-  // Don't drive segmentation off ambiguous classifications. Mirrors the
-  // bar the previous heuristic classifier used.
+  const confidence = typeof output.confidence === 'number' ? output.confidence : 1;
   if (confidence < CONFIDENCE_THRESHOLD) {
     return null;
   }
+
+  const secondaryTopics = (output.secondaryTopics ?? [])
+    .filter(topic => VALID_TOPICS.has(topic) && topic !== primaryTopic)
+    .slice(0, 2);
+
+  const summary = typeof output.summary === 'string'
+    ? output.summary.trim().slice(0, SUMMARY_MAX_LENGTH)
+    : '';
 
   return { primaryTopic, secondaryTopics, summary, confidence, classifiedBy: 'llm' };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@aws-sdk/client-sesv2": "^3.1084.0",
         "@aws-sdk/signature-v4a": "^3.1082.0",
         "@github-docs/frontmatter": "^1.3.1",
+        "@strands-agents/sdk": "^1.9.0",
         "aws-jwt-verify": "^5.2.1",
         "handlebars": "^4.7.9",
         "maxmind": "^5.0.6",
@@ -130,7 +131,7 @@
       "version": "3.1000.16",
       "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.16.tgz",
       "integrity": "sha512-EKnvkXSmz3IpA99tCNuI+dLFXyZyClSm8zns9sB/elvkU+MTuomAs6toJMPMBf98/fICG/urXDkzGz0/c3yyAQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.975.1",
@@ -147,7 +148,6 @@
       "version": "3.1084.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1084.0.tgz",
       "integrity": "sha512-GpfKaPbKQ+PI8oVbWyzzSnlnPEsRGt9m6h9Q1hvnCiC/g2X5Zf1siOlj3GrgOQSMLuV9L4ZdEanJJJ9xSFlCgA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.975.1",
@@ -171,7 +171,6 @@
       "version": "3.1084.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1084.0.tgz",
       "integrity": "sha512-gs0WwdzhYk4zN2vAji2KwXSo/fplAowqpoqzR+jpVoYo8Pzt3/Y+q8Z9meKbFpIgJbC9tRDh218j45KdGrfkJQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.975.1",
@@ -273,6 +272,7 @@
       "integrity": "sha512-OEpj0IEqUoJiEUa1/+/b+9OD9O20kR/c09VBxM1g/QeCfQqYaDr78HLN1zDSFGG7Y2wQeIPNKDF35IInaXnBWA==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "^3.975.1",
         "@aws-sdk/credential-provider-node": "^3.972.66",
@@ -334,8 +334,9 @@
       "version": "3.1084.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1084.0.tgz",
       "integrity": "sha512-W8KZlbU3vL4N0rZnXqryH5Ft3fkBnGypaorZmFxBoZRMGkwtvRBGiSnNXu1/1a/j/qZNwwt6LLNBWQQysB/pRg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/checksums": "^3.1000.16",
         "@aws-sdk/core": "^3.975.1",
@@ -379,6 +380,7 @@
       "integrity": "sha512-D2ocz+Q0Ajdq9RTfAWA2KYx3aJwdLIbiB8h1SY3rUTC81JwIL2EdJ0isGv6gHTtI/aXbQNS0kF20g+tuKxuXFg==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "^3.975.1",
         "@aws-sdk/credential-provider-node": "^3.972.66",
@@ -460,6 +462,7 @@
       "integrity": "sha512-LyRldNUFPS3ZDkY1D50WYBnXVf7f1hl7ifyshme5TSoWQ37jvAbeNtM92K+60VYz7WBDsqVWQ86PnUTofRmQOQ==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "^3.975.1",
         "@aws-sdk/credential-provider-node": "^3.972.66",
@@ -675,7 +678,6 @@
       "version": "3.972.26",
       "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.26.tgz",
       "integrity": "sha512-RE1fu7Nn05vG0EUJM+8Sde2GFecC658WGaC/asPzLF6K4x3H5ZaDBcQtHRE67Gdgb1VZpyUUliYejHFK1qt0Uw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.974.0",
@@ -708,7 +710,6 @@
       "version": "3.972.22",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.22.tgz",
       "integrity": "sha512-jtkgmhevnpzC1WeS+Y/sgymYbaQ6qg7pVOUl5cUT/8MiLptqrtnXQlNV80m+j2WIx5MIL7kVHIZNxxcK2tfUEQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.974.0",
@@ -724,7 +725,7 @@
       "version": "3.972.62",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.62.tgz",
       "integrity": "sha512-k8JJwYXVYlOOjWnPZDThQS1xDFJgi5Dokt73qFlDtrZAbdcint5aIdjB9XgJAAQVP5OoqcefQmh1FYXiPpvsvw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.975.1",
@@ -758,7 +759,6 @@
       "version": "3.972.39",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.39.tgz",
       "integrity": "sha512-CS1spxRSezmTmI3PD+3Xrnp6KryTSEz0EefA8u6uGd0s2I0uXseWHALDI/03Wi0IUczXNWo2QrZEaHDuJNby/Q==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.975.1",
@@ -874,6 +874,7 @@
       "integrity": "sha512-xLimZjA/ebA7jZn4NNkvLgj9WRl14rhidGND6oPt14s7ywe3I64g9X+WJpBraU5UR7loRq2K1tAXZj0FXkWLZg==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -937,6 +938,7 @@
       "integrity": "sha512-5FgxM4dLQpMJHSiVATk8foW263dVHQHBVpXYiimNECVWG01f4nFyEbQixeT6Mwvg7TayREJ2gpKl3o2RoMdnqw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^8.0.0",
         "@babel/generator": "^8.0.0",
@@ -5871,6 +5873,18 @@
         "revalidator": "^0.3.1"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "dev": true,
@@ -6045,9 +6059,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -6065,9 +6076,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -6085,9 +6093,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -6105,9 +6110,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -6125,9 +6127,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -6145,9 +6144,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -6165,9 +6161,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -6185,9 +6178,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -6205,9 +6195,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -6231,9 +6218,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -6257,9 +6241,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -6283,9 +6264,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -6309,9 +6287,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -6335,9 +6310,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -6361,9 +6333,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -6387,9 +6356,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -7002,6 +6968,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -7120,6 +7087,68 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -7228,6 +7257,7 @@
     "node_modules/@octokit/core": {
       "version": "7.0.6",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -7424,6 +7454,16 @@
         "node": ">= 20"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -7601,6 +7641,104 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@strands-agents/sdk": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@strands-agents/sdk/-/sdk-1.9.0.tgz",
+      "integrity": "sha512-9pO9BxzakCX1yQPWQMmr1BtYfjeUO3pFoMXTMyxB7kMtuJQww1txVPFUse8R89Wc2IbM4HcPZcvQOP/2q8dMwA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-bedrock-runtime": "^3.1078.0",
+        "@types/json-schema": "^7.0.15",
+        "uuid": "^14.0.1",
+        "yaml": "^2.8.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@a2a-js/sdk": "^0.3.10",
+        "@ai-sdk/provider": "^3.0.0",
+        "@anthropic-ai/sdk": "^0.109.1",
+        "@aws-sdk/client-bedrock-agent": "^3.1078.0",
+        "@aws-sdk/client-bedrock-agent-runtime": "^3.1078.0",
+        "@aws-sdk/client-s3": "^3.1078.0",
+        "@aws/bedrock-token-generator": "^1.1.0",
+        "@cedar-policy/cedar-wasm": "^4.0.0",
+        "@cedar-policy/mcp-schema-generator-wasm": "^0.6.0",
+        "@google/genai": "^2.6.0",
+        "@modelcontextprotocol/sdk": "^1.25.2",
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "^0.219.0",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
+        "@opentelemetry/resources": "^2.8.0",
+        "@opentelemetry/sdk-metrics": "^2.6.1",
+        "@opentelemetry/sdk-trace-base": "^2.6.1",
+        "@opentelemetry/sdk-trace-node": "^2.6.1",
+        "@smithy/types": "^4.15.1",
+        "express": "^5.1.0",
+        "openai": "^6.45.0",
+        "zod": "^4.1.12"
+      },
+      "peerDependenciesMeta": {
+        "@a2a-js/sdk": {
+          "optional": true
+        },
+        "@ai-sdk/provider": {
+          "optional": true
+        },
+        "@anthropic-ai/sdk": {
+          "optional": true
+        },
+        "@aws-sdk/client-bedrock-agent": {
+          "optional": true
+        },
+        "@aws-sdk/client-bedrock-agent-runtime": {
+          "optional": true
+        },
+        "@aws-sdk/client-s3": {
+          "optional": true
+        },
+        "@aws/bedrock-token-generator": {
+          "optional": true
+        },
+        "@cedar-policy/cedar-wasm": {
+          "optional": true
+        },
+        "@cedar-policy/mcp-schema-generator-wasm": {
+          "optional": true
+        },
+        "@google/genai": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-metrics-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/resources": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-metrics": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-node": {
+          "optional": true
+        },
+        "@smithy/types": {
+          "optional": true
+        },
+        "express": {
+          "optional": true
+        },
+        "openai": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
@@ -7719,13 +7857,13 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "25.3.1",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -8024,10 +8162,24 @@
         "win32"
       ]
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8057,6 +8209,45 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -8475,6 +8666,43 @@
       "version": "4.0.0",
       "license": "Apache-2.0"
     },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/bottleneck": {
       "version": "2.19.5",
       "license": "MIT"
@@ -8510,6 +8738,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -8540,6 +8769,15 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/c8": {
       "version": "11.0.0",
@@ -8707,6 +8945,35 @@
       },
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -8994,10 +9261,50 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
     },
     "node_modules/core-js-compat": {
       "version": "3.49.0",
@@ -9013,9 +9320,25 @@
         "url": "https://opencollective.com/core-js"
       }
     },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -9053,7 +9376,6 @@
     },
     "node_modules/debug": {
       "version": "4.4.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -9097,6 +9419,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "dev": true,
@@ -9128,11 +9459,31 @@
         "url": "https://dotenvx.com"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
@@ -9168,6 +9519,15 @@
         "node": ">=14"
       }
     },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
@@ -9178,6 +9538,36 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "dev": true,
@@ -9185,6 +9575,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "2.0.0",
@@ -9200,6 +9596,7 @@
       "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -9433,6 +9830,36 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "dev": true,
@@ -9481,6 +9908,68 @@
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
       }
     },
     "node_modules/extend-shallow": {
@@ -9547,7 +10036,6 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -9559,6 +10047,22 @@
       "version": "2.0.6",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -9600,6 +10104,27 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-up": {
@@ -9657,6 +10182,24 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "dev": true,
@@ -9677,6 +10220,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "dev": true,
@@ -9693,12 +10245,49 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-package-type": {
       "version": "0.1.0",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -9755,6 +10344,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "dev": true,
@@ -9800,10 +10401,64 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.30",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.30.tgz",
+      "integrity": "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -9811,6 +10466,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ignore": {
@@ -9871,8 +10542,25 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -9967,6 +10655,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "dev": true,
@@ -10030,7 +10724,6 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -10062,6 +10755,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -10360,6 +11054,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -10839,6 +11534,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -11053,6 +11749,15 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "dev": true,
@@ -11096,6 +11801,12 @@
       "version": "0.4.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -11246,6 +11957,15 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/maxmind": {
       "version": "5.0.6",
       "license": "MIT",
@@ -11258,10 +11978,56 @@
         "npm": ">=6"
       }
     },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
@@ -11317,7 +12083,6 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/napi-postinstall": {
@@ -11340,6 +12105,15 @@
       "version": "1.4.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/neo-async": {
       "version": "2.6.2",
@@ -11376,6 +12150,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/obliterator": {
@@ -11419,9 +12214,20 @@
         "node": ">= 20"
       }
     },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -11541,6 +12347,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "dev": true,
@@ -11559,7 +12374,6 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11580,6 +12394,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/picocolors": {
@@ -11606,6 +12430,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/pkg-dir": {
@@ -11681,6 +12514,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "dev": true,
@@ -11705,6 +12551,50 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/react-is-18": {
       "name": "react-is",
@@ -11788,6 +12678,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-cwd": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
@@ -11814,6 +12713,22 @@
       "license": "Apache 2.0",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/run-jxa": {
@@ -11844,6 +12759,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/section-matter": {
       "version": "1.0.0",
       "license": "MIT",
@@ -11862,6 +12783,57 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
     },
     "node_modules/sharp": {
       "version": "0.35.3",
@@ -11928,7 +12900,6 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -11939,7 +12910,6 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11957,6 +12927,78 @@
       "funding": {
         "type": "individual",
         "url": "https://www.paypal.me/tiviesantos"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/signal-exit": {
@@ -12003,6 +13045,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/string-length": {
@@ -12226,6 +13277,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "license": "0BSD"
@@ -12262,6 +13322,37 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/uglify-js": {
@@ -12364,6 +13455,15 @@
       "version": "7.0.3",
       "license": "ISC"
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
@@ -12436,6 +13536,19 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.2.0",
       "dev": true,
@@ -12447,6 +13560,15 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/walker": {
@@ -12461,7 +13583,6 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -12522,7 +13643,6 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
@@ -12560,6 +13680,21 @@
       "version": "3.1.1",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",
@@ -12619,8 +13754,18 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@aws-sdk/client-sesv2": "^3.1084.0",
     "@aws-sdk/signature-v4a": "^3.1082.0",
     "@github-docs/frontmatter": "^1.3.1",
+    "@strands-agents/sdk": "^1.9.0",
     "aws-jwt-verify": "^5.2.1",
     "handlebars": "^4.7.9",
     "maxmind": "^5.0.6",

--- a/template.yaml
+++ b/template.yaml
@@ -3380,7 +3380,7 @@ Resources:
         Variables:
           AWS_NODEJS_CONNECTION_REUSE_ENABLED: 1
           TABLE_NAME: !Ref NewsletterTable
-          MODEL_ID: us.amazon.nova-pro-v1:0
+          MODEL_ID: us.amazon.nova-lite-v1:0
           REDIRECT_URL: !If
             - HasRedirectCustomDomain
             - !Sub https://${RedirectCustomDomain}/r

--- a/template.yaml
+++ b/template.yaml
@@ -3360,6 +3360,7 @@ Resources:
       Runtime: nodejs24.x
       CodeUri: functions
       Handler: update-link-tracking.handler
+      Timeout: 60
       Policies:
         - AWSLambdaBasicExecutionRole
         - Version: 2012-10-17
@@ -3368,6 +3369,7 @@ Resources:
               Action:
                 - dynamodb:PutItem
                 - dynamodb:GetItem
+                - dynamodb:UpdateItem
               Resource: !GetAtt NewsletterTable.Arn
             - Effect: Allow
               Action: bedrock:InvokeModel


### PR DESCRIPTION
## Summary

- Replace the custom JavaScript Bedrock agent loop with a Strands-backed helper.
- Move link classification to Strands structured output with the vended HTTP request tool.
- Migrate setup-voting-options from raw Bedrock Converse tool plumbing to Strands structured output.
- Keep link enrichment bounded, add the missing DynamoDB UpdateItem permission, and add focused regression coverage.

## Why

UpdateLinksWithTrackingDataFunction was timing out after the latest link-classification path started doing model/tool-use work per link. The custom loop made that behavior harder to reason about and duplicated agent orchestration that Strands already provides.

## Validation

- `npm test -- --runTestsByPath functions/__tests__/setup-voting-options.test.mjs functions/__tests__/update-link-tracking-handler.test.mjs functions/__tests__/calculate-pricing.test.mjs functions/__tests__/generate-outreach.test.mjs`
- `npx eslint functions/setup-voting-options.mjs functions/__tests__/setup-voting-options.test.mjs functions/update-link-tracking.mjs functions/__tests__/update-link-tracking-handler.test.mjs functions/utils/agents.mjs functions/utils/llm-link-classifier.mjs`
- import smoke test for setup voting and Strands modules

## Notes

The remaining custom agent loop is the Rust Bedrock helper in `functions/src/shared/ai/bedrock.rs`; this PR keeps that separate from the JavaScript Strands migration.