### PR TITLE
fix(subscribers): grant GetItem on SubscribersTable so profile detail loads

### DIFF
--- a/functions/src/api/controllers/subscribers.rs
+++ b/functions/src/api/controllers/subscribers.rs
@@ -1,4 +1,5 @@
 use aws_sdk_dynamodb::types::AttributeValue;
+use aws_smithy_types::error::display::DisplayErrorContext;
 use lambda_http::{Body, Error, Request, RequestExt, Response};
 use newsletter::admin::{auth, aws_clients, error::AppError, response};
 use percent_encoding::percent_decode_str;
@@ -402,7 +403,14 @@ async fn handle_get_subscriber(
         .key("email", AttributeValue::S(decoded_email))
         .send()
         .await
-        .map_err(|e| AppError::AwsError(format!("DynamoDB GetItem failed: {}", e)))?;
+        // DisplayErrorContext walks the SdkError source chain so the log carries
+        // the real cause (e.g. an AccessDenied/ValidationException from DynamoDB)
+        // rather than the bare "service error" that `{}` on SdkError renders. The
+        // end user still only ever sees the obscured "Something went wrong" that
+        // format_error_response returns for AwsError.
+        .map_err(|e| {
+            AppError::AwsError(format!("DynamoDB GetItem failed: {}", DisplayErrorContext(&e)))
+        })?;
 
     let item = result
         .item()

--- a/template.yaml
+++ b/template.yaml
@@ -1242,6 +1242,7 @@ Resources:
               Resource: !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:event-bus/default
             - Effect: Allow
               Action:
+                - dynamodb:GetItem
                 - dynamodb:PutItem
                 - dynamodb:DeleteItem
                 - dynamodb:UpdateItem


### PR DESCRIPTION
The subscriber profile modal loads recent activity from GET /subscribers/{email},
which does a DynamoDB GetItem on SubscribersTable. The ApiFunction IAM policy
granted PutItem/DeleteItem/UpdateItem/BatchGetItem/BatchWriteItem and Query on
that table, but not GetItem — so every profile view failed with AccessDenied,
surfacing to the UI as a 500. The list endpoint (Query) and delete (DeleteItem)
were unaffected, which is why only the detail/activity call broke.

Also wrap the GetItem SdkError in DisplayErrorContext when building the AwsError
so the logged message carries the real cause (e.g. the AccessDenied /
ValidationException in the source chain) instead of the bare "service error"
that Display on SdkError renders. The end-user response is unchanged: AwsError
still returns the obscured "Something went wrong".

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RhHaYyBaD6cmPuYb6YNTBS