### PR TITLE
Fix link-tracking drop-off from URL rewrite/encoding bugs

### DIFF
--- a/functions/__tests__/update-link-tracking-handler.test.mjs
+++ b/functions/__tests__/update-link-tracking-handler.test.mjs
@@ -50,6 +50,51 @@ describe('update-link-tracking handler', () => {
     expect(result.content).toContain('s=__EMAIL_HASH__');
   });
 
+  test('encodes the destination so query-string links round-trip to the same hash', async () => {
+    // A URL with query params (UTM tags) must be encoded such that its `&`/`?`
+    // do not leak out of the `u=` param and split the redirect query string.
+    // Otherwise the redirect truncates the destination and the logged click
+    // hashes to a different link record, so the increment is silently dropped.
+    const url = 'https://example.com/post?utm_source=newsletter&utm_medium=email';
+    const result = await handler({
+      tenantId: 'tenant123',
+      issueId: '42',
+      content: `Read [the post](${url}) today.`
+    });
+
+    const expected = `u=${encodeURIComponent(url)}`;
+    expect(result.content).toContain(expected);
+    // The raw, unescaped ampersand must not appear inside the tracking link.
+    expect(result.content).not.toContain('utm_medium=email&cid=');
+    // The value under `u=` must decode back to the exact original URL.
+    const uValue = result.content.match(/u=([^&]+)&cid=/)[1];
+    expect(decodeURIComponent(uValue)).toBe(url);
+  });
+
+  test('tracks every occurrence when a URL is reused / is a prefix of others', async () => {
+    // The homepage URL is a prefix of the article URL and appears twice. The old
+    // first-occurrence substring replace left later occurrences un-tracked and
+    // corrupted earlier links; every link must now become a distinct tracking URL.
+    const home = 'https://readysetcloud.io';
+    const article = 'https://readysetcloud.io/serverless';
+    const result = await handler({
+      tenantId: 'tenant123',
+      issueId: '42',
+      content: `Welcome to [home](${home}). Read [serverless](${article}). Visit [home again](${home}).`
+    });
+
+    // No original URL should remain as a bare markdown target (all rewritten).
+    expect(result.content).not.toContain(`](${home})`);
+    expect(result.content).not.toContain(`](${article})`);
+    // Positions 1, 2, 3 all present -> all three links tracked.
+    expect(result.content).toContain('p=1');
+    expect(result.content).toContain('p=2');
+    expect(result.content).toContain('p=3');
+    // No double-wrapped redirect (a symptom of the substring-collision bug).
+    expect(result.content).not.toMatch(/u=[^&]*r(?:edirect)?\.example\.com/);
+    expect(result.content).not.toContain(`u=${encodeURIComponent(process.env.REDIRECT_URL)}`);
+  });
+
   test('stores the LLM topic classification and summary on the link record', async () => {
     mockClassifyLinkWithLlm.mockResolvedValue({
       primaryTopic: 'ai',

--- a/functions/update-link-tracking.mjs
+++ b/functions/update-link-tracking.mjs
@@ -64,19 +64,43 @@ function extractContext(content, matchIndex) {
 }
 
 export const handler = async (state) => {
-  const links = extractLinks(state.content);
+  const cid = `${state.tenantId}#${state.issueId}`;
+  const linkRegex = /\[(.*?)\]\((.*?)\)/g;
   let linkPosition = 0;
-
-  let updatedContent = state.content;
   const linkTasks = [];
-  for (const { url, anchorText, context } of links) {
+
+  // Rewrite each markdown link in a single pass keyed on the link syntax itself.
+  // A previous implementation replaced the bare URL substring one link at a time
+  // (updatedContent.replace(url, ...)). That was doubly broken:
+  //   1. String.replace(url, ...) only touches the FIRST occurrence, and the
+  //      replacement embeds the original URL as the `u=` param. A later link whose
+  //      URL is a prefix of an earlier one (a bare domain / homepage reused across
+  //      the issue) then matched INSIDE the already-rewritten tracking URL, so it
+  //      was left un-tracked while corrupting the earlier link. Rewriting the whole
+  //      `[text](url)` match in place avoids matching text we just inserted.
+  //   2. encodeURI() leaves `&`, `?`, `=`, `#`, `+` unescaped. For any URL carrying
+  //      a query string (UTM tags, campaign params — common on the sponsor/CTA links
+  //      near the bottom of an issue) the extra `&`s split the redirect query string,
+  //      truncating the destination. The redirect then logged the truncated URL,
+  //      whose hash no longer matched the link record, so the click increment failed
+  //      its ConditionalCheck and was silently dropped. encodeURIComponent() keeps
+  //      the destination intact so it round-trips to the same `link#<hash>` record.
+  const updatedContent = state.content.replace(linkRegex, (match, anchorText, url, offset) => {
+    if (!url || url.indexOf('mailto:') !== -1) {
+      return match;
+    }
+
     linkPosition += 1;
-    linkTasks.push({ url, anchorText, context, position: linkPosition });
-    updatedContent = updatedContent.replace(
+    linkTasks.push({
       url,
-      `${process.env.REDIRECT_URL}?u=${encodeURI(url)}&cid=${encodeURIComponent(`${state.tenantId}#${state.issueId}`)}&p=${encodeURIComponent(linkPosition)}&s=__EMAIL_HASH__`
-    );
-  }
+      anchorText,
+      context: extractContext(state.content, offset),
+      position: linkPosition
+    });
+
+    const trackingUrl = `${process.env.REDIRECT_URL}?u=${encodeURIComponent(url)}&cid=${encodeURIComponent(cid)}&p=${encodeURIComponent(linkPosition)}&s=__EMAIL_HASH__`;
+    return `[${anchorText}](${trackingUrl})`;
+  });
 
   await processLinks(linkTasks, state.tenantId, state.issueId);
 


### PR DESCRIPTION
The click-tracking rewrite in update-link-tracking rewrote each link with
`updatedContent.replace(url, ...)` and encoded the destination with
`encodeURI`. Both are broken in ways that silently lose clicks for a
consistent subset of links every issue:

1. String.replace(url, ...) only replaces the first occurrence, and the
   replacement embeds the original URL in the `u=` param. A later link
   whose URL is a prefix of an earlier one (a bare domain / homepage
   reused across the issue) then matched INSIDE an already-rewritten
   tracking URL, leaving that link un-tracked and corrupting the earlier
   one.

2. encodeURI leaves `&`, `?`, `=`, `#`, `+` unescaped. Any URL with a
   query string (UTM/campaign params, common on sponsor and CTA links)
   leaked its `&` into the redirect query string, truncating the
   destination. The redirect then logged the truncated URL, whose hash no
   longer matched the link record, so the click increment failed its
   ConditionalCheck and was dropped.

Rewrite links in a single regex pass keyed on the `[text](url)` markdown
syntax (so we never match text we just inserted) and encode the
destination with encodeURIComponent so it round-trips to the same
`link#<hash>` record. Adds regression tests for both failure modes.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WrjDU8gPJVr6QrkdowBmEF