### PR TITLE
fix(issues): unblock GitHub draft->schedule flow and html issue previews

### DIFF
--- a/dashboard-ui/src/pages/issues/IssueDetailPage.tsx
+++ b/dashboard-ui/src/pages/issues/IssueDetailPage.tsx
@@ -523,7 +523,11 @@ export const IssueDetailPage: React.FC = () => {
   // The content heatmap overlays click data on the rendered markdown, so it only
   // applies to markdown issues that have per-link analytics.
   const canShowHeatmap = useMemo(
-    () => issue?.contentType !== 'json' && !!analytics?.links && analytics.links.length > 0,
+    () =>
+      issue?.contentType !== 'json' &&
+      issue?.contentType !== 'html' &&
+      !!analytics?.links &&
+      analytics.links.length > 0,
     [issue?.contentType, analytics]
   );
 
@@ -1210,6 +1214,17 @@ export const IssueDetailPage: React.FC = () => {
                   <pre className="overflow-x-auto rounded-lg border border-border bg-muted/40 p-4 text-sm font-mono text-foreground whitespace-pre-wrap break-words">
                     {issue.content}
                   </pre>
+                ) : issue.contentType === 'html' ? (
+                  // Pre-rendered email masters are fully self-styled and assume a
+                  // light, email-client background. The sandboxed iframe keeps the
+                  // app's theme (e.g. dark-mode text color overrides) out of the
+                  // email and the email's <style> block out of the app.
+                  <iframe
+                    srcDoc={issue.content}
+                    sandbox=""
+                    title="Rendered email preview"
+                    className="h-[70vh] w-full rounded-lg border border-border bg-white"
+                  />
                 ) : (
                   <MarkdownPreview content={issue.content} />
                 )}

--- a/dashboard-ui/src/pages/issues/IssueFormPage.tsx
+++ b/dashboard-ui/src/pages/issues/IssueFormPage.tsx
@@ -145,7 +145,10 @@ export const IssueFormPage: React.FC = () => {
           issueNumber: issue.issueNumber ? String(issue.issueNumber) : '',
           scheduledAt: issue.scheduledAt ? toDatetimeLocal(issue.scheduledAt) : '',
           templateId: issue.templateId ?? DEFAULT_TEMPLATE_VALUE,
-          contentType: issue.contentType === 'json' ? 'json' : 'markdown',
+          // Preserve 'html' so editing a pre-rendered issue doesn't silently
+          // flip it to markdown on save (which would send the raw master
+          // through the markdown pipeline).
+          contentType: issue.contentType ?? 'markdown',
         });
 
         // Hydrate A/B test config, converting send times to datetime-local.

--- a/dashboard-ui/src/types/issues.ts
+++ b/dashboard-ui/src/types/issues.ts
@@ -5,7 +5,7 @@ export type IssueStatus = 'draft' | 'scheduled' | 'in progress' | 'published' | 
  * - `markdown`: content is markdown (rendered to HTML on publish).
  * - `json`: content is a JSON data object rendered against a selected template.
  */
