### PR TITLE
Mark A/B tests as 'testing' once the sample is sent

### DIFF
--- a/__tests__/send-email-v2.test.mjs
+++ b/__tests__/send-email-v2.test.mjs
@@ -553,6 +553,29 @@ describe('send-email-v2', () => {
       expect(detail.sendPayload.html).toBe('<p>Hello __EMAIL__</p>');
       expect(detail.sendPayload.to.list).toBe('my-list');
     });
+
+    test('marks the test as testing once the sample has been sent', async () => {
+      listSubscribers.mockResolvedValue({ subscribers: makeSubscribers(20), lastEvaluatedKey: undefined });
+
+      await handler({ detail: { ...abEvent.detail } });
+
+      const newsletterUpdates = ddbInstance.send.mock.calls
+        .map(([cmd]) => cmd)
+        .filter((cmd) => cmd.__type === 'UpdateItem' && cmd.Key?.marshalled?.sk === 'newsletter');
+      expect(newsletterUpdates).toHaveLength(1);
+
+      const update = newsletterUpdates[0];
+      expect(update.Key.marshalled.pk).toBe('tenant-123#42');
+      // Both the CAS mirror and embedded status flip to 'testing', and the write
+      // is guarded so it can only advance a still-pending test.
+      expect(update.UpdateExpression).toContain('abTestStatus = :testing');
+      expect(update.ConditionExpression).toContain('abTestStatus = :pending');
+      const values = update.ExpressionAttributeValues.marshalled;
+      expect(values[':testing']).toBe('testing');
+      const persisted = JSON.parse(values[':ab']);
+      expect(persisted.status).toBe('testing');
+      expect(persisted.dimension).toBe('subject');
+    });
   });
 
   describe('A/B send-time testing', () => {
@@ -615,6 +638,21 @@ describe('send-email-v2', () => {
       expect(schedulerInstance.send).toHaveBeenCalledTimes(1);
       const entry = JSON.parse(schedulerInstance.send.mock.calls[0][0].Target.Input).Entries[0];
       expect(entry.DetailType).toBe('Evaluate AB Test');
+    });
+
+    test('marks the test as testing when fanning out per-variant sends', async () => {
+      await handler({ detail: sendTimeDetail() });
+
+      const newsletterUpdates = ddbInstance.send.mock.calls
+        .map(([cmd]) => cmd)
+        .filter((cmd) => cmd.__type === 'UpdateItem' && cmd.Key?.marshalled?.sk === 'newsletter');
+      expect(newsletterUpdates).toHaveLength(1);
+
+      const values = newsletterUpdates[0].ExpressionAttributeValues.marshalled;
+      expect(values[':testing']).toBe('testing');
+      const persisted = JSON.parse(values[':ab']);
+      expect(persisted.status).toBe('testing');
+      expect(persisted.dimension).toBe('sendTime');
     });
 
     test('per-variant fire (variantFilter) sends only that variant bucket and schedules nothing', async () => {

--- a/dashboard-ui/src/components/issues/AbTestInProgress.tsx
+++ b/dashboard-ui/src/components/issues/AbTestInProgress.tsx
@@ -1,0 +1,266 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import {
+  FlaskConical,
+  Mail,
+  Clock,
+  Loader2,
+  AlertCircle,
+  ArrowRight,
+} from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '../ui/Card';
+import { cn } from '../../utils/cn';
+import type {
+  ActiveAbTest,
+  AbTestStatus,
+  VariantId,
+  AbTestWinMetric,
+  VariantStats,
+} from '../../types/issues';
+
+export interface AbTestInProgressProps {
+  /** In-progress A/B tests to surface. */
+  tests?: ActiveAbTest[];
+  /** Whether the active tests are currently loading. */
+  loading?: boolean;
+  /** An error message to surface instead of the panel body. */
+  error?: string | null;
+  /** Optional retry handler shown alongside the error state. */
+  onRetry?: () => void;
+}
+
+const VARIANT_LABELS: Record<VariantId, string> = {
+  a: 'A',
+  b: 'B',
+};
+
+// Only the non-final states reach this panel; each gets a spinner to read as
+// "live". Mirrors the badge styling used on the issue-detail A/B results panel.
+const STATUS_CONFIG: Record<
+  Extract<AbTestStatus, 'pending' | 'testing' | 'evaluating'>,
+  { label: string; className: string }
+> = {
+  pending: {
+    label: 'Starting',
+    className:
+      'bg-gray-100 text-gray-800 border-gray-300 dark:bg-gray-700 dark:text-gray-100 dark:border-gray-500',
+  },
+  testing: {
+    label: 'Testing',
+    className:
+      'bg-blue-100 text-blue-800 border-blue-300 dark:bg-blue-800/60 dark:text-blue-100 dark:border-blue-400',
+  },
+  evaluating: {
+    label: 'Evaluating',
+    className:
+      'bg-yellow-100 text-yellow-800 border-yellow-300 dark:bg-yellow-800/60 dark:text-yellow-100 dark:border-yellow-400',
+  },
+};
+
+const formatRate = (successes: number, deliveries: number): string => {
+  if (!deliveries || deliveries <= 0) return '—';
+  return `${((successes / deliveries) * 100).toFixed(1)}%`;
+};
+
+const statsFor = (
+  variantStats: VariantStats[],
+  variantId: VariantId
+): VariantStats | undefined => variantStats.find((s) => s.variantId === variantId);
+
+interface VariantProgressProps {
+  variantId: VariantId;
+  label: string;
+  stats?: VariantStats;
+  winMetric: AbTestWinMetric;
+}
+
+const VariantProgress: React.FC<VariantProgressProps> = ({
+  variantId,
+  label,
+  stats,
+  winMetric,
+}) => {
+  const deliveries = stats?.deliveries ?? 0;
+  const successes =
+    winMetric === 'clickRate' ? stats?.clicks ?? 0 : stats?.opens ?? 0;
+
+  return (
+    <div className="rounded-md border border-border bg-muted/40 p-2" aria-label={`Variant ${VARIANT_LABELS[variantId]} progress`}>
+      <div className="flex items-center justify-between gap-1">
+        <span className="text-xs font-semibold text-foreground">
+          Variant {VARIANT_LABELS[variantId]}
+        </span>
+        <span className="text-xs text-muted-foreground">
+          {winMetric === 'clickRate' ? 'Click rate' : 'Open rate'}
+        </span>
+      </div>
+      <p className="text-xs text-muted-foreground truncate mb-1" title={label}>
+        {label}
+      </p>
+      <div className="text-lg font-bold text-foreground">
+        {formatRate(successes, deliveries)}
+      </div>
+      <div className="text-xs text-muted-foreground">
+        {successes} / {deliveries} delivered
+      </div>
+    </div>
+  );
+};
+
+const variantDescriptor = (test: ActiveAbTest, variantId: VariantId): string => {
+  const variant = test.variants.find((v) => v.variantId === variantId);
+  if (!variant) return '';
+  if (test.dimension === 'subject') return variant.subject || 'No subject set';
+  return variant.sendAt || 'No send time set';
+};
+
+const TestCard: React.FC<{ test: ActiveAbTest }> = ({ test }) => {
+  const status = STATUS_CONFIG[test.status as keyof typeof STATUS_CONFIG] ?? STATUS_CONFIG.testing;
+  const winMetric = test.winMetric ?? 'openRate';
+
+  return (
+    <div className="rounded-lg border border-border bg-background p-3 sm:p-4">
+      <div className="flex items-start justify-between gap-3 mb-3">
+        <div className="min-w-0">
+          <Link
+            to={`/issues/${test.issueId}`}
+            className="group inline-flex items-center gap-1 text-sm font-semibold text-foreground hover:text-primary-600 dark:hover:text-primary-400"
+          >
+            Issue #{test.issueNumber}
+            <ArrowRight className="w-3.5 h-3.5 opacity-0 group-hover:opacity-100 transition-opacity" aria-hidden="true" />
+          </Link>
+          <p className="text-xs text-muted-foreground truncate" title={test.subject}>
+            {test.subject}
+          </p>
+        </div>
+        <div className="flex items-center gap-2 flex-shrink-0">
+          <span className="inline-flex items-center gap-1 text-xs text-muted-foreground font-medium">
+            {test.dimension === 'subject' ? (
+              <Mail className="w-3.5 h-3.5" aria-hidden="true" />
+            ) : (
+              <Clock className="w-3.5 h-3.5" aria-hidden="true" />
+            )}
+            <span className="hidden sm:inline">
+              {test.dimension === 'subject' ? 'Subject line' : 'Send time'}
+            </span>
+          </span>
+          <span
+            className={cn(
+              'inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium border',
+              status.className
+            )}
+            role="status"
+            aria-label={`A/B test status: ${status.label}`}
+          >
+            <Loader2 className="w-3 h-3 animate-spin" aria-hidden="true" />
+            {status.label}
+          </span>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2">
+        <VariantProgress
+          variantId="a"
+          label={variantDescriptor(test, 'a')}
+          stats={statsFor(test.variantStats, 'a')}
+          winMetric={winMetric}
+        />
+        <VariantProgress
+          variantId="b"
+          label={variantDescriptor(test, 'b')}
+          stats={statsFor(test.variantStats, 'b')}
+          winMetric={winMetric}
+        />
+      </div>
+
+      <p className="mt-2 text-xs text-muted-foreground">
+        The winner is sent to the rest of your list automatically once the hold-out
+        window closes
+        {typeof test.evaluateAfterMinutes === 'number'
+          ? ` (about ${test.evaluateAfterMinutes} min after the test send).`
+          : '.'}
+      </p>
+    </div>
+  );
+};
+
+/**
+ * Dashboard panel that surfaces A/B tests that are actively running — the sample
+ * has been sent but the winner has not been decided yet — with live per-variant
+ * engagement. Renders nothing when there are no active tests so the dashboard
+ * stays uncluttered between tests.
+ */
+export const AbTestInProgress: React.FC<AbTestInProgressProps> = ({
+  tests,
+  loading = false,
+  error = null,
+  onRetry,
+}) => {
+  if (loading) {
+    return (
+      <Card>
+        <CardContent className="py-6">
+          <div className="flex items-center gap-2 text-sm text-muted-foreground" role="status" aria-live="polite">
+            <Loader2 className="w-4 h-4 animate-spin" aria-hidden="true" />
+            Checking for running A/B tests…
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card>
+        <CardContent className="py-6">
+          <div className="flex items-start gap-2" role="alert">
+            <AlertCircle className="w-4 h-4 mt-0.5 text-error-500 flex-shrink-0" aria-hidden="true" />
+            <div>
+              <p className="text-sm font-medium text-foreground">Couldn’t load running A/B tests</p>
+              <p className="text-xs text-muted-foreground mt-0.5">{error}</p>
+              {onRetry && (
+                <button
+                  type="button"
+                  onClick={onRetry}
+                  className="mt-2 text-xs font-medium text-primary-600 hover:text-primary-700 dark:text-primary-400"
+                >
+                  Try again
+                </button>
+              )}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // Nothing running — render nothing so the section collapses cleanly.
+  if (!tests || tests.length === 0) {
+    return null;
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <FlaskConical className="w-5 h-5" aria-hidden="true" />
+          A/B Tests In Progress
+          <span className="inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1.5 rounded-full text-xs font-semibold bg-primary-100 text-primary-800 dark:bg-primary-900/40 dark:text-primary-200">
+            {tests.length}
+          </span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-3">
+          {tests.map((test) => (
+            <TestCard key={test.issueId} test={test} />
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+AbTestInProgress.displayName = 'AbTestInProgress';
+
+export default AbTestInProgress;

--- a/dashboard-ui/src/components/issues/__tests__/AbTestInProgress.test.tsx
+++ b/dashboard-ui/src/components/issues/__tests__/AbTestInProgress.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { AbTestInProgress } from '../AbTestInProgress';
+import type { ActiveAbTest } from '@/types/issues';
+
+const renderWithRouter = (ui: React.ReactElement) =>
+  render(<MemoryRouter>{ui}</MemoryRouter>);
+
+const activeTest = (overrides: Partial<ActiveAbTest> = {}): ActiveAbTest => ({
+  issueId: '42',
+  issueNumber: 42,
+  subject: 'Weekly digest',
+  dimension: 'subject',
+  status: 'testing',
+  winMetric: 'openRate',
+  evaluateAfterMinutes: 120,
+  variants: [
+    { variantId: 'a', subject: 'Control subject' },
+    { variantId: 'b', subject: 'Challenger subject' },
+  ],
+  variantStats: [
+    { variantId: 'a', opens: 50, clicks: 10, deliveries: 100 },
+    { variantId: 'b', opens: 70, clicks: 20, deliveries: 100 },
+  ],
+  ...overrides,
+});
+
+describe('AbTestInProgress', () => {
+  it('renders nothing when there are no running tests', () => {
+    const { container } = renderWithRouter(<AbTestInProgress tests={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders a loading state', () => {
+    renderWithRouter(<AbTestInProgress loading />);
+    expect(screen.getByText(/checking for running a\/b tests/i)).toBeInTheDocument();
+  });
+
+  it('renders an error with a retry affordance', () => {
+    renderWithRouter(<AbTestInProgress error="boom" onRetry={() => {}} />);
+    expect(screen.getByText(/couldn.t load running a\/b tests/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+  });
+
+  it('renders a running test with live open rates and a link to the issue', () => {
+    renderWithRouter(<AbTestInProgress tests={[activeTest()]} />);
+
+    // Count badge + issue link.
+    expect(screen.getByText('A/B Tests In Progress')).toBeInTheDocument();
+    const link = screen.getByRole('link', { name: /issue #42/i });
+    expect(link).toHaveAttribute('href', '/issues/42');
+
+    // Status badge reflects the live 'testing' state.
+    expect(screen.getByText('Testing')).toBeInTheDocument();
+
+    // Open rates: A 50/100 = 50.0%, B 70/100 = 70.0%.
+    expect(screen.getByText('50.0%')).toBeInTheDocument();
+    expect(screen.getByText('70.0%')).toBeInTheDocument();
+    expect(screen.getByText(/120 min/i)).toBeInTheDocument();
+  });
+
+  it('uses click rate when winMetric is clickRate', () => {
+    renderWithRouter(
+      <AbTestInProgress tests={[activeTest({ winMetric: 'clickRate' })]} />
+    );
+    // A clicks 10/100 = 10.0%, B clicks 20/100 = 20.0%.
+    expect(screen.getByText('10.0%')).toBeInTheDocument();
+    expect(screen.getByText('20.0%')).toBeInTheDocument();
+    expect(screen.getAllByText('Click rate').length).toBe(2);
+  });
+
+  it('guards divide-by-zero deliveries', () => {
+    renderWithRouter(
+      <AbTestInProgress
+        tests={[
+          activeTest({
+            variantStats: [{ variantId: 'a', opens: 0, clicks: 0, deliveries: 0 }],
+          }),
+        ]}
+      />
+    );
+    expect(screen.getAllByText('—').length).toBeGreaterThan(0);
+  });
+});

--- a/dashboard-ui/src/pages/dashboard/DashboardPage.tsx
+++ b/dashboard-ui/src/pages/dashboard/DashboardPage.tsx
@@ -10,7 +10,7 @@ import MetricsCard from '@/components/MetricsCard';
 import { SubscriberGrowthChart } from '@/components/SubscriberGrowthChart';
 import { MiniSparkline } from '@/components/MiniSparkline';
 import type { TrendsData, UserProfile, TrendComparison } from '@/types';
-import type { AbHistoryResponse } from '@/types/issues';
+import type { AbHistoryResponse, ActiveAbTest } from '@/types/issues';
 import { useAuth } from '@/contexts/AuthContext';
 import { calculatePercentageDifference, calculateHealthStatus } from '@/utils/analyticsCalculations';
 import {
@@ -33,6 +33,9 @@ const TopRegionsWidget = lazy(() => import('@/components/TopRegionsWidget'));
 const AbTestHistory = lazy(() =>
   import('@/components/issues/AbTestHistory').then((m) => ({ default: m.AbTestHistory }))
 );
+const AbTestInProgress = lazy(() =>
+  import('@/components/issues/AbTestInProgress').then((m) => ({ default: m.AbTestInProgress }))
+);
 
 export function DashboardPage() {
   const { user } = useAuth();
@@ -43,6 +46,9 @@ export function DashboardPage() {
   const [abHistory, setAbHistory] = useState<AbHistoryResponse | null>(null);
   const [abHistoryLoading, setAbHistoryLoading] = useState(true);
   const [abHistoryError, setAbHistoryError] = useState<string | null>(null);
+  const [activeAbTests, setActiveAbTests] = useState<ActiveAbTest[]>([]);
+  const [activeAbLoading, setActiveAbLoading] = useState(true);
+  const [activeAbError, setActiveAbError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -209,10 +215,29 @@ export function DashboardPage() {
     }
   }, []);
 
+  const loadActiveAbTests = useCallback(async () => {
+    try {
+      setActiveAbLoading(true);
+      setActiveAbError(null);
+      const response = await issuesService.getActiveAbTests();
+      if (response.success && response.data) {
+        setActiveAbTests(response.data.tests);
+      } else {
+        setActiveAbError(response.error || 'Failed to load running A/B tests');
+      }
+    } catch (err) {
+      console.error('Active A/B tests error:', err);
+      setActiveAbError(err instanceof Error ? err.message : 'Failed to load running A/B tests');
+    } finally {
+      setActiveAbLoading(false);
+    }
+  }, []);
+
   const handleRefresh = () => {
     dashboardService.invalidateTrendsCache();
     loadTrendsData(true);
     loadAbHistory();
+    loadActiveAbTests();
   };
 
   useEffect(() => {
@@ -241,6 +266,10 @@ export function DashboardPage() {
   useEffect(() => {
     loadAbHistory();
   }, [loadAbHistory]);
+
+  useEffect(() => {
+    loadActiveAbTests();
+  }, [loadActiveAbTests]);
 
   const formatPercentage = (value: number) => `${value.toFixed(1)}%`;
   const formatNumber = (value: number) => value.toLocaleString();
@@ -679,6 +708,17 @@ export function DashboardPage() {
                 <div className="flex items-center justify-between pt-2 border-t border-border">
                   <h3 className="text-sm uppercase tracking-widest text-muted-foreground">A/B Testing</h3>
                 </div>
+                {/* In-progress tests (running now) surface above the completed history. */}
+                {(activeAbLoading || activeAbError || activeAbTests.length > 0) && (
+                  <Suspense fallback={<div className="bg-surface rounded-lg shadow p-6 animate-pulse h-32" />}>
+                    <AbTestInProgress
+                      tests={activeAbTests}
+                      loading={activeAbLoading}
+                      error={activeAbError}
+                      onRetry={loadActiveAbTests}
+                    />
+                  </Suspense>
+                )}
                 <Suspense fallback={<div className="bg-surface rounded-lg shadow p-6 animate-pulse h-48" />}>
                   <AbTestHistory
                     data={abHistory}

--- a/dashboard-ui/src/services/issuesService.ts
+++ b/dashboard-ui/src/services/issuesService.ts
@@ -10,6 +10,7 @@ import type {
   ListIssuesParams,
   VariantId,
   AbHistoryResponse,
+  ActiveAbTestsResponse,
   AbSuggestionRequest,
   AbSuggestionResponse,
 } from '@/types/issues';
@@ -166,6 +167,16 @@ class IssuesService {
    */
   async getAbHistory(): Promise<ApiResponse<AbHistoryResponse>> {
     return apiClient.get<AbHistoryResponse>('/ab-test/history');
+  }
+
+  /**
+   * Retrieves the tenant's in-progress A/B tests: managed tests whose sample has
+   * been sent but whose winner has not been decided yet, with live per-variant
+   * engagement counters. Used for the dashboard's "test in progress" indicator.
+   * @returns Promise resolving to the active A/B tests response
+   */
+  async getActiveAbTests(): Promise<ApiResponse<ActiveAbTestsResponse>> {
+    return apiClient.get<ActiveAbTestsResponse>('/ab-test/active');
   }
 
   /**

--- a/dashboard-ui/src/types/issues.ts
+++ b/dashboard-ui/src/types/issues.ts
@@ -394,6 +394,34 @@ export interface AbHistoryResponse {
 }
 
 // ---------------------------------------------------------------------------
+// Active A/B tests (in progress) — GET /ab-test/active
+// ---------------------------------------------------------------------------
+
+/** A single in-progress A/B test surfaced on the dashboard. */
+export interface ActiveAbTest {
+  /** Issue id (issue number as a string), matching the issue detail route. */
+  issueId: string;
+  issueNumber: number;
+  /** The issue's subject line. */
+  subject: string;
+  dimension: AbTestDimension;
+  /** Non-final lifecycle state: 'pending' | 'testing' | 'evaluating'. */
+  status: AbTestStatus;
+  winMetric: AbTestWinMetric;
+  publishedAt?: string;
+  /** Hold-out wait before the winner is evaluated. */
+  evaluateAfterMinutes?: number;
+  variants: AbTestVariant[];
+  /** Live per-variant engagement counters collected so far. */
+  variantStats: VariantStats[];
+}
+
+/** Response payload for GET /ab-test/active. */
+export interface ActiveAbTestsResponse {
+  tests: ActiveAbTest[];
+}
+
+// ---------------------------------------------------------------------------
 // A/B test AI suggestions (POST /ab-test/suggestions)
 // ---------------------------------------------------------------------------
 

--- a/functions/send-email-v2.mjs
+++ b/functions/send-email-v2.mjs
@@ -453,6 +453,61 @@ const scheduleAbEvaluation = async ({ tenantId, referenceNumber, abTest, subject
 };
 
 /**
+ * Transitions a managed A/B test from `pending` to `testing` the moment the test
+ * sample has actually gone out (subject tests) or the per-variant sends have been
+ * fanned out (send-time tests). Without this the test stays `pending` for the
+ * entire hold-out window, so the dashboard shows an inert "Pending" badge with
+ * zero variant stats from publish until evaluation — indistinguishable, to the
+ * user, from the test never having been picked up at all.
+ *
+ * Both the embedded `abTest.status` (what the dashboard reads) and the top-level
+ * `abTestStatus` CAS mirror (what evaluate-ab-winner claims on) are written
+ * together, mirroring how finalizeEvaluation keeps the two in sync. The write is
+ * conditional on the test still being unset/`pending` so a redelivery can never
+ * regress a test that has already been claimed (`evaluating`) or finalized
+ * (`sent`/`inconclusive`). Best-effort: a failure here is logged, not thrown, so
+ * it never fails an otherwise-successful send.
+ *
+ * @param {Object} params
+ * @param {string} params.tenantId
+ * @param {string} params.referenceNumber - `${tenantId}_${issueNumber}`
+ * @param {Object} params.abTest - The managed A/B config; its status is set to 'testing'.
+ */
+const markAbTestTesting = async ({ tenantId, referenceNumber, abTest }) => {
+  if (!referenceNumber) {
+    console.warn('[A/B] Skipping testing-status transition - missing referenceNumber');
+    return;
+  }
+
+  const issueNumber = referenceNumber.slice(referenceNumber.lastIndexOf('_') + 1);
+  const issueId = `${tenantId}#${issueNumber}`;
+  const updatedAbTest = { ...abTest, status: 'testing' };
+
+  try {
+    await ddb.send(new UpdateItemCommand({
+      TableName: process.env.TABLE_NAME,
+      Key: marshall({ pk: issueId, sk: 'newsletter' }),
+      UpdateExpression: 'SET abTest = :ab, abTestStatus = :testing, updatedAt = :now',
+      ConditionExpression: 'attribute_not_exists(abTestStatus) OR abTestStatus = :pending',
+      ExpressionAttributeValues: marshall({
+        ':ab': JSON.stringify(updatedAbTest),
+        ':testing': 'testing',
+        ':pending': 'pending',
+        ':now': new Date().toISOString()
+      })
+    }));
+    console.log(`[A/B] Marked test as testing for ${referenceNumber}`);
+  } catch (err) {
+    if (err.name === 'ConditionalCheckFailedException') {
+      // Already claimed, finalized, or marked testing by a prior delivery.
+      console.log('[A/B] Test already past pending, leaving status unchanged', { issueId });
+      return;
+    }
+    console.error('[A/B] Failed to mark test as testing', { issueId, error: err.message });
+  }
+};
+
+/**
  * Fan out a send-time A/B test: emit one `Send Email v2` event per variant, each
  * carrying a `variantFilter` and the variant's `sendAt`. The existing future-send
  * scheduling defers each event to its send time; when it fires, the handler sends
@@ -575,6 +630,7 @@ export const handler = async (event) => {
       await executePhase('A/B Send-Time Fan-Out', async () => {
         await fanOutSendTimeVariants({ data, subject, html, to, tenantId, replacements, from, abTest });
         await scheduleAbEvaluation({ tenantId, referenceNumber: data.referenceNumber, abTest, subject, html, replacements, from, to });
+        await markAbTestTesting({ tenantId, referenceNumber: data.referenceNumber, abTest });
       });
       console.log('[EXECUTION COMPLETE] Send-time A/B test fanned out to per-variant sends');
       return { sent: false, scheduled: true, abTest: 'sendTime', variants: abTest.variants.length };
@@ -693,7 +749,7 @@ export const handler = async (event) => {
     // (variantFilter set) must not schedule a duplicate.
     if (abTest && to.list && !variantFilter) {
       await executePhase('Schedule A/B Evaluation', async () => {
-        return await scheduleAbEvaluation({
+        await scheduleAbEvaluation({
           tenantId,
           referenceNumber: data.referenceNumber,
           abTest,
@@ -702,6 +758,7 @@ export const handler = async (event) => {
           from,
           to
         });
+        await markAbTestTesting({ tenantId, referenceNumber: data.referenceNumber, abTest });
       });
     }
 

--- a/functions/src/api/controllers/issues.rs
+++ b/functions/src/api/controllers/issues.rs
@@ -406,6 +406,13 @@ pub async fn get_ab_history(event: Request) -> Result<Response<Body>, Error> {
     }
 }
 
+pub async fn get_active_ab_tests(event: Request) -> Result<Response<Body>, Error> {
+    match handle_get_active_ab_tests(event).await {
+        Ok(response) => Ok(response),
+        Err(e) => Ok(response::format_error_response(&e)),
+    }
+}
+
 pub async fn suggest_ab_test(event: Request) -> Result<Response<Body>, Error> {
     match handle_suggest_ab_test(event).await {
         Ok(response) => Ok(response),
@@ -757,6 +764,188 @@ async fn handle_get_ab_history(event: Request) -> Result<Response<Body>, AppErro
     let aggregates = compute_ab_history_aggregates(&tests);
 
     response::format_response(200, AbHistoryResponse { tests, aggregates })
+}
+
+// ---------------------------------------------------------------------------
+// Active A/B tests (in-progress, cross-issue)
+// ---------------------------------------------------------------------------
+
+// A/B lifecycle states that mean the test is still running — the sample has gone
+// out and a winner has not been decided yet. These are exactly the non-final
+// statuses (everything except `sent`/`inconclusive`); the dashboard surfaces
+// them as "in progress".
+const IN_PROGRESS_AB_STATUSES: [&str; 3] = ["pending", "testing", "evaluating"];
+
+// Upper bound on newsletter records scanned (newest-first) when collecting
+// in-progress tests. An active test always sits within a tenant's most recent
+// issues — its hold-out window is measured in hours — so a bounded recent window
+// is sufficient and keeps the DynamoDB read (and the API Lambda's latency) flat
+// regardless of how many issues a tenant has published.
+const ACTIVE_AB_SCAN_LIMIT: i32 = 25;
+
+#[derive(Serialize)]
+pub struct ActiveAbTestVariant {
+    #[serde(rename = "variantId")]
+    variant_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    subject: Option<String>,
+    #[serde(rename = "sendAt", skip_serializing_if = "Option::is_none")]
+    send_at: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct ActiveAbTest {
+    #[serde(rename = "issueId")]
+    issue_id: String,
+    #[serde(rename = "issueNumber")]
+    issue_number: i32,
+    subject: String,
+    dimension: String,
+    status: String,
+    #[serde(rename = "winMetric")]
+    win_metric: String,
+    #[serde(rename = "publishedAt", skip_serializing_if = "Option::is_none")]
+    published_at: Option<String>,
+    #[serde(rename = "evaluateAfterMinutes", skip_serializing_if = "Option::is_none")]
+    evaluate_after_minutes: Option<i64>,
+    variants: Vec<ActiveAbTestVariant>,
+    #[serde(rename = "variantStats")]
+    variant_stats: Vec<VariantStats>,
+}
+
+#[derive(Serialize)]
+pub struct ActiveAbTestsResponse {
+    tests: Vec<ActiveAbTest>,
+}
+
+async fn handle_get_active_ab_tests(event: Request) -> Result<Response<Body>, AppError> {
+    let user_context = auth::get_user_context(&event)?;
+    let tenant_id = user_context
+        .tenant_id
+        .ok_or_else(|| AppError::Unauthorized("Tenant access required".to_string()))?;
+
+    let tests = query_active_ab_tests(&tenant_id).await?;
+
+    response::format_response(200, ActiveAbTestsResponse { tests })
+}
+
+/// Collects the tenant's in-progress A/B tests by scanning a bounded window of
+/// the most recent newsletter records (GSI1, newest-first) and keeping those
+/// whose embedded abTest is non-final. Live per-variant engagement counters are
+/// attached so the dashboard can show the test's progress while it runs.
+async fn query_active_ab_tests(tenant_id: &str) -> Result<Vec<ActiveAbTest>, AppError> {
+    let ddb_client = aws_clients::get_dynamodb_client().await;
+    let table_name = std::env::var("TABLE_NAME")
+        .map_err(|_| AppError::InternalError("TABLE_NAME not set".to_string()))?;
+
+    let gsi1pk = format!("{}#newsletter", tenant_id);
+
+    let result = ddb_client
+        .query()
+        .table_name(&table_name)
+        .index_name("GSI1")
+        .key_condition_expression("GSI1PK = :gsi1pk")
+        .filter_expression("attribute_exists(abTest)")
+        .expression_attribute_values(":gsi1pk", AttributeValue::S(gsi1pk))
+        .scan_index_forward(false)
+        .limit(ACTIVE_AB_SCAN_LIMIT)
+        .send()
+        .await?;
+
+    let mut tests = Vec::new();
+    for item in result.items() {
+        if let Some(mut test) = parse_active_ab_test(item) {
+            test.variant_stats = get_variant_stats(tenant_id, &test.issue_id).await;
+            tests.push(test);
+        }
+    }
+
+    Ok(tests)
+}
+
+/// Parses a newsletter record into an `ActiveAbTest` when it carries a non-final
+/// managed A/B test on a published issue. Returns `None` for records without an
+/// abTest, with a finished test (`sent`/`inconclusive`), or that are not yet
+/// published (drafts/scheduled issues have not run their sample send, so they
+/// are not "in progress"). Variant stats are left empty here and filled by the
+/// caller.
+fn parse_active_ab_test(item: &HashMap<String, AttributeValue>) -> Option<ActiveAbTest> {
+    // Only published issues have actually sent a test sample.
+    let issue_status = item.get("status").and_then(|v| v.as_s().ok())?;
+    if issue_status != "published" {
+        return None;
+    }
+
+    // abTest is persisted as a JSON string (mirroring metadata).
+    let ab_test: serde_json::Value = item
+        .get("abTest")
+        .and_then(|v| v.as_s().ok())
+        .and_then(|s| serde_json::from_str(s).ok())?;
+
+    let status = ab_test.get("status").and_then(|v| v.as_str()).unwrap_or("");
+    if !IN_PROGRESS_AB_STATUSES.contains(&status) {
+        return None;
+    }
+
+    let issue_number = item
+        .get("pk")
+        .and_then(|v| v.as_s().ok())
+        .and_then(|pk| pk.split('#').nth(1))
+        .and_then(|s| s.parse::<i32>().ok())?;
+
+    let subject = item
+        .get("subject")
+        .and_then(|v| v.as_s().ok())
+        .map(|s| s.to_string())
+        .unwrap_or_default();
+
+    let published_at = item
+        .get("publishedAt")
+        .and_then(|v| v.as_s().ok())
+        .map(|s| s.to_string());
+
+    let dimension = ab_test
+        .get("dimension")
+        .and_then(|v| v.as_str())
+        .unwrap_or(AB_DIMENSION_SUBJECT)
+        .to_string();
+    let win_metric = ab_test
+        .get("winMetric")
+        .and_then(|v| v.as_str())
+        .unwrap_or("openRate")
+        .to_string();
+    let evaluate_after_minutes = ab_test.get("evaluateAfterMinutes").and_then(|v| v.as_i64());
+
+    let variants = ab_test
+        .get("variants")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .map(|v| ActiveAbTestVariant {
+                    variant_id: v
+                        .get("variantId")
+                        .and_then(|x| x.as_str())
+                        .unwrap_or_default()
+                        .to_string(),
+                    subject: v.get("subject").and_then(|x| x.as_str()).map(|s| s.to_string()),
+                    send_at: v.get("sendAt").and_then(|x| x.as_str()).map(|s| s.to_string()),
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    Some(ActiveAbTest {
+        issue_id: issue_number.to_string(),
+        issue_number,
+        subject,
+        dimension,
+        status: status.to_string(),
+        win_metric,
+        published_at,
+        evaluate_after_minutes,
+        variants,
+        variant_stats: Vec::new(),
+    })
 }
 
 /// Upper bound on history tests read for prompt grounding. The suggestion
@@ -3630,6 +3819,83 @@ mod tests {
         assert!(!ab_test_explicitly_cleared(
             b"{\"abTest\":{\"dimension\":\"subject\"}}"
         ));
+    }
+
+    fn active_ab_item(
+        issue_status: &str,
+        ab_test_json: Option<&str>,
+    ) -> HashMap<String, AttributeValue> {
+        let mut item = HashMap::new();
+        item.insert("pk".to_string(), AttributeValue::S("tenant-123#42".to_string()));
+        item.insert(
+            "status".to_string(),
+            AttributeValue::S(issue_status.to_string()),
+        );
+        item.insert(
+            "subject".to_string(),
+            AttributeValue::S("Weekly digest".to_string()),
+        );
+        item.insert(
+            "publishedAt".to_string(),
+            AttributeValue::S("2026-07-01T00:00:00Z".to_string()),
+        );
+        if let Some(json) = ab_test_json {
+            item.insert("abTest".to_string(), AttributeValue::S(json.to_string()));
+        }
+        item
+    }
+
+    #[test]
+    fn test_parse_active_ab_test_keeps_in_progress_published() {
+        let json = r#"{"dimension":"subject","status":"testing","winMetric":"clickRate","evaluateAfterMinutes":120,"variants":[{"variantId":"a","subject":"A"},{"variantId":"b","subject":"B"}]}"#;
+        let parsed = parse_active_ab_test(&active_ab_item("published", Some(json)))
+            .expect("in-progress published test should parse");
+        assert_eq!(parsed.issue_number, 42);
+        assert_eq!(parsed.issue_id, "42");
+        assert_eq!(parsed.status, "testing");
+        assert_eq!(parsed.dimension, "subject");
+        assert_eq!(parsed.win_metric, "clickRate");
+        assert_eq!(parsed.evaluate_after_minutes, Some(120));
+        assert_eq!(parsed.variants.len(), 2);
+        assert_eq!(parsed.variants[0].subject.as_deref(), Some("A"));
+        // Stats are attached by the caller, not the parser.
+        assert!(parsed.variant_stats.is_empty());
+    }
+
+    #[test]
+    fn test_parse_active_ab_test_keeps_pending_and_evaluating() {
+        for status in ["pending", "evaluating"] {
+            let json =
+                format!(r#"{{"dimension":"subject","status":"{status}","variants":[]}}"#);
+            assert!(
+                parse_active_ab_test(&active_ab_item("published", Some(&json))).is_some(),
+                "status {status} should count as in progress"
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_active_ab_test_skips_final_statuses() {
+        for status in ["sent", "inconclusive"] {
+            let json =
+                format!(r#"{{"dimension":"subject","status":"{status}","variants":[]}}"#);
+            assert!(
+                parse_active_ab_test(&active_ab_item("published", Some(&json))).is_none(),
+                "status {status} is final and must be excluded"
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_active_ab_test_skips_unpublished_and_missing() {
+        let json = r#"{"dimension":"subject","status":"testing","variants":[]}"#;
+        // Draft/scheduled issues have not sent a sample yet, so their test is not
+        // "in progress" regardless of the embedded status.
+        assert!(parse_active_ab_test(&active_ab_item("draft", Some(json))).is_none());
+        assert!(parse_active_ab_test(&active_ab_item("scheduled", Some(json))).is_none());
+        assert!(parse_active_ab_test(&active_ab_item("failed", Some(json))).is_none());
+        // Published issue with no A/B test at all.
+        assert!(parse_active_ab_test(&active_ab_item("published", None)).is_none());
     }
 
     fn ab_history_test(

--- a/functions/src/api/router.rs
+++ b/functions/src/api/router.rs
@@ -84,6 +84,7 @@ pub async fn route_request(event: Request) -> Result<Response<Body>, Error> {
         (&Method::GET, "/issues") => issues::list_issues(event).await,
         (&Method::GET, "/issues/trends") => issues::get_trends(event).await,
         (&Method::GET, "/ab-test/history") => issues::get_ab_history(event).await,
+        (&Method::GET, "/ab-test/active") => issues::get_active_ab_tests(event).await,
         (&Method::POST, "/ab-test/suggestions") => issues::suggest_ab_test(event).await,
         (&Method::POST, "/issues") => issues::create_issue(event).await,
         (&Method::POST, path)
@@ -391,6 +392,7 @@ fn is_valid_api_path(path: &str) -> bool {
         || path == "/issues"
         || path == "/issues/trends"
         || path == "/ab-test/history"
+        || path == "/ab-test/active"
         || path == "/ab-test/suggestions"
         || path.starts_with("/issues/")
         // Reports paths

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1559,6 +1559,30 @@ paths:
         "500":
           $ref: "#/components/responses/UnknownError"
 
+  /ab-test/active:
+    get:
+      summary: Get in-progress A/B tests
+      description: >-
+        Retrieves the authenticated tenant's A/B tests that are currently running
+        — the test sample has been sent but a winner has not been decided yet
+        (status "pending", "testing", or "evaluating") — with live per-variant
+        engagement counters. Only published issues are considered, scanning a
+        bounded window of the most recent issues. Returns an empty tests array
+        when no tests are in progress.
+      tags:
+        - Issues
+      responses:
+        "200":
+          description: In-progress A/B tests with live per-variant stats
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActiveAbTestsResponse"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/UnknownError"
+
   /ab-test/suggestions:
     post:
       summary: Suggest A/B test variants
@@ -4391,6 +4415,85 @@ components:
           enum: [a, b]
           description: The variant to declare as the winner
       additionalProperties: false
+
+    ActiveAbTestsResponse:
+      type: object
+      required:
+        - tests
+      properties:
+        tests:
+          type: array
+          items:
+            $ref: "#/components/schemas/ActiveAbTest"
+          description: In-progress A/B tests, newest issue first (empty when none are running)
+
+    ActiveAbTest:
+      type: object
+      required:
+        - issueId
+        - issueNumber
+        - subject
+        - dimension
+        - status
+        - winMetric
+        - variants
+        - variantStats
+      properties:
+        issueId:
+          type: string
+          description: Issue id (issue number as a string), matching the issue detail route
+        issueNumber:
+          type: integer
+          description: The issue number this A/B test belongs to
+        subject:
+          type: string
+          description: The issue's subject line
+        dimension:
+          type: string
+          enum: [subject, sendTime]
+          description: The dimension under test
+        status:
+          type: string
+          enum: [pending, testing, evaluating]
+          description: Non-final lifecycle state of the running test
+        winMetric:
+          type: string
+          enum: [openRate, clickRate]
+          description: Metric that will decide the winner
+        publishedAt:
+          type: string
+          format: date-time
+          description: ISO 8601 timestamp when the issue was published
+        evaluateAfterMinutes:
+          type: integer
+          description: Hold-out wait, in minutes, before the winner is evaluated
+        variants:
+          type: array
+          items:
+            $ref: "#/components/schemas/ActiveAbTestVariant"
+          description: The test's variant definitions
+        variantStats:
+          type: array
+          items:
+            $ref: "#/components/schemas/VariantStats"
+          description: Live per-variant engagement counters collected so far
+
+    ActiveAbTestVariant:
+      type: object
+      required:
+        - variantId
+      properties:
+        variantId:
+          type: string
+          enum: [a, b]
+          description: Variant identifier
+        subject:
+          type: string
+          description: Subject line for this variant (subject-dimension tests)
+        sendAt:
+          type: string
+          format: date-time
+          description: Send time for this variant (send-time tests)
 
     AbHistoryResponse:
       type: object


### PR DESCRIPTION
A managed A/B test was created with status 'pending' and never
transitioned to 'testing'. The status only changed when
evaluate-ab-winner ran (default 4 hours after publish), moving it
straight to 'sent'/'inconclusive'. For the entire hold-out window the
dashboard therefore showed an inert "Pending" badge with zero variant
stats — indistinguishable, to the user, from the test never having been
picked up at all.

send-email-v2 now flips the test to 'testing' the moment the sample has
gone out (subject tests) or the per-variant sends have been fanned out
(send-time tests), so the issue's A/B panel confirms the test is live
within seconds of an immediate publish. Both the embedded abTest.status
(what the dashboard reads) and the top-level abTestStatus CAS mirror
(what evaluate-ab-winner claims on) are written together, mirroring how
finalizeEvaluation keeps them in sync. The write is conditional on the
test still being pending/unset so a redelivery can never regress a test
already claimed or finalized, and 'testing' remains a claimable state for
the evaluator.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Y92pi2kcN1uw5tRxPVyu4T