### PR TITLE
Automate monthly GeoLite2 database updates (activates timezone detection)

### DIFF
--- a/.github/workflows/update-geolocation-db.yml
+++ b/.github/workflows/update-geolocation-db.yml
@@ -1,0 +1,151 @@
+name: Update GeoLite2 Databases
+
+# Monthly refresh of the MaxMind GeoLite2 databases inside the geolocation
+# Lambda layer (functions/layers/geolocation-layer.zip). The layer carries:
+#   - GeoLite2-Country.mmdb  (~10 MB) — country analytics
+#   - GeoLite2-City.mmdb     (~60 MB) — IANA timezone for subscriber timezone
+#                                        detection and local send
+# plus the maxmind node module under nodejs/ (preserved as-is on rebuild).
+#
+# Requires the MAXMIND_LICENSE_KEY repository secret (free key from
+# maxmind.com — see docs/geolocation-database-updates.md). Deploy credentials
+# reuse the existing prod environment secrets.
+
+on:
+  schedule:
+    # 1st of every month at 02:00 UTC (MaxMind publishes weekly; monthly is
+    # the accuracy/operational-overhead balance recommended in the docs).
+    - cron: '0 2 1 * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+concurrency:
+  group: update-geolocation-db
+  cancel-in-progress: false
+
+jobs:
+  update-layer:
+    name: Rebuild geolocation layer
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    outputs:
+      changed: ${{ steps.rebuild.outputs.changed }}
+      sha: ${{ steps.commit.outputs.sha }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Download latest GeoLite2 databases
+        env:
+          LICENSE_KEY: ${{ secrets.MAXMIND_LICENSE_KEY }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${LICENSE_KEY}" ]]; then
+            echo "::error::MAXMIND_LICENSE_KEY secret is not configured. Create a free license key at maxmind.com and add it to the repository secrets."
+            exit 1
+          fi
+
+          mkdir -p downloads
+          for edition in GeoLite2-Country GeoLite2-City; do
+            echo "Downloading ${edition}..."
+            curl -fsSL -o "downloads/${edition}.tar.gz" \
+              "https://download.maxmind.com/app/geoip_download?edition_id=${edition}&license_key=${LICENSE_KEY}&suffix=tar.gz"
+            tar -xzf "downloads/${edition}.tar.gz" -C downloads
+            find downloads -name "${edition}.mmdb" -exec mv {} "downloads/${edition}.mmdb" \;
+            test -f "downloads/${edition}.mmdb"
+          done
+
+          # Sanity bounds so a truncated download or an HTML error page can
+          # never ship into the layer.
+          country_size=$(stat -c%s downloads/GeoLite2-Country.mmdb)
+          city_size=$(stat -c%s downloads/GeoLite2-City.mmdb)
+          echo "Country: ${country_size} bytes, City: ${city_size} bytes"
+          [[ ${country_size} -gt 3000000 && ${country_size} -lt 40000000 ]] || { echo "::error::Country DB size out of expected bounds"; exit 1; }
+          [[ ${city_size} -gt 30000000 && ${city_size} -lt 200000000 ]] || { echo "::error::City DB size out of expected bounds"; exit 1; }
+
+      - name: Rebuild layer zip if databases changed
+        id: rebuild
+        run: |
+          set -euo pipefail
+          workdir=$(mktemp -d)
+          unzip -q functions/layers/geolocation-layer.zip -d "${workdir}"
+
+          # Compare mmdb contents, not zip bytes: zips embed timestamps, so a
+          # byte-compare of rebuilt zips would always differ.
+          changed=false
+          for edition in GeoLite2-Country GeoLite2-City; do
+            if [[ ! -f "${workdir}/${edition}.mmdb" ]] || ! cmp -s "downloads/${edition}.mmdb" "${workdir}/${edition}.mmdb"; then
+              changed=true
+            fi
+            cp "downloads/${edition}.mmdb" "${workdir}/${edition}.mmdb"
+          done
+
+          if [[ "${changed}" == "false" ]]; then
+            echo "Databases already up to date; nothing to do."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          (cd "${workdir}" && zip -qr "${RUNNER_TEMP}/geolocation-layer.zip" .)
+          mv "${RUNNER_TEMP}/geolocation-layer.zip" functions/layers/geolocation-layer.zip
+          unzip -l functions/layers/geolocation-layer.zip | head -6
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push updated layer
+        id: commit
+        if: steps.rebuild.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add functions/layers/geolocation-layer.zip
+          git commit -m "Update GeoLite2 Country + City databases in geolocation layer"
+          git push
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+  deploy:
+    # A push made with GITHUB_TOKEN does not trigger the "Deploy to
+    # Production" workflow (GitHub suppresses workflow runs caused by the
+    # workflow token), so the updated layer is deployed here directly,
+    # mirroring deploy.yaml's backend job. Data-only change: the pre-deploy
+    # validation suite is intentionally not repeated for a database refresh.
+    name: Deploy updated layer
+    needs: update-layer
+    if: needs.update-layer.outputs.changed == 'true'
+    environment: prod
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.update-layer.outputs.sha }}
+      - name: Install Rust toolchain with Cargo Lambda
+        uses: moonrepo/setup-rust@v1
+        with:
+          bins: cargo-lambda
+          targets: aarch64-unknown-linux-gnu
+      - name: Install Zig toolchain
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.14.0
+      - name: Configure AWS
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-region: us-east-1
+          aws-access-key-id: ${{ secrets.PROD_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.PROD_SECRET_KEY }}
+      - name: SAM Build and Deploy
+        run: |
+          npm install -g esbuild
+          npm install --no-fund --no-audit
+
+          sam --info
+          sam build --beta-features
+
+          sam deploy \
+          --stack-name newsletter-service \
+          --resolve-s3 \
+          --no-fail-on-empty-changeset \
+          --capabilities CAPABILITY_IAM \
+          --parameter-overrides Environment=production EncryptionKey=${{secrets.ENCRYPTION_KEY}} RedirectCustomDomain=rdyset.click VerifiedFromEmail=${{vars.VERIFIED_FROM_EMAIL}} FrontendCustomDomain=${{vars.FRONTEND_CUSTOM_DOMAIN}} FrontendHostedZoneId=${{vars.FRONTEND_HOSTED_ZONE_ID}}

--- a/docs/geolocation-database-updates.md
+++ b/docs/geolocation-database-updates.md
@@ -43,122 +43,64 @@ MaxMind updates these databases weekly, but we recommend monthly updates for a b
 
 ### Update Lambda Layer
 
-1. Replace the database files:
+The layer ships as a prebuilt zip committed to the repository
+(`functions/layers/geolocation-layer.zip`) with the `.mmdb` files at the zip
+root and the `maxmind` node module under `nodejs/`. To rebuild it:
+
+1. Unpack the current layer (preserves the bundled node module):
    ```bash
-   cp /path/to/downloaded/GeoLite2-Country.mmdb layers/geolocation/GeoLite2-Country.mmdb
-   cp /path/to/downloaded/GeoLite2-City.mmdb layers/geolocation/GeoLite2-City.mmdb
+   mkdir -p /tmp/geo-layer
+   unzip functions/layers/geolocation-layer.zip -d /tmp/geo-layer
    ```
 
-2. Verify file sizes (Country ~6-8 MB, City ~60 MB):
+2. Replace the database files and verify sizes (Country ~6-10 MB, City ~60 MB):
    ```bash
-   ls -lh layers/geolocation/GeoLite2-Country.mmdb layers/geolocation/GeoLite2-City.mmdb
+   cp /path/to/downloaded/GeoLite2-Country.mmdb /tmp/geo-layer/GeoLite2-Country.mmdb
+   cp /path/to/downloaded/GeoLite2-City.mmdb /tmp/geo-layer/GeoLite2-City.mmdb
+   ls -lh /tmp/geo-layer/*.mmdb
    ```
 
-3. Deploy the updated layer:
+3. Repack and deploy:
    ```bash
-   sam build
-   s
-Confirm country data is appearing correctly
+   (cd /tmp/geo-layer && zip -r geolocation-layer.zip .)
+   mv /tmp/geo-layer/geolocation-layer.zip functions/layers/geolocation-layer.zip
+   sam build && sam deploy
+   ```
+
+4. **Verify after deploy**:
+   - Confirm country data is appearing correctly
    - Verify no "unknown" countries for valid public IPs
+   - Check CloudWatch logs for geolocation errors and confirm no increase in
+     error rates after the update
 
-3. **Monitor errors**:
-   - Check CloudWatch logs for geolocation errors
-   - Verify no increase in error rates after update
+## Automated Monthly Updates (GitHub Actions)
 
-## Automated CI/CD Update Workflow (Optional)
+The repository ships a scheduled workflow that keeps both databases fresh:
+[`.github/workflows/update-geolocation-db.yml`](../.github/workflows/update-geolocation-db.yml).
 
-For automated monthly updates, set up a scheduled workflow:
+On the 1st of every month (or on manual dispatch) it:
 
-### Prerequisites
+1. Downloads the latest GeoLite2 Country and City databases from MaxMind
+2. Sanity-checks the file sizes so a truncated download or error page can never ship
+3. Rebuilds `functions/layers/geolocation-layer.zip` in place, preserving the bundled
+   `maxmind` node module — and skips everything if the database contents are unchanged
+4. Commits the updated layer zip to `main`
+5. Deploys the stack directly (a push made with the workflow token does not trigger
+   the regular Deploy to Production workflow, so this workflow runs the same
+   `sam build && sam deploy` itself)
 
-- MaxMind Account ID and License Key stored in AWS Secrets Manager
-- CI/CD pipeline with AWS access (GitHub Actions, GitLab CI, etc.)
+### One-time setup
 