-export type IssueContentType = 'markdown' | 'json';
+export type IssueContentType = 'markdown' | 'json' | 'html';
 
 export interface IssueListItem {
   id: string;

--- a/functions/src/api/controllers/domain.rs
+++ b/functions/src/api/controllers/domain.rs
@@ -313,10 +313,7 @@ async fn handle_get_domain_verification(
     // shouldn't block returning the domain status.
     if current_status == VerificationStatus::Verified {
         if let Err(e) = mark_domain_senders_verified(&tenant_id, &domain).await {
-            tracing::error!(
-                "Failed to propagate domain verification to senders: {}",
-                e
-            );
+            tracing::error!("Failed to propagate domain verification to senders: {}", e);
         }
     }
 

--- a/functions/src/api/controllers/issues.rs
+++ b/functions/src/api/controllers/issues.rs
@@ -824,7 +824,10 @@ pub struct ActiveAbTest {
     win_metric: String,
     #[serde(rename = "publishedAt", skip_serializing_if = "Option::is_none")]
     published_at: Option<String>,
-    #[serde(rename = "evaluateAfterMinutes", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "evaluateAfterMinutes",
+        skip_serializing_if = "Option::is_none"
+    )]
     evaluate_after_minutes: Option<i64>,
     variants: Vec<ActiveAbTestVariant>,
     #[serde(rename = "variantStats")]
@@ -945,8 +948,14 @@ fn parse_active_ab_test(item: &HashMap<String, AttributeValue>) -> Option<Active
                         .and_then(|x| x.as_str())
                         .unwrap_or_default()
                         .to_string(),
-                    subject: v.get("subject").and_then(|x| x.as_str()).map(|s| s.to_string()),
-                    send_at: v.get("sendAt").and_then(|x| x.as_str()).map(|s| s.to_string()),
+                    subject: v
+                        .get("subject")
+                        .and_then(|x| x.as_str())
+                        .map(|s| s.to_string()),
+                    send_at: v
+                        .get("sendAt")
+                        .and_then(|x| x.as_str())
+                        .map(|s| s.to_string()),
                 })
                 .collect()
         })
@@ -1740,16 +1749,26 @@ async fn handle_create_issue(event: Request) -> Result<Response<Body>, AppError>
 
     validate_create_request(&body)?;
 
-    let ab_test = extract_ab_test(event.body().as_ref())?
-        .map(|value| validate_and_normalize_ab_test(&value))
+    // The raw (pre-normalization) config values also feed the idempotency
+    // hash: normalization injects server-generated values (e.g. the A/B
+    // testId), so hashing normalized config would make byte-identical
+    // replays look different.
+    let raw_ab_test = extract_ab_test(event.body().as_ref())?;
+    let ab_test = raw_ab_test
+        .as_ref()
+        .map(validate_and_normalize_ab_test)
         .transpose()?;
 
-    let local_send = extract_local_send(event.body().as_ref())?
-        .map(|value| validate_and_normalize_local_send(&value))
+    let raw_local_send = extract_local_send(event.body().as_ref())?;
+    let local_send = raw_local_send
+        .as_ref()
+        .map(validate_and_normalize_local_send)
         .transpose()?
         .flatten();
-    let content_assembly = extract_content_assembly(event.body().as_ref())?
-        .map(|value| validate_and_normalize_content_assembly(&value))
+    let raw_content_assembly = extract_content_assembly(event.body().as_ref())?;
+    let content_assembly = raw_content_assembly
+        .as_ref()
+        .map(validate_and_normalize_content_assembly)
         .transpose()?;
 
     if let Some(template_id) = body.template_id.as_deref() {
@@ -1770,6 +1789,11 @@ async fn handle_create_issue(event: Request) -> Result<Response<Body>, AppError>
 
     let normalized_scheduled_at = normalize_scheduled_at(body.scheduled_at.as_deref())?;
 
+    // Set when an exact replay's recorded issue no longer exists and the
+    // request falls through to a fresh create: the idempotency record for the
+    // key is still in place and must be overwritten, not condition-failed.
+    let mut replace_idempotency_record = false;
+
     if let Some(key) = idempotency_key.as_deref() {
         if let Some(existing) = get_idempotency_record(&tenant_id, key).await? {
             if let Some(issue_number) = body.issue_number {
@@ -1785,6 +1809,9 @@ async fn handle_create_issue(event: Request) -> Result<Response<Body>, AppError>
                 existing.issue_number,
                 action,
                 normalized_scheduled_at.as_deref(),
+                raw_ab_test.as_ref(),
+                raw_local_send.as_ref(),
+                raw_content_assembly.as_ref(),
             );
 
             if existing_hash != existing.payload_hash {
@@ -1813,7 +1840,9 @@ async fn handle_create_issue(event: Request) -> Result<Response<Body>, AppError>
                         },
                     );
                 }
-                Err(AppError::NotFound(_)) => {}
+                Err(AppError::NotFound(_)) => {
+                    replace_idempotency_record = true;
+                }
                 Err(err) => return Err(err),
             }
         }
@@ -1848,6 +1877,9 @@ async fn handle_create_issue(event: Request) -> Result<Response<Body>, AppError>
             issue_number,
             action,
             normalized_scheduled_at.as_deref(),
+            raw_ab_test.as_ref(),
+            raw_local_send.as_ref(),
+            raw_content_assembly.as_ref(),
         )
     });
 
@@ -1864,6 +1896,14 @@ async fn handle_create_issue(event: Request) -> Result<Response<Body>, AppError>
     .await?;
 
     publish_event(&tenant_id, "ISSUE_DRAFT_SAVED", &issue).await?;
+
+    // Overwriting an existing draft invalidates any TTL deletion schedule it
+    // had: left in place it would fire against the new record (which is still
+    // a draft) and delete it. schedule_draft_deletion recreates one below when
+    // this request carries its own ttlSeconds.
+    if overwrite_draft {
+        delete_draft_ttl_schedule(&tenant_id, issue_number).await?;
+    }
 
     if action == CreateIssueAction::Schedule {
         start_issue_schedule(
@@ -1882,7 +1922,14 @@ async fn handle_create_issue(event: Request) -> Result<Response<Body>, AppError>
     }
 
     if let (Some(key), Some(hash)) = (idempotency_key.as_deref(), payload_hash.as_deref()) {
-        save_idempotency_record(&tenant_id, key, issue_number, hash).await?;
+        save_idempotency_record(
+            &tenant_id,
+            key,
+            issue_number,
+            hash,
+            replace_idempotency_record,
+        )
+        .await?;
     }
 
     response::format_response(201, issue)
@@ -3295,11 +3342,20 @@ fn normalize_scheduled_at(value: Option<&str>) -> Result<Option<String>, AppErro
     Ok(Some(parsed.to_rfc3339()))
 }
 
+/// Hashes everything that determines what a create request does, so a reused
+/// Idempotency-Key with any behavioral change is rejected instead of replayed.
+/// The send-config values (`abTest`, `localSend`, `contentAssembly`) are the
+/// raw caller-supplied objects, not the normalized forms: normalization
+/// injects server-generated values (e.g. the A/B `testId`), which would make
+/// byte-identical replays hash differently.
 fn compute_idempotency_hash(
     body: &CreateIssueRequest,
     issue_number: i32,
     action: CreateIssueAction,
     scheduled_at: Option<&str>,
+    ab_test: Option<&serde_json::Value>,
+    local_send: Option<&serde_json::Value>,
+    content_assembly: Option<&serde_json::Value>,
 ) -> String {
     let payload = serde_json::json!({
         "issueNumber": issue_number,
@@ -3314,6 +3370,9 @@ fn compute_idempotency_hash(
         "templateId": body.template_id.clone(),
         "contentType": normalize_content_type(body.content_type.as_deref()),
         "ttlSeconds": body.ttl_seconds,
+        "abTest": ab_test,
+        "localSend": local_send,
+        "contentAssembly": content_assembly,
     });
 
     let mut hasher = Sha256::new();
@@ -3324,10 +3383,7 @@ fn compute_idempotency_hash(
 /// Returns the status of an issue, or None when no record exists. Used by the
 /// create path to decide whether an existing record may be overwritten (drafts
 /// only).
-async fn get_issue_status(
-    tenant_id: &str,
-    issue_number: i32,
-) -> Result<Option<String>, AppError> {
+async fn get_issue_status(tenant_id: &str, issue_number: i32) -> Result<Option<String>, AppError> {
     let ddb_client = aws_clients::get_dynamodb_client().await;
     let table_name = std::env::var("TABLE_NAME")
         .map_err(|_| AppError::InternalError("TABLE_NAME not set".to_string()))?;
@@ -3423,11 +3479,18 @@ async fn get_idempotency_record(
     }))
 }
 
+/// Stores the idempotency record for a processed create. `replace_existing`
+/// is set when a replay's recorded issue no longer existed and the request was
+/// processed as a fresh create: the prior record for the key is still present
+/// (its 24h TTL outlives an expired draft), so the conditional put would fail
+/// after the issue and its side effects were already created. In that case the
+/// record is overwritten to point at the new issue.
 async fn save_idempotency_record(
     tenant_id: &str,
     idempotency_key: &str,
     issue_number: i32,
     payload_hash: &str,
+    replace_existing: bool,
 ) -> Result<(), AppError> {
     let ddb_client = aws_clients::get_dynamodb_client().await;
     let table_name = std::env::var("TABLE_NAME")
@@ -3456,13 +3519,14 @@ async fn save_idempotency_record(
     item.insert("createdAt".to_string(), AttributeValue::S(now.to_rfc3339()));
     item.insert("ttl".to_string(), AttributeValue::N(ttl.to_string()));
 
-    let result = ddb_client
+    let mut put = ddb_client
         .put_item()
         .table_name(&table_name)
-        .set_item(Some(item))
-        .condition_expression("attribute_not_exists(pk) AND attribute_not_exists(sk)")
-        .send()
-        .await;
+        .set_item(Some(item));
+    if !replace_existing {
+        put = put.condition_expression("attribute_not_exists(pk) AND attribute_not_exists(sk)");
+    }
+    let result = put.send().await;
 
     match result {
         Ok(_) => Ok(()),
@@ -3556,21 +3620,8 @@ async fn schedule_draft_deletion(
     let schedule_name = build_draft_ttl_schedule_name(tenant_id, issue_number);
 
     // Re-staging a draft (same issue number) replaces its TTL schedule; the
-    // name is deterministic, so drop any previous schedule first. A missing
-    // schedule is the normal case; any real problem resurfaces on create.
-    if let Err(err) = scheduler
-        .delete_schedule()
-        .name(&schedule_name)
-        .group_name("newsletter")
-        .send()
-        .await
-    {
-        tracing::debug!(
-            "No prior draft TTL schedule {} to delete: {}",
-            schedule_name,
-            err
-        );
-    }
+    // name is deterministic, so drop any previous schedule first.
+    delete_draft_ttl_schedule(tenant_id, issue_number).await?;
 
     let detail = serde_json::json!({
         "tenantId": tenant_id,
@@ -3614,17 +3665,49 @@ async fn schedule_draft_deletion(
     Ok(())
 }
 
+/// Deletes the draft TTL schedule for an issue, tolerating a missing schedule
+/// (the normal case). Any other failure propagates: leaving a stale schedule
+/// behind would let it fire later and delete a freshly re-staged draft.
+async fn delete_draft_ttl_schedule(tenant_id: &str, issue_number: i32) -> Result<(), AppError> {
+    let scheduler = aws_clients::get_scheduler_client().await;
+    let schedule_name = build_draft_ttl_schedule_name(tenant_id, issue_number);
+
+    match scheduler
+        .delete_schedule()
+        .name(&schedule_name)
+        .group_name("newsletter")
+        .send()
+        .await
+    {
+        Ok(_) => Ok(()),
+        Err(err) => {
+            let is_not_found = err
+                .as_service_error()
+                .is_some_and(|service_err| service_err.is_resource_not_found_exception());
+
+            if is_not_found {
+                return Ok(());
+            }
+
+            Err(AppError::AwsError(format!(
+                "Failed to delete draft TTL schedule {}: {}",
+                schedule_name, err
+            )))
+        }
+    }
+}
+
 /// Builds a schedule name within EventBridge Scheduler's constraints
-/// (<= 64 chars, `[0-9a-zA-Z-_.]`). The tenant id is sanitized and truncated
-/// and a millisecond timestamp keeps repeated drafts from colliding.
+/// (<= 64 chars, `[0-9a-zA-Z-_.]`). The tenant id is sanitized and truncated.
+/// The name is deterministic per (tenant, issue) so re-staging a draft can
+/// find and replace the previous TTL schedule instead of leaking it.
 fn build_draft_ttl_schedule_name(tenant_id: &str, issue_number: i32) -> String {
     let tenant_prefix: String = tenant_id
         .chars()
         .filter(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_')
         .take(16)
         .collect();
-    let suffix = chrono::Utc::now().timestamp_millis();
-    format!("draft-ttl-{}-{}-{}", tenant_prefix, issue_number, suffix)
+    format!("draft-ttl-{}-{}", tenant_prefix, issue_number)
 }
 
 async fn get_next_issue_number(tenant_id: &str) -> Result<i32, AppError> {
@@ -4277,9 +4360,17 @@ Thanks!"#;
   ]
 }"#;
         let review = parse_review_response(raw).unwrap();
-        assert_eq!(review.grammar.len(), 1, "only the fully-formed grammar item survives");
+        assert_eq!(
+            review.grammar.len(),
+            1,
+            "only the fully-formed grammar item survives"
+        );
         assert_eq!(review.grammar[0].quote, "their are");
-        assert_eq!(review.spelling.len(), 1, "only the fully-formed spelling item survives");
+        assert_eq!(
+            review.spelling.len(),
+            1,
+            "only the fully-formed spelling item survives"
+        );
         assert_eq!(review.spelling[0].word, "teh");
     }
 
@@ -4744,7 +4835,10 @@ Thanks!"#;
         ab_test_json: Option<&str>,
     ) -> HashMap<String, AttributeValue> {
         let mut item = HashMap::new();
-        item.insert("pk".to_string(), AttributeValue::S("tenant-123#42".to_string()));
+        item.insert(
+            "pk".to_string(),
+            AttributeValue::S("tenant-123#42".to_string()),
+        );
         item.insert(
             "status".to_string(),
             AttributeValue::S(issue_status.to_string()),
@@ -4783,8 +4877,7 @@ Thanks!"#;
     #[test]
     fn test_parse_active_ab_test_keeps_pending_and_evaluating() {
         for status in ["pending", "evaluating"] {
-            let json =
-                format!(r#"{{"dimension":"subject","status":"{status}","variants":[]}}"#);
+            let json = format!(r#"{{"dimension":"subject","status":"{status}","variants":[]}}"#);
             assert!(
                 parse_active_ab_test(&active_ab_item("published", Some(&json))).is_some(),
                 "status {status} should count as in progress"
@@ -4795,8 +4888,7 @@ Thanks!"#;
     #[test]
     fn test_parse_active_ab_test_skips_final_statuses() {
         for status in ["sent", "inconclusive"] {
-            let json =
-                format!(r#"{{"dimension":"subject","status":"{status}","variants":[]}}"#);
+            let json = format!(r#"{{"dimension":"subject","status":"{status}","variants":[]}}"#);
             assert!(
                 parse_active_ab_test(&active_ab_item("published", Some(&json))).is_none(),
                 "status {status} is final and must be excluded"
@@ -5480,11 +5572,102 @@ Thanks!"#;
     fn test_build_draft_ttl_schedule_name_is_valid() {
         let name = build_draft_ttl_schedule_name("tenant-abc_123", 42);
 
-        assert!(name.starts_with("draft-ttl-tenant-abc_123-42-"));
+        assert_eq!(name, "draft-ttl-tenant-abc_123-42");
         assert!(name.len() <= 64);
         assert!(name
             .chars()
             .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.'));
+    }
+
+    #[test]
+    fn test_build_draft_ttl_schedule_name_is_deterministic() {
+        // Re-staging a draft must produce the same name so the prior TTL
+        // schedule is found and replaced instead of leaking (and later firing
+        // against the re-staged draft).
+        assert_eq!(
+            build_draft_ttl_schedule_name("tenant-abc_123", 42),
+            build_draft_ttl_schedule_name("tenant-abc_123", 42)
+        );
+    }
+
+    #[test]
+    fn test_compute_idempotency_hash_stable_for_identical_requests() {
+        let request = create_request("# Test Content", None, None);
+        let ab_test = serde_json::json!({ "dimension": "subject", "variants": ["A", "B"] });
+
+        let first = compute_idempotency_hash(
+            &request,
+            7,
+            CreateIssueAction::Draft,
+            None,
+            Some(&ab_test),
+            None,
+            None,
+        );
+        let second = compute_idempotency_hash(
+            &request,
+            7,
+            CreateIssueAction::Draft,
+            None,
+            Some(&ab_test),
+            None,
+            None,
+        );
+
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn test_compute_idempotency_hash_changes_with_send_config() {
+        // A reused key with changed abTest/localSend/contentAssembly must not
+        // look like an exact replay: replaying would silently keep the old
+        // send configuration.
+        let request = create_request("# Test Content", None, None);
+        let ab_test = serde_json::json!({ "dimension": "subject", "variants": ["A", "B"] });
+        let local_send = serde_json::json!({ "enabled": true, "batchSize": 10 });
+        let content_assembly = serde_json::json!({ "enabled": true });
+
+        let base = compute_idempotency_hash(
+            &request,
+            7,
+            CreateIssueAction::Draft,
+            None,
+            None,
+            None,
+            None,
+        );
+        let with_ab = compute_idempotency_hash(
+            &request,
+            7,
+            CreateIssueAction::Draft,
+            None,
+            Some(&ab_test),
+            None,
+            None,
+        );
+        let with_local_send = compute_idempotency_hash(
+            &request,
+            7,
+            CreateIssueAction::Draft,
+            None,
+            None,
+            Some(&local_send),
+            None,
+        );
+        let with_assembly = compute_idempotency_hash(
+            &request,
+            7,
+            CreateIssueAction::Draft,
+            None,
+            None,
+            None,
+            Some(&content_assembly),
+        );
+
+        assert_ne!(base, with_ab);
+        assert_ne!(base, with_local_send);
+        assert_ne!(base, with_assembly);
+        assert_ne!(with_ab, with_local_send);
     }
 
     #[test]

--- a/functions/src/api/controllers/issues.rs
+++ b/functions/src/api/controllers/issues.rs
@@ -1792,16 +1792,50 @@ async fn handle_create_issue(event: Request) -> Result<Response<Body>, AppError>
                     "Idempotency key reuse with different payload".to_string(),
                 ));
             }
-            return Err(AppError::Conflict("Duplicate request".to_string()));
+            // Exact replay of a request we already processed: succeed
+            // idempotently with the previously created issue rather than 409,
+            // so CI re-runs of the same commit don't fail the workflow. If the
+            // issue has since been deleted (e.g. an expired draft), fall
+            // through and process the request as a fresh create.
+            match get_issue_by_id(&tenant_id, &existing.issue_number.to_string()).await {
+                Ok(issue) => {
+                    return response::format_response(
+                        200,
+                        CreateIssueResponse {
+                            id: issue.issue_number.to_string(),
+                            issue_number: issue.issue_number,
+                            subject: issue.subject,
+                            status: issue.status,
+                            content: issue.content,
+                            created_at: issue.created_at,
+                            updated_at: issue.updated_at,
+                            content_type: normalize_content_type(issue.content_type.as_deref()),
+                        },
+                    );
+                }
+                Err(AppError::NotFound(_)) => {}
+                Err(err) => return Err(err),
+            }
         }
     }
 
+    // An existing record only blocks the create while it is past the draft
+    // stage. Overwriting a draft is allowed on purpose: the GitHub flow stages
+    // a draft from the PR (re-staged on every push) and later re-posts the
+    // same issue number with action: schedule when the PR merges.
+    let mut overwrite_draft = false;
     let issue_number = if let Some(issue_number) = body.issue_number {
-        if issue_exists(&tenant_id, issue_number).await? {
-            return Err(AppError::Conflict(format!(
-                "Issue {} already exists",
-                issue_number
-            )));
+        match get_issue_status(&tenant_id, issue_number).await? {
+            None => {}
+            Some(status) if status == "draft" => {
+                overwrite_draft = true;
+            }
+            Some(_) => {
+                return Err(AppError::Conflict(format!(
+                    "Issue {} already exists",
+                    issue_number
+                )));
+            }
         }
         issue_number
     } else {
@@ -1825,6 +1859,7 @@ async fn handle_create_issue(event: Request) -> Result<Response<Body>, AppError>
         ab_test,
         local_send,
         content_assembly,
+        overwrite_draft,
     )
     .await?;
 
@@ -3286,23 +3321,34 @@ fn compute_idempotency_hash(
     hex::encode(hasher.finalize())
 }
 
-async fn issue_exists(tenant_id: &str, issue_number: i32) -> Result<bool, AppError> {
+/// Returns the status of an issue, or None when no record exists. Used by the
+/// create path to decide whether an existing record may be overwritten (drafts
+/// only).
+async fn get_issue_status(
+    tenant_id: &str,
+    issue_number: i32,
+) -> Result<Option<String>, AppError> {
     let ddb_client = aws_clients::get_dynamodb_client().await;
     let table_name = std::env::var("TABLE_NAME")
         .map_err(|_| AppError::InternalError("TABLE_NAME not set".to_string()))?;
 
     let pk = format!("{}#{}", tenant_id, issue_number);
-    let sk = "newsletter";
 
     let result = ddb_client
         .get_item()
         .table_name(&table_name)
         .key("pk", AttributeValue::S(pk))
-        .key("sk", AttributeValue::S(sk.to_string()))
+        .key("sk", AttributeValue::S("newsletter".to_string()))
+        .projection_expression("#status")
+        .expression_attribute_names("#status", "status")
         .send()
         .await?;
 
-    Ok(result.item().is_some())
+    Ok(result.item().and_then(|item| {
+        item.get("status")
+            .and_then(|v| v.as_s().ok())
+            .map(|s| s.to_string())
+    }))
 }
 
 async fn validate_template_exists(tenant_id: &str, template_id: &str) -> Result<(), AppError> {
@@ -3509,6 +3555,23 @@ async fn schedule_draft_deletion(
     let schedule_expression = format!("at({})", run_at.format("%Y-%m-%dT%H:%M:%S"));
     let schedule_name = build_draft_ttl_schedule_name(tenant_id, issue_number);
 
+    // Re-staging a draft (same issue number) replaces its TTL schedule; the
+    // name is deterministic, so drop any previous schedule first. A missing
+    // schedule is the normal case; any real problem resurfaces on create.
+    if let Err(err) = scheduler
+        .delete_schedule()
+        .name(&schedule_name)
+        .group_name("newsletter")
+        .send()
+        .await
+    {
+        tracing::debug!(
+            "No prior draft TTL schedule {} to delete: {}",
+            schedule_name,
+            err
+        );
+    }
+
     let detail = serde_json::json!({
         "tenantId": tenant_id,
         "issueNumber": issue_number
@@ -3604,6 +3667,7 @@ async fn create_issue_record(
     ab_test: Option<serde_json::Value>,
     local_send: Option<serde_json::Value>,
     content_assembly: Option<serde_json::Value>,
+    overwrite_draft: bool,
 ) -> Result<CreateIssueResponse, AppError> {
     let ddb_client = aws_clients::get_dynamodb_client().await;
     let table_name = std::env::var("TABLE_NAME")
@@ -3685,13 +3749,22 @@ async fn create_issue_record(
         );
     }
 
-    ddb_client
+    // Overwrites are only permitted while the record is still a draft; the
+    // condition re-checks the status so a concurrent schedule/publish between
+    // the caller's status read and this write can't be clobbered.
+    let mut put = ddb_client
         .put_item()
         .table_name(&table_name)
-        .set_item(Some(item))
-        .condition_expression("attribute_not_exists(pk) AND attribute_not_exists(sk)")
-        .send()
-        .await?;
+        .set_item(Some(item));
+    if overwrite_draft {
+        put = put
+            .condition_expression("attribute_not_exists(pk) OR #status = :draftStatus")
+            .expression_attribute_names("#status", "status")
+            .expression_attribute_values(":draftStatus", AttributeValue::S("draft".to_string()));
+    } else {
+        put = put.condition_expression("attribute_not_exists(pk) AND attribute_not_exists(sk)");
+    }
+    put.send().await?;
 
     Ok(CreateIssueResponse {
         id: issue_number.to_string(),

--- a/functions/src/api/controllers/subscribers.rs
+++ b/functions/src/api/controllers/subscribers.rs
@@ -409,7 +409,10 @@ async fn handle_get_subscriber(
         // end user still only ever sees the obscured "Something went wrong" that
         // format_error_response returns for AwsError.
         .map_err(|e| {
-            AppError::AwsError(format!("DynamoDB GetItem failed: {}", DisplayErrorContext(&e)))
+            AppError::AwsError(format!(
+                "DynamoDB GetItem failed: {}",
+                DisplayErrorContext(&e)
+            ))
         })?;
 
     let item = result


### PR DESCRIPTION
## Context

The GitHub newsletter flow moved to `POST /issues` with `contentType: html` (a Hugo-rendered email master sent verbatim). Staging the first issue through it (readysetcloud/ready-set-cloud PR #166, issue 226) surfaced three gaps. The send pipeline itself (Route By Content Type -> Parse JSON Issue -> `__master` verbatim publish) is already correct - these fixes are in the API create path and the dashboard.

## What changed

**1. `POST /issues` allows overwriting an existing draft** (`issues.rs`)
The PR workflow stages issue N as a draft; the merge workflow re-posts issue N with `action: schedule`, and pushes to the PR re-post it as a draft. All of those 409'd on `issue_exists`. An existing record now only conflicts when it is past the draft stage. The put re-checks `status = draft` in its condition expression so a concurrent schedule can't be clobbered, and re-staging a draft replaces its TTL deletion schedule (delete-then-create; the schedule name is deterministic).

**2. Exact idempotent replays return 200 instead of 409** (`issues.rs`)
Same `Idempotency-Key` + same payload previously returned 409 "Duplicate request", which fails CI re-runs of the same commit. It now returns 200 with the previously created issue. If the recorded issue no longer exists (expired draft), the request falls through to a fresh create.

**3. Dashboard renders html issues in a sandboxed iframe** (`IssueDetailPage.tsx`)
`contentType: html` content went through `MarkdownPreview`, whose `[&_p]:text-foreground` / `[&_h3]:text-foreground` overrides re-color the email's paragraphs - in dark mode that's near-white text on the master's hardcoded white card (the bug Allen hit on the issue 226 draft). A sandboxed `srcDoc` iframe isolates the email from app theming and stops the email's `<style>` block from leaking into the app (it currently restyles `body`/`p`/`div`/`a` on that page). Also: the content heatmap no longer offers itself for html issues, editing an html issue no longer silently flips it to `markdown` on save, and `IssueContentType` gains `'html'`.

## Verification

- `cargo check` / `cargo test`: all green (487 controller tests + the rest, 0 failures).
- `dashboard-ui`: `npm run build` (tsc + vite) clean; `npm test` 988/988 passing.
- Root jest suite has 112 pre-existing failures identical on clean `main` (environment-related); no JS lambdas are touched by this PR.

## Follow-up (readysetcloud/ready-set-cloud)

Production sends are currently pinned to the legacy EventBridge path (`FORCE_LEGACY`, ready-set-cloud PR #168) so the 2026-07-27 send is safe regardless of when this deploys. Cutting over afterward needs two caller-side tweaks there: schedule at 14:00 UTC (front-matter dates are midnight; legacy sent at 14:00) and include the commit SHA in the idempotency key so new commits to a PR re-draft cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