-### Store Credentials in Secrets Manager
+1. Create a free MaxMind license key (see [Generate License Key](#generate-license-key) above)
+2. Add it as a repository secret named `MAXMIND_LICENSE_KEY`
+   (Settings → Secrets and variables → Actions)
+3. The deploy step reuses the existing `prod` environment credentials
+   (`PROD_ACCESS_KEY` / `PROD_SECRET_KEY`) — no additional AWS setup is needed
 
-```bash
-aws secretsmanager create-secret \
-  --name maxmind-credentials \
-  --secret-string '{"account_id":"YOUR_ACCOUNT_ID","license_key":"YOUR_LICENSE_KEY"}'
-```
+If branch protection on `main` blocks pushes from `github-actions[bot]`, add the
+bot (or a bypass rule for the workflow) to the branch protection allowances.
 
-### GitHub Actions Workflow Example
-
-Create `.github/workflows/update-geolocation-db.yml`:
-
-```yaml
-name: Update GeoLite2 Database
-
-on:
-  schedule:
-    # Run on the 1st of every month at 2 AM UTC
-    - cron: '0 2 1 * *'
-  workflow_dispatch: # Allow manual trigger
-
-jobs:
-  update-database:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-
-      - name: Get MaxMind credentials
-        id: maxmind
-        run: |
-          SECRET=$(aws secretsmanager get-secret-value --secret-id maxmind-credentials --query SecretString --output text)
-          echo "ACCOUNT_ID=$(echo $SECRET | jq -r .account_id)" >> $GITHUB_OUTPUT
-          echo "LICENSE_KEY=$(echo $SECRET | jq -r .license_key)" >> $GITHUB_OUTPUT
-
-      - name: Download latest GeoLite2 database
-        run: |
-          curl -o GeoLite2-Country.tar.gz \
-            "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-Country&license_key=${{ steps.maxmind.outputs.LICENSE_KEY }}&suffix=tar.gz"
-          tar -xzf GeoLite2-Country.tar.gz
-          find . -name "GeoLite2-Country.mmdb" -exec cp {} layers/geolocation/GeoLite2-Country.mmdb \;
-
-      - name: Setup SAM CLI
-        uses: aws-actions/setup-sam@v2
-
-      - name: Build and deploy
-        run: |
-          sam build
-          sam deploy --no-confirm-changeset --no-fail-on-empty-changeset
-
-      - name: Verify deployment
-        run: |
-          echo "Deployment completed. Verify in AWS Console."
-          # Add verification steps here (e.g., invoke test Lambda)
-```
-
-### GitLab CI Example
-
-Create `.gitlab-ci.yml` job:
-
-```yaml
-update-geolocation-db:
-  stage: deploy
-  only:
-    - schedules
-  script:
-    - apt-get update && apt-get install -y curl jq
-    - SECRET=$(aws secretsmanager get-secret-value --secret-id maxmind-credentials --query SecretString --output text)
-    - ACCOUNT_ID=$(echo $SECRET | jq -r .account_id)
-    - LICENSE_KEY=$(echo $SECRET | jq -r .license_key)
-    - curl -o GeoLite2-Country.tar.gz "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-Country&license_key=$LICENSE_KEY&suffix=tar.gz"
-    - tar -xzf GeoLite2-Country.tar.gz
-    - find . -name "GeoLite2-Country.mmdb" -exec cp {} layers/geolocation/GeoLite2-Country.mmdb \;
-    - sam build
-    - sam deploy --no-confirm-changeset --no-fail-on-empty-changeset
-```
-
-Schedule the job to run monthly in GitLab CI/CD settings.
+To run an update immediately: Actions → "Update GeoLite2 Databases" → Run workflow.
 
 ## Update Frequency Recommendations
 
@@ -173,7 +115,7 @@ Schedule the job to run monthly in GitLab CI/CD settings.
 **Symptom**: CloudWatch logs show "db_missing" errors
 
 **Solution**:
-1. Verify file exists: `ls -lh layers/geolocation/GeoLite2-Country.mmdb`
+1. Verify the file is in the layer zip: `unzip -l functions/layers/geolocation-layer.zip`
 2. Check file permissions (should be readable)
 3. Redeploy layer: `sam build && sam deploy`
 

--- a/template.yaml
+++ b/template.yaml
@@ -4291,7 +4291,7 @@ Resources:
     Type: AWS::Serverless::LayerVersion
     Properties:
       LayerName: geolocation-maxmind
-      Description: MaxMind GeoLite2 Country database
+      Description: MaxMind GeoLite2 Country + City databases
       ContentUri: functions/layers/geolocation-layer.zip
       CompatibleRuntimes:
         - nodejs22.x


### PR DESCRIPTION
Follow-up to #341: the timezone detection / local-send features need `GeoLite2-City.mmdb` in the geolocation layer, which until now was a manual ops step. This adds the automation the docs previously only sketched — **the first run of this workflow is what turns timezone detection on in production.**

## What it does

`.github/workflows/update-geolocation-db.yml` — monthly (1st, 02:00 UTC) or manual dispatch:

1. Downloads the latest **GeoLite2 Country + City** databases using the `MAXMIND_LICENSE_KEY` secret
2. Sanity-checks file sizes so a truncated download or HTML error page can never ship into the layer
3. Rebuilds `functions/layers/geolocation-layer.zip` in place, preserving the bundled `maxmind` node module — and **skips the commit entirely when database contents are unchanged** (compares `.mmdb` bytes, not zip bytes, since zips embed timestamps and never byte-match)
4. Commits the updated zip to `main`
5. **Deploys directly**, mirroring `deploy.yaml`'s backend job — a push made with `GITHUB_TOKEN` does not trigger the regular Deploy to Production workflow (GitHub suppresses workflow-token-initiated runs), so relying on the normal pipeline would silently never deploy

Also fixes the manual-update section of `docs/geolocation-database-updates.md`, which referenced a nonexistent `layers/geolocation/` directory and contained a truncated code block — it now documents the real zip-based layout — and updates the layer description in `template.yaml` to mention both databases.

## One-time setup before the first run

1. Create a free MaxMind license key (docs walk through it)
2. Add it as the `MAXMIND_LICENSE_KEY` repository secret
3. If branch protection blocks `github-actions[bot]` pushes to `main`, add an allowance

Then: **Actions → "Update GeoLite2 Databases" → Run workflow** to activate timezone detection immediately rather than waiting for the 1st of the month.

## Notes

- Deploy job uses the existing `prod` environment credentials — no new AWS setup
- The pre-deploy validation suite is intentionally not repeated for a database-only refresh (noted in the workflow)
- Repo-size tradeoff: the City database adds ~60 MB to the committed layer zip, and each monthly refresh commits a new version. If that growth becomes a concern, the follow-up would be moving the layer's `ContentUri` to an S3 artifact — kept out of scope here to avoid touching the deploy pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HUHNvSYhqMGgNqdybCJqwS

---
_Generated by [Claude Code](https://claude.ai/code/session_01HUHNvSYhqMGgNqdybCJqwS)_