### PR TITLE
feat(settings): tenant defaults for timezone and send time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ aws-smithy-types = { workspace = true }
 aws_lambda_events = { workspace = true }
 base64 = { workspace = true }
 chrono = { workspace = true }
+chrono-tz = { workspace = true }
 handlebars = { workspace = true }
 hex = { workspace = true }
 jsonwebtoken = { workspace = true }
@@ -117,6 +118,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 thiserror = "1"
 chrono = { version = "0.4", features = ["serde"] }
+chrono-tz = "0.10"
 rand = "0.8"
 percent-encoding = "2"
 sha2 = "0.10"

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ There are two backend surfaces in this repository:
 The admin API includes routes for:
 
 - `/me` and profile management
+- `/settings` (tenant-wide defaults: display/send timezone and the default send time applied when a request supplies a date without a time)
 - `/brand`
 - `/api-keys`
 - `/senders` and `/senders/domain`

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ There are two backend surfaces in this repository:
 The admin API includes routes for:
 
 - `/me` and profile management
-- `/settings` (tenant-wide defaults: display/send timezone and the default send time applied when a request supplies a date without a time)
+- `/settings` (tenant-wide defaults used when a request doesn't supply a value: display/send timezone, the send time applied to a date without a time, the subject-line format, and the public issue URL)
 - `/brand`
 - `/api-keys`
 - `/senders` and `/senders/domain`

--- a/dashboard-ui/src/App.tsx
+++ b/dashboard-ui/src/App.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import { AuthProvider } from '@/contexts/AuthContext';
+import { SettingsProvider } from '@/contexts/SettingsContext';
 import { ToastProvider } from '@/components/ui/Toast';
 import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
 import { OnboardingGuard } from '@/components/auth/OnboardingGuard';
@@ -12,6 +13,7 @@ import {
   LazyDashboardPage,
   LazyBrandPage,
   LazyProfilePage,
+  LazySettingsPage,
   LazyApiKeysPage,
   LazySenderEmailSetupPage,
   LazyBillingPage,
@@ -49,462 +51,482 @@ function App() {
     <ErrorBoundary>
       <Router>
         <AuthProvider>
-          <ToastProvider>
-            <div className="min-h-screen bg-background overflow-x-hidden flex flex-col">
-              <div className="flex-1">
-                <Routes>
-                  {/* Public Routes */}
-                  <Route
-                    path="/login"
-                    element={
-                      <RouteErrorBoundary routeName="Login">
-                        <PageLoader>
-                          <LazyLoginPage />
-                        </PageLoader>
-                      </RouteErrorBoundary>
-                    }
-                  />
-                  <Route
-                    path="/signup"
-                    element={
-                      <RouteErrorBoundary routeName="Sign Up">
-                        <PageLoader>
-                          <LazySignUpPage />
-                        </PageLoader>
-                      </RouteErrorBoundary>
-                    }
-                  />
-                  <Route
-                    path="/verify-sender"
-                    element={
-                      <RouteErrorBoundary routeName="Verify Sender">
-                        <PageLoader>
-                          <VerifySenderPage />
-                        </PageLoader>
-                      </RouteErrorBoundary>
-                    }
-                  />
+          {/* Tenant defaults (timezone, send time) — loaded once and shared by
+              every page that formats a date. */}
+          <SettingsProvider>
+            <ToastProvider>
+              <div className="min-h-screen bg-background overflow-x-hidden flex flex-col">
+                <div className="flex-1">
+                  <Routes>
+                    {/* Public Routes */}
+                    <Route
+                      path="/login"
+                      element={
+                        <RouteErrorBoundary routeName="Login">
+                          <PageLoader>
+                            <LazyLoginPage />
+                          </PageLoader>
+                        </RouteErrorBoundary>
+                      }
+                    />
+                    <Route
+                      path="/signup"
+                      element={
+                        <RouteErrorBoundary routeName="Sign Up">
+                          <PageLoader>
+                            <LazySignUpPage />
+                          </PageLoader>
+                        </RouteErrorBoundary>
+                      }
+                    />
+                    <Route
+                      path="/verify-sender"
+                      element={
+                        <RouteErrorBoundary routeName="Verify Sender">
+                          <PageLoader>
+                            <VerifySenderPage />
+                          </PageLoader>
+                        </RouteErrorBoundary>
+                      }
+                    />
 
-                  {/* Onboarding Routes */}
-                  <Route
-                    path="/onboarding/brand"
-                    element={
-                      <RouteErrorBoundary routeName="Brand Onboarding">
-                        <ProtectedRoute>
-                          <BrandOnboardingPage />
-                        </ProtectedRoute>
-                      </RouteErrorBoundary>
-                    }
-                  />
-                  <Route
-                    path="/onboarding/profile"
-                    element={
-                      <RouteErrorBoundary routeName="Profile Onboarding">
-                        <ProtectedRoute>
-                          <ProfileOnboardingPage />
-                        </ProtectedRoute>
-                      </RouteErrorBoundary>
-                    }
-                  />
-                  <Route
-                    path="/onboarding/sender"
-                    element={
-                      <RouteErrorBoundary routeName="Sender Onboarding">
-                        <ProtectedRoute>
-                          <SenderOnboardingPage />
-                        </ProtectedRoute>
-                      </RouteErrorBoundary>
-                    }
-                  />
+                    {/* Onboarding Routes */}
+                    <Route
+                      path="/onboarding/brand"
+                      element={
+                        <RouteErrorBoundary routeName="Brand Onboarding">
+                          <ProtectedRoute>
+                            <BrandOnboardingPage />
+                          </ProtectedRoute>
+                        </RouteErrorBoundary>
+                      }
+                    />
+                    <Route
+                      path="/onboarding/profile"
+                      element={
+                        <RouteErrorBoundary routeName="Profile Onboarding">
+                          <ProtectedRoute>
+                            <ProfileOnboardingPage />
+                          </ProtectedRoute>
+                        </RouteErrorBoundary>
+                      }
+                    />
+                    <Route
+                      path="/onboarding/sender"
+                      element={
+                        <RouteErrorBoundary routeName="Sender Onboarding">
+                          <ProtectedRoute>
+                            <SenderOnboardingPage />
+                          </ProtectedRoute>
+                        </RouteErrorBoundary>
+                      }
+                    />
 
-                  {/* Protected Routes with Onboarding Guard — wrapped in AppShell */}
-                  <Route
-                    path="/"
-                    element={
-                      <RouteErrorBoundary routeName="Dashboard">
-                        <ProtectedRoute>
-                          <OnboardingGuard>
-                            <AppShell>
-                              <PageLoader>
-                                <LazyDashboardPage />
-                              </PageLoader>
-                            </AppShell>
-                          </OnboardingGuard>
-                        </ProtectedRoute>
-                      </RouteErrorBoundary>
-                    }
-                  />
-                  <Route
-                    path="/brand"
-                    element={
-                      <RouteErrorBoundary routeName="Brand">
-                        <ProtectedRoute>
-                          <OnboardingGuard allowOnboarding>
-                            <AppShell>
-                              <PageLoader>
-                                <LazyBrandPage />
-                              </PageLoader>
-                            </AppShell>
-                          </OnboardingGuard>
-                        </ProtectedRoute>
-                      </RouteErrorBoundary>
-                    }
-                  />
-                  <Route
-                    path="/profile"
-                    element={
-                      <RouteErrorBoundary routeName="Profile">
-                        <ProtectedRoute>
-                          <OnboardingGuard allowOnboarding>
-                            <AppShell>
-                              <PageLoader>
-                                <LazyProfilePage />
-                              </PageLoader>
-                            </AppShell>
-                          </OnboardingGuard>
-                        </ProtectedRoute>
-                      </RouteErrorBoundary>
-                    }
-                  />
-                  <Route
-                    path="/api-keys"
-                    element={
-                      <RouteErrorBoundary routeName="API Keys">
-                        <ProtectedRoute>
-                          <OnboardingGuard>
-                            <AppShell>
-                              <PageLoader>
-                                <LazyApiKeysPage />
-                              </PageLoader>
-                            </AppShell>
-                          </OnboardingGuard>
-                        </ProtectedRoute>
-                      </RouteErrorBoundary>
-                    }
-                  />
-                  <Route
-                    path="/senders"
-                    element={
-                      <RouteErrorBoundary routeName="Sender Email Setup">
-                        <ProtectedRoute>
-                          <OnboardingGuard>
-                            <AppShell>
-                              <PageLoader>
-                                <LazySenderEmailSetupPage />
-                              </PageLoader>
-                            </AppShell>
-                          </OnboardingGuard>
-                        </ProtectedRoute>
-                      </RouteErrorBoundary>
-                    }
-                  />
-                  <Route
-                    path="/billing"
-                    element={
-                      <RouteErrorBoundary routeName="Billing">
-                        <ProtectedRoute>
-                          <OnboardingGuard>
-                            <AppShell>
-                              <PageLoader>
-                                <LazyBillingPage />
-                              </PageLoader>
-                            </AppShell>
-                          </OnboardingGuard>
-                        </ProtectedRoute>
-                      </RouteErrorBoundary>
-                    }
-                  />
-                  <Route
-                    path="/pricing"
-                    element={
-                      <RouteErrorBoundary routeName="Sponsors">
-                        <ProtectedRoute>
-                          <OnboardingGuard>
-                            <AppShell>
-                              <PageLoader>
-                                <LazySponsorshipPricingPage />
-                              </PageLoader>
-                            </AppShell>
-                          </OnboardingGuard>
-                        </ProtectedRoute>
-                      </RouteErrorBoundary>
-                    }
-                  />
-                  <Route
-                    path="/subscribers"
-                    element={
-                      <RouteErrorBoundary routeName="Subscribers">
-                        <ProtectedRoute>
-                          <OnboardingGuard>
-                            <AppShell>
-                              <PageLoader>
-                                <LazySubscribersPage />
-                              </PageLoader>
-                            </AppShell>
-                          </OnboardingGuard>
-                        </ProtectedRoute>
-                      </RouteErrorBoundary>
-                    }
-                  />
-                  <Route
-                    path="/sponsors"
-                    element={
-                      <RouteErrorBoundary routeName="Sponsors">
-                        <ProtectedRoute>
-                          <OnboardingGuard>
-                            <AppShell>
-                              <PageLoader>
-                                <LazySponsorDirectoryPage />
-                              </PageLoader>
-                            </AppShell>
-                          </OnboardingGuard>
-                        </ProtectedRoute>
-                      </RouteErrorBoundary>
-                    }
-                  />
-                  <Route
-                    path="/sponsors/:sponsorId"
-                    element={
-                      <RouteErrorBoundary routeName="Sponsor Details">
-                        <ProtectedRoute>
-                          <OnboardingGuard>
-                            <AppShell>
-                              <PageLoader>
-                                <LazySponsorDetailPage />
-                              </PageLoader>
-                            </AppShell>
-                          </OnboardingGuard>
-                        </ProtectedRoute>
-                      </RouteErrorBoundary>
-                    }
-                  />
-                  <Route
-                    path="/segments"
-                    element={<Navigate to="/subscribers" replace />}
-                  />
-                  <Route
-                    path="/segments/:segmentId"
-                    element={
-                      <RouteErrorBoundary routeName="Segment Details">
-                        <ProtectedRoute>
-                          <OnboardingGuard>
-                            <AppShell>
-                              <PageLoader>
-                                <LazySegmentDetailPage />
-                              </PageLoader>
-                            </AppShell>
-                          </OnboardingGuard>
-                        </ProtectedRoute>
-                      </RouteErrorBoundary>
-                    }
-                  />
-                  <Route
-                    path="/issues"
-                    element={
-                      <RouteErrorBoundary routeName="Issues">
-                        <ProtectedRoute>
-                          <OnboardingGuard>
-                            <AppShell>
-                              <PageLoader>
-                                <LazyIssuesListPage />
-                              </PageLoader>
-                            </AppShell>
-                          </OnboardingGuard>
-                        </ProtectedRoute>
-                      </RouteErrorBoundary>
-                    }
-                  />
-                  <Route
-                    path="/issues/new"
-                    element={
-                      <RouteErrorBoundary routeName="Create Issue">
-                        <ProtectedRoute>
-                          <OnboardingGuard>
-                            <AppShell>
-                              <PageLoader>
-                                <LazyIssueFormPage />
-                              </PageLoader>
-                            </AppShell>
-                          </OnboardingGuard>
-                        </ProtectedRoute>
-                      </RouteErrorBoundary>
-                    }
-                  />
-                  <Route
-                    path="/issues/:id"
-                    element={
-                      <RouteErrorBoundary routeName="Issue Details">
-                        <ProtectedRoute>
-                          <OnboardingGuard>
-                            <AppShell>
-                              <PageLoader>
-                                <LazyIssueDetailPage />
-                              </PageLoader>
-                            </AppShell>
-                          </OnboardingGuard>
-                        </ProtectedRoute>
-                      </RouteErrorBoundary>
-                    }
-                  />
-                  <Route
-                    path="/issues/:id/edit"
-                    element={
-                      <RouteErrorBoundary routeName="Edit Issue">
-                        <ProtectedRoute>
-                          <OnboardingGuard>
-                            <AppShell>
-                              <PageLoader>
-                                <LazyIssueFormPage />
-                              </PageLoader>
-                            </AppShell>
-                          </OnboardingGuard>
-                        </ProtectedRoute>
-                      </RouteErrorBoundary>
-                    }
-                  />
+                    {/* Protected Routes with Onboarding Guard — wrapped in AppShell */}
+                    <Route
+                      path="/"
+                      element={
+                        <RouteErrorBoundary routeName="Dashboard">
+                          <ProtectedRoute>
+                            <OnboardingGuard>
+                              <AppShell>
+                                <PageLoader>
+                                  <LazyDashboardPage />
+                                </PageLoader>
+                              </AppShell>
+                            </OnboardingGuard>
+                          </ProtectedRoute>
+                        </RouteErrorBoundary>
+                      }
+                    />
+                    <Route
+                      path="/brand"
+                      element={
+                        <RouteErrorBoundary routeName="Brand">
+                          <ProtectedRoute>
+                            <OnboardingGuard allowOnboarding>
+                              <AppShell>
+                                <PageLoader>
+                                  <LazyBrandPage />
+                                </PageLoader>
+                              </AppShell>
+                            </OnboardingGuard>
+                          </ProtectedRoute>
+                        </RouteErrorBoundary>
+                      }
+                    />
+                    <Route
+                      path="/profile"
+                      element={
+                        <RouteErrorBoundary routeName="Profile">
+                          <ProtectedRoute>
+                            <OnboardingGuard allowOnboarding>
+                              <AppShell>
+                                <PageLoader>
+                                  <LazyProfilePage />
+                                </PageLoader>
+                              </AppShell>
+                            </OnboardingGuard>
+                          </ProtectedRoute>
+                        </RouteErrorBoundary>
+                      }
+                    />
+                    <Route
+                      path="/settings"
+                      element={
+                        <RouteErrorBoundary routeName="Settings">
+                          <ProtectedRoute>
+                            <OnboardingGuard allowOnboarding>
+                              <AppShell>
+                                <PageLoader>
+                                  <LazySettingsPage />
+                                </PageLoader>
+                              </AppShell>
+                            </OnboardingGuard>
+                          </ProtectedRoute>
+                        </RouteErrorBoundary>
+                      }
+                    />
+                    <Route
+                      path="/api-keys"
+                      element={
+                        <RouteErrorBoundary routeName="API Keys">
+                          <ProtectedRoute>
+                            <OnboardingGuard>
+                              <AppShell>
+                                <PageLoader>
+                                  <LazyApiKeysPage />
+                                </PageLoader>
+                              </AppShell>
+                            </OnboardingGuard>
+                          </ProtectedRoute>
+                        </RouteErrorBoundary>
+                      }
+                    />
+                    <Route
+                      path="/senders"
+                      element={
+                        <RouteErrorBoundary routeName="Sender Email Setup">
+                          <ProtectedRoute>
+                            <OnboardingGuard>
+                              <AppShell>
+                                <PageLoader>
+                                  <LazySenderEmailSetupPage />
+                                </PageLoader>
+                              </AppShell>
+                            </OnboardingGuard>
+                          </ProtectedRoute>
+                        </RouteErrorBoundary>
+                      }
+                    />
+                    <Route
+                      path="/billing"
+                      element={
+                        <RouteErrorBoundary routeName="Billing">
+                          <ProtectedRoute>
+                            <OnboardingGuard>
+                              <AppShell>
+                                <PageLoader>
+                                  <LazyBillingPage />
+                                </PageLoader>
+                              </AppShell>
+                            </OnboardingGuard>
+                          </ProtectedRoute>
+                        </RouteErrorBoundary>
+                      }
+                    />
+                    <Route
+                      path="/pricing"
+                      element={
+                        <RouteErrorBoundary routeName="Sponsors">
+                          <ProtectedRoute>
+                            <OnboardingGuard>
+                              <AppShell>
+                                <PageLoader>
+                                  <LazySponsorshipPricingPage />
+                                </PageLoader>
+                              </AppShell>
+                            </OnboardingGuard>
+                          </ProtectedRoute>
+                        </RouteErrorBoundary>
+                      }
+                    />
+                    <Route
+                      path="/subscribers"
+                      element={
+                        <RouteErrorBoundary routeName="Subscribers">
+                          <ProtectedRoute>
+                            <OnboardingGuard>
+                              <AppShell>
+                                <PageLoader>
+                                  <LazySubscribersPage />
+                                </PageLoader>
+                              </AppShell>
+                            </OnboardingGuard>
+                          </ProtectedRoute>
+                        </RouteErrorBoundary>
+                      }
+                    />
+                    <Route
+                      path="/sponsors"
+                      element={
+                        <RouteErrorBoundary routeName="Sponsors">
+                          <ProtectedRoute>
+                            <OnboardingGuard>
+                              <AppShell>
+                                <PageLoader>
+                                  <LazySponsorDirectoryPage />
+                                </PageLoader>
+                              </AppShell>
+                            </OnboardingGuard>
+                          </ProtectedRoute>
+                        </RouteErrorBoundary>
+                      }
+                    />
+                    <Route
+                      path="/sponsors/:sponsorId"
+                      element={
+                        <RouteErrorBoundary routeName="Sponsor Details">
+                          <ProtectedRoute>
+                            <OnboardingGuard>
+                              <AppShell>
+                                <PageLoader>
+                                  <LazySponsorDetailPage />
+                                </PageLoader>
+                              </AppShell>
+                            </OnboardingGuard>
+                          </ProtectedRoute>
+                        </RouteErrorBoundary>
+                      }
+                    />
+                    <Route
+                      path="/segments"
+                      element={<Navigate to="/subscribers" replace />}
+                    />
+                    <Route
+                      path="/segments/:segmentId"
+                      element={
+                        <RouteErrorBoundary routeName="Segment Details">
+                          <ProtectedRoute>
+                            <OnboardingGuard>
+                              <AppShell>
+                                <PageLoader>
+                                  <LazySegmentDetailPage />
+                                </PageLoader>
+                              </AppShell>
+                            </OnboardingGuard>
+                          </ProtectedRoute>
+                        </RouteErrorBoundary>
+                      }
+                    />
+                    <Route
+                      path="/issues"
+                      element={
+                        <RouteErrorBoundary routeName="Issues">
+                          <ProtectedRoute>
+                            <OnboardingGuard>
+                              <AppShell>
+                                <PageLoader>
+                                  <LazyIssuesListPage />
+                                </PageLoader>
+                              </AppShell>
+                            </OnboardingGuard>
+                          </ProtectedRoute>
+                        </RouteErrorBoundary>
+                      }
+                    />
+                    <Route
+                      path="/issues/new"
+                      element={
+                        <RouteErrorBoundary routeName="Create Issue">
+                          <ProtectedRoute>
+                            <OnboardingGuard>
+                              <AppShell>
+                                <PageLoader>
+                                  <LazyIssueFormPage />
+                                </PageLoader>
+                              </AppShell>
+                            </OnboardingGuard>
+                          </ProtectedRoute>
+                        </RouteErrorBoundary>
+                      }
+                    />
+                    <Route
+                      path="/issues/:id"
+                      element={
+                        <RouteErrorBoundary routeName="Issue Details">
+                          <ProtectedRoute>
+                            <OnboardingGuard>
+                              <AppShell>
+                                <PageLoader>
+                                  <LazyIssueDetailPage />
+                                </PageLoader>
+                              </AppShell>
+                            </OnboardingGuard>
+                          </ProtectedRoute>
+                        </RouteErrorBoundary>
+                      }
+                    />
+                    <Route
+                      path="/issues/:id/edit"
+                      element={
+                        <RouteErrorBoundary routeName="Edit Issue">
+                          <ProtectedRoute>
+                            <OnboardingGuard>
+                              <AppShell>
+                                <PageLoader>
+                                  <LazyIssueFormPage />
+                                </PageLoader>
+                              </AppShell>
+                            </OnboardingGuard>
+                          </ProtectedRoute>
+                        </RouteErrorBoundary>
+                      }
+                    />
 
-                  <Route
-                    path="/reports"
-                    element={
-                      <RouteErrorBoundary routeName="Reports">
-                        <ProtectedRoute>
-                          <OnboardingGuard>
-                            <AppShell>
-                              <PageLoader>
-                                <LazyReportsListPage />
-                              </PageLoader>
-                            </AppShell>
-                          </OnboardingGuard>
-                        </ProtectedRoute>
-                      </RouteErrorBoundary>
-                    }
-                  />
-                  <Route
-                    path="/reports/:id"
-                    element={
-                      <RouteErrorBoundary routeName="Report Details">
-                        <ProtectedRoute>
-                          <OnboardingGuard>
-                            <AppShell>
-                              <PageLoader>
-                                <LazyReportDetailPage />
-                              </PageLoader>
-                            </AppShell>
-                          </OnboardingGuard>
-                        </ProtectedRoute>
-                      </RouteErrorBoundary>
-                    }
-                  />
+                    <Route
+                      path="/reports"
+                      element={
+                        <RouteErrorBoundary routeName="Reports">
+                          <ProtectedRoute>
+                            <OnboardingGuard>
+                              <AppShell>
+                                <PageLoader>
+                                  <LazyReportsListPage />
+                                </PageLoader>
+                              </AppShell>
+                            </OnboardingGuard>
+                          </ProtectedRoute>
+                        </RouteErrorBoundary>
+                      }
+                    />
+                    <Route
+                      path="/reports/:id"
+                      element={
+                        <RouteErrorBoundary routeName="Report Details">
+                          <ProtectedRoute>
+                            <OnboardingGuard>
+                              <AppShell>
+                                <PageLoader>
+                                  <LazyReportDetailPage />
+                                </PageLoader>
+                              </AppShell>
+                            </OnboardingGuard>
+                          </ProtectedRoute>
+                        </RouteErrorBoundary>
+                      }
+                    />
 
-                  <Route
-                    path="/templates"
-                    element={
-                      <RouteErrorBoundary routeName="Templates">
-                        <ProtectedRoute>
-                          <OnboardingGuard>
-                            <AppShell>
-                              <PageLoader>
-                                <LazyTemplatesListPage />
-                              </PageLoader>
-                            </AppShell>
-                          </OnboardingGuard>
-                        </ProtectedRoute>
-                      </RouteErrorBoundary>
-                    }
-                  />
-                  <Route
-                    path="/templates/new"
-                    element={
-                      <RouteErrorBoundary routeName="Create Template">
-                        <ProtectedRoute>
-                          <OnboardingGuard>
-                            <AppShell>
-                              <PageLoader>
-                                <LazyTemplateFormPage />
-                              </PageLoader>
-                            </AppShell>
-                          </OnboardingGuard>
-                        </ProtectedRoute>
-                      </RouteErrorBoundary>
-                    }
-                  />
-                  <Route
-                    path="/templates/:id/edit"
-                    element={
-                      <RouteErrorBoundary routeName="Edit Template">
-                        <ProtectedRoute>
-                          <OnboardingGuard>
-                            <AppShell>
-                              <PageLoader>
-                                <LazyTemplateFormPage />
-                              </PageLoader>
-                            </AppShell>
-                          </OnboardingGuard>
-                        </ProtectedRoute>
-                      </RouteErrorBoundary>
-                    }
-                  />
+                    <Route
+                      path="/templates"
+                      element={
+                        <RouteErrorBoundary routeName="Templates">
+                          <ProtectedRoute>
+                            <OnboardingGuard>
+                              <AppShell>
+                                <PageLoader>
+                                  <LazyTemplatesListPage />
+                                </PageLoader>
+                              </AppShell>
+                            </OnboardingGuard>
+                          </ProtectedRoute>
+                        </RouteErrorBoundary>
+                      }
+                    />
+                    <Route
+                      path="/templates/new"
+                      element={
+                        <RouteErrorBoundary routeName="Create Template">
+                          <ProtectedRoute>
+                            <OnboardingGuard>
+                              <AppShell>
+                                <PageLoader>
+                                  <LazyTemplateFormPage />
+                                </PageLoader>
+                              </AppShell>
+                            </OnboardingGuard>
+                          </ProtectedRoute>
+                        </RouteErrorBoundary>
+                      }
+                    />
+                    <Route
+                      path="/templates/:id/edit"
+                      element={
+                        <RouteErrorBoundary routeName="Edit Template">
+                          <ProtectedRoute>
+                            <OnboardingGuard>
+                              <AppShell>
+                                <PageLoader>
+                                  <LazyTemplateFormPage />
+                                </PageLoader>
+                              </AppShell>
+                            </OnboardingGuard>
+                          </ProtectedRoute>
+                        </RouteErrorBoundary>
+                      }
+                    />
 
-                  <Route
-                    path="/snippets"
-                    element={
-                      <RouteErrorBoundary routeName="Snippets">
-                        <ProtectedRoute>
-                          <OnboardingGuard>
-                            <AppShell>
-                              <PageLoader>
-                                <LazySnippetsListPage />
-                              </PageLoader>
-                            </AppShell>
-                          </OnboardingGuard>
-                        </ProtectedRoute>
-                      </RouteErrorBoundary>
-                    }
-                  />
-                  <Route
-                    path="/snippets/new"
-                    element={
-                      <RouteErrorBoundary routeName="Create Snippet">
-                        <ProtectedRoute>
-                          <OnboardingGuard>
-                            <AppShell>
-                              <PageLoader>
-                                <LazySnippetFormPage />
-                              </PageLoader>
-                            </AppShell>
-                          </OnboardingGuard>
-                        </ProtectedRoute>
-                      </RouteErrorBoundary>
-                    }
-                  />
-                  <Route
-                    path="/snippets/:id/edit"
-                    element={
-                      <RouteErrorBoundary routeName="Edit Snippet">
-                        <ProtectedRoute>
-                          <OnboardingGuard>
-                            <AppShell>
-                              <PageLoader>
-                                <LazySnippetFormPage />
-                              </PageLoader>
-                            </AppShell>
-                          </OnboardingGuard>
-                        </ProtectedRoute>
-                      </RouteErrorBoundary>
-                    }
-                  />
+                    <Route
+                      path="/snippets"
+                      element={
+                        <RouteErrorBoundary routeName="Snippets">
+                          <ProtectedRoute>
+                            <OnboardingGuard>
+                              <AppShell>
+                                <PageLoader>
+                                  <LazySnippetsListPage />
+                                </PageLoader>
+                              </AppShell>
+                            </OnboardingGuard>
+                          </ProtectedRoute>
+                        </RouteErrorBoundary>
+                      }
+                    />
+                    <Route
+                      path="/snippets/new"
+                      element={
+                        <RouteErrorBoundary routeName="Create Snippet">
+                          <ProtectedRoute>
+                            <OnboardingGuard>
+                              <AppShell>
+                                <PageLoader>
+                                  <LazySnippetFormPage />
+                                </PageLoader>
+                              </AppShell>
+                            </OnboardingGuard>
+                          </ProtectedRoute>
+                        </RouteErrorBoundary>
+                      }
+                    />
+                    <Route
+                      path="/snippets/:id/edit"
+                      element={
+                        <RouteErrorBoundary routeName="Edit Snippet">
+                          <ProtectedRoute>
+                            <OnboardingGuard>
+                              <AppShell>
+                                <PageLoader>
+                                  <LazySnippetFormPage />
+                                </PageLoader>
+                              </AppShell>
+                            </OnboardingGuard>
+                          </ProtectedRoute>
+                        </RouteErrorBoundary>
+                      }
+                    />
 
-                  {/* Catch all - redirect to home */}
-                  <Route path="*" element={<Navigate to="/" replace />} />
-                </Routes>
-              </div>
-              <footer className="border-t border-border bg-surface">
-                <div className="mx-auto max-w-7xl px-4 py-3 text-xs text-muted-foreground sm:px-6 lg:px-8">
-                  <div>© {new Date().getFullYear()} {BRAND.copyrightHolder}</div>
+                    {/* Catch all - redirect to home */}
+                    <Route path="*" element={<Navigate to="/" replace />} />
+                  </Routes>
                 </div>
-              </footer>
-            </div>
-          </ToastProvider>
+                <footer className="border-t border-border bg-surface">
+                  <div className="mx-auto max-w-7xl px-4 py-3 text-xs text-muted-foreground sm:px-6 lg:px-8">
+                    <div>© {new Date().getFullYear()} {BRAND.copyrightHolder}</div>
+                  </div>
+                </footer>
+              </div>
+            </ToastProvider>
+          </SettingsProvider>
         </AuthProvider>
       </Router>
     </ErrorBoundary>

--- a/dashboard-ui/src/components/issues/IssueCard.tsx
+++ b/dashboard-ui/src/components/issues/IssueCard.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '../ui/Card
 import { IssueStatusBadge } from './IssueStatusBadge';
 import { usePrefetchIssueDetail, shouldPrefetch } from '../../utils/prefetch';
 import type { IssueListItem } from '../../types/issues';
+import { useTenantDateFormat } from '@/contexts/SettingsContext';
 
 /**
  * Props for the IssueCard component
@@ -23,13 +24,9 @@ export interface IssueCardProps {
 export const IssueCard: React.FC<IssueCardProps> = React.memo(({ issue }) => {
   const { prefetchIssueComponents } = usePrefetchIssueDetail();
 
-  const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString('en-US', {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric'
-    });
-  };
+  // Dates read in the newsletter's timezone, not the viewer's, so a card and
+  // the schedule that produced it always agree on which day a send lands on.
+  const { formatDate } = useTenantDateFormat();
 
   const handleMouseEnter = useCallback(() => {
     // Only prefetch on fast connections

--- a/dashboard-ui/src/components/layout/AvatarMenu.tsx
+++ b/dashboard-ui/src/components/layout/AvatarMenu.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { useTheme } from '@/hooks/useTheme';
 import {
   UserIcon,
+  Cog6ToothIcon,
   EnvelopeIcon,
   KeyIcon,
   CreditCardIcon,
@@ -38,6 +39,7 @@ export function AvatarMenu({ showThemeToggle = true }: AvatarMenuProps = {}) {
   const getMenuItems = useCallback(() => {
     const items: { id: string; type: 'link' | 'button' }[] = [
       { id: 'profile', type: 'link' },
+      { id: 'settings', type: 'link' },
       { id: 'senders', type: 'link' },
       { id: 'api-keys', type: 'link' },
     ];
@@ -161,6 +163,7 @@ export function AvatarMenu({ showThemeToggle = true }: AvatarMenuProps = {}) {
 
   const linkItems = [
     { id: 'profile', label: 'Profile', href: '/profile', icon: UserSolidIcon },
+    { id: 'settings', label: 'Settings', href: '/settings', icon: Cog6ToothIcon },
     { id: 'senders', label: 'Sender Emails', href: '/senders', icon: EnvelopeIcon },
     { id: 'api-keys', label: 'API Keys', href: '/api-keys', icon: KeyIcon },
     ...(showBilling

--- a/dashboard-ui/src/contexts/SettingsContext.tsx
+++ b/dashboard-ui/src/contexts/SettingsContext.tsx
@@ -1,0 +1,156 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
+import { useAuth } from './AuthContext';
+import { settingsService } from '@/services/settingsService';
+import {
+  formatDateInTimeZone,
+  formatDateTimeInTimeZone,
+  formatLongDateInTimeZone,
+  formatTimeInTimeZone,
+  getTimeZoneAbbreviation,
+  type DateInput
+} from '@/utils/dateFormatting';
+import type { SettingsResponse, TenantSettings, UpdateSettingsRequest } from '@/types/settings';
+
+/**
+ * What the app falls back to before settings have loaded, and if the request
+ * fails. Kept in step with the backend's own defaults (`settings.rs`) so a
+ * page that renders during the initial fetch doesn't briefly show times in a
+ * different zone than the one it settles on.
+ */
+export const FALLBACK_SETTINGS: TenantSettings = {
+  timezone: 'UTC',
+  defaultSendTime: '09:00'
+};
+
+interface SettingsContextValue {
+  /** Effective settings — never null, so callers don't need a loading branch. */
+  settings: TenantSettings;
+  /** System defaults, for marking which effective values are inherited. */
+  defaults: TenantSettings;
+  /** When settings were last saved; undefined if they never have been. */
+  updatedAt?: string;
+  isLoading: boolean;
+  error: string | null;
+  /** Re-read settings from the API. */
+  refresh: () => Promise<void>;
+  /** Save a partial update and adopt the result app-wide. */
+  save: (update: UpdateSettingsRequest) => Promise<void>;
+}
+
+const SettingsContext = createContext<SettingsContextValue | null>(null);
+
+interface SettingsProviderProps {
+  children: ReactNode;
+}
+
+/**
+ * Loads the tenant's settings once per session and shares them with every
+ * page, so timezone-aware formatting doesn't cost a request per component.
+ */
+export function SettingsProvider({ children }: SettingsProviderProps) {
+  const { isAuthenticated } = useAuth();
+  const [response, setResponse] = useState<SettingsResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const result = await settingsService.getSettings();
+      if (result.success && result.data) {
+        setResponse(result.data);
+      } else {
+        setError(result.error || 'Failed to load settings');
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load settings');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      // Signing out clears the cached tenant values rather than leaking them
+      // into the next session in this tab.
+      setResponse(null);
+      setError(null);
+      return;
+    }
+    void load();
+  }, [isAuthenticated, load]);
+
+  const save = useCallback(async (update: UpdateSettingsRequest) => {
+    const result = await settingsService.updateSettings(update);
+    if (!result.success || !result.data) {
+      throw new Error(result.error || 'Failed to save settings');
+    }
+    setResponse(result.data);
+  }, []);
+
+  const value = useMemo<SettingsContextValue>(
+    () => ({
+      settings: response?.settings ?? FALLBACK_SETTINGS,
+      defaults: response?.defaults ?? FALLBACK_SETTINGS,
+      updatedAt: response?.updatedAt,
+      isLoading,
+      error,
+      refresh: load,
+      save
+    }),
+    [response, isLoading, error, load, save]
+  );
+
+  return <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>;
+}
+
+/**
+ * The full settings store, including `save` and `refresh`. Requires a
+ * provider: a component that writes settings has no sensible fallback.
+ */
+export function useSettings(): SettingsContextValue {
+  const context = useContext(SettingsContext);
+  if (!context) {
+    throw new Error('useSettings must be used within a SettingsProvider');
+  }
+  return context;
+}
+
+/**
+ * Read-only access to the tenant's settings that degrades to the fallbacks
+ * outside a provider. Formatting a date is not a good enough reason to crash a
+ * page (or to make every test that renders one wire up a provider), so the
+ * read path stays lenient where the write path above does not.
+ */
+export function useTenantSettings(): TenantSettings {
+  return useContext(SettingsContext)?.settings ?? FALLBACK_SETTINGS;
+}
+
+/**
+ * Formatters bound to the tenant's configured timezone. Use these instead of
+ * `toLocaleString` so every surface reports the same wall clock — the one the
+ * newsletter is actually scheduled against.
+ */
+export function useTenantDateFormat() {
+  const timeZone = useTenantSettings().timezone;
+
+  return useMemo(
+    () => ({
+      timeZone,
+      /** `Aug 1, 2026` */
+      formatDate: (value: DateInput) => formatDateInTimeZone(value, timeZone),
+      /** `August 1, 2026` */
+      formatLongDate: (value: DateInput) => formatLongDateInTimeZone(value, timeZone),
+      /** `9:00 AM` */
+      formatTime: (value: DateInput) => formatTimeInTimeZone(value, timeZone),
+      /** `Aug 1, 2026, 9:00 AM CDT` */
+      formatDateTime: (value: DateInput) => formatDateTimeInTimeZone(value, timeZone),
+      /** `CDT` — the zone label in effect at the given instant. */
+      timeZoneLabel: (value?: DateInput) => getTimeZoneAbbreviation(timeZone, value)
+    }),
+    [timeZone]
+  );
+}

--- a/dashboard-ui/src/contexts/SettingsContext.tsx
+++ b/dashboard-ui/src/contexts/SettingsContext.tsx
@@ -7,10 +7,16 @@ import {
   formatDateTimeInTimeZone,
   formatLongDateInTimeZone,
   formatTimeInTimeZone,
+  getBrowserTimeZone,
   getTimeZoneAbbreviation,
   type DateInput
 } from '@/utils/dateFormatting';
-import type { SettingsResponse, TenantSettings, UpdateSettingsRequest } from '@/types/settings';
+import type {
+  SettingName,
+  SettingsResponse,
+  TenantSettings,
+  UpdateSettingsRequest
+} from '@/types/settings';
 
 /**
  * What the app falls back to before settings have loaded, and if the request
@@ -24,10 +30,20 @@ export const FALLBACK_SETTINGS: TenantSettings = {
 };
 
 interface SettingsContextValue {
-  /** Effective settings — never null, so callers don't need a loading branch. */
+  /**
+   * Effective settings — never null, so callers don't need a loading branch.
+   * When the tenant has never chosen a timezone, this reports the viewer's
+   * browser zone rather than the server-side UTC default: the server can't
+   * know where anyone is, but the browser can, and reading a send time in your
+   * own zone beats reading it in UTC.
+   */
   settings: TenantSettings;
   /** System defaults, for marking which effective values are inherited. */
   defaults: TenantSettings;
+  /** Which settings the tenant has explicitly chosen. */
+  configured: SettingName[];
+  /** True when the tenant has never picked a timezone. */
+  isTimeZoneInferred: boolean;
   /** When settings were last saved; undefined if they never have been. */
   updatedAt?: string;
   isLoading: boolean;
@@ -91,18 +107,26 @@ export function SettingsProvider({ children }: SettingsProviderProps) {
     setResponse(result.data);
   }, []);
 
-  const value = useMemo<SettingsContextValue>(
-    () => ({
-      settings: response?.settings ?? FALLBACK_SETTINGS,
+  const value = useMemo<SettingsContextValue>(() => {
+    const configured = response?.configured ?? [];
+    const settings = response?.settings ?? FALLBACK_SETTINGS;
+    const isTimeZoneInferred = !configured.includes('timezone');
+
+    return {
+      // Substituting the browser zone only changes how instants are *rendered*
+      // — the instant itself is whatever the API returned. Once the tenant
+      // saves a zone, their choice wins everywhere.
+      settings: isTimeZoneInferred ? { ...settings, timezone: getBrowserTimeZone() } : settings,
       defaults: response?.defaults ?? FALLBACK_SETTINGS,
+      configured,
+      isTimeZoneInferred,
       updatedAt: response?.updatedAt,
       isLoading,
       error,
       refresh: load,
       save
-    }),
-    [response, isLoading, error, load, save]
-  );
+    };
+  }, [response, isLoading, error, load, save]);
 
   return <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>;
 }
@@ -127,6 +151,18 @@ export function useSettings(): SettingsContextValue {
  */
 export function useTenantSettings(): TenantSettings {
   return useContext(SettingsContext)?.settings ?? FALLBACK_SETTINGS;
+}
+
+/**
+ * The zone dates are rendered in, and whether it's the tenant's own choice or
+ * the browser zone standing in for one they haven't made yet.
+ */
+export function useDisplayTimeZone(): { timeZone: string; isInferred: boolean } {
+  const context = useContext(SettingsContext);
+  return {
+    timeZone: context?.settings.timezone ?? FALLBACK_SETTINGS.timezone,
+    isInferred: context?.isTimeZoneInferred ?? false
+  };
 }
 
 /**

--- a/dashboard-ui/src/contexts/index.ts
+++ b/dashboard-ui/src/contexts/index.ts
@@ -1,3 +1,4 @@
 // Contexts export
 export * from './AppContext';
 export * from './AuthContext';
+export * from './SettingsContext';

--- a/dashboard-ui/src/pages/issues/IssueDetailPage.tsx
+++ b/dashboard-ui/src/pages/issues/IssueDetailPage.tsx
@@ -46,6 +46,7 @@ import { getErrorDetails, validateAnalyticsData } from '../../utils/errorMessage
 import { useKeyboardShortcuts } from '../../hooks/useKeyboardShortcuts';
 import type { Issue, IssueAnalytics, IssueMetrics, TrendsData } from '../../types/issues';
 import type { NavigationSection } from '../../components/issues/QuickNavigation';
+import { useTenantDateFormat } from '@/contexts/SettingsContext';
 
 // Lazy load analytics components for better performance
 const LinkPerformanceTable = lazy(() => import('../../components/issues/LinkPerformanceTable').then(m => ({ default: m.LinkPerformanceTable })));
@@ -506,15 +507,9 @@ export const IssueDetailPage: React.FC = () => {
     navigate('/issues');
   }, [navigate]);
 
-  const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString('en-US', {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit'
-    });
-  };
+  // Times here carry a zone label: an issue's send time is only meaningful
+  // against the newsletter's timezone, which may not be the viewer's.
+  const { formatDateTime: formatDate } = useTenantDateFormat();
 
   const isDraft = useMemo(() => issue?.status === 'draft', [issue?.status]);
   const isPublished = useMemo(() => issue?.status === 'published', [issue?.status]);

--- a/dashboard-ui/src/pages/issues/IssueFormPage.tsx
+++ b/dashboard-ui/src/pages/issues/IssueFormPage.tsx
@@ -126,6 +126,8 @@ export const IssueFormPage: React.FC = () => {
   const [localSendTimeZone, setLocalSendTimeZone] = useState(timeZone);
   /** Set once the author (or a saved issue) picks a zone explicitly. */
   const localSendTouched = useRef(false);
+  /** The issue id already fetched, so a re-render can't trigger a second GET. */
+  const loadedIssueId = useRef<string | null>(null);
   // Interest-aware assembly: personalized section order (contentAssembly).
   const [personalizedOrder, setPersonalizedOrder] = useState(false);
 
@@ -242,12 +244,46 @@ export const IssueFormPage: React.FC = () => {
     }
   }, [navigate, addToast, toDatetimeLocal]);
 
-  // Load existing issue data for edit mode
+  // Load existing issue data for edit mode, once per issue. `loadIssue` changes
+  // identity when the tenant timezone resolves (it converts timestamps for
+  // display), and re-running it would fire a second GET, reset the form under
+  // the author, and race the first response. The zone change is handled by
+  // reprojection below instead.
   useEffect(() => {
-    if (isEditMode && id) {
+    if (isEditMode && id && loadedIssueId.current !== id) {
+      loadedIssueId.current = id;
       loadIssue(id);
     }
   }, [isEditMode, id, loadIssue]);
+
+  // Settings can resolve after the issue does, in which case the schedule
+  // fields were converted against the fallback zone. Re-express them from the
+  // issue's stored timestamps — no refetch, and only while the form is
+  // untouched, so this can never overwrite something the author typed.
+  useEffect(() => {
+    if (!existingIssue || isDirty) return;
+
+    setFormData((prev) => ({
+      ...prev,
+      scheduledAt: existingIssue.scheduledAt ? toDatetimeLocal(existingIssue.scheduledAt) : '',
+    }));
+
+    if (existingIssue.abTest) {
+      setAbTest((prev) =>
+        prev
+          ? {
+            ...prev,
+            variants: prev.variants.map((variant, index) => {
+              const saved = existingIssue.abTest?.variants[index];
+              return saved?.sendAt
+                ? { ...variant, sendAt: toDatetimeLocal(saved.sendAt) }
+                : variant;
+            }),
+          }
+          : prev
+      );
+    }
+  }, [existingIssue, isDirty, toDatetimeLocal]);
 
   // Load available templates for the template picker
   useEffect(() => {

--- a/dashboard-ui/src/pages/issues/IssueFormPage.tsx
+++ b/dashboard-ui/src/pages/issues/IssueFormPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, Link } from 'react-router-dom';
 import { Eye, EyeOff, FileText, FileJson } from 'lucide-react';
 import { Input } from '@/components/ui/Input';
 import { Button } from '@/components/ui/Button';
@@ -21,6 +21,11 @@ import {
 import { issuesService } from '@/services/issuesService';
 import { templateService } from '@/services/templateService';
 import { timezoneOptions } from '@/schemas/profileSchema';
+import { useTenantDateFormat, useTenantSettings } from '@/contexts/SettingsContext';
+import {
+  fromDatetimeLocalInTimeZone,
+  toDatetimeLocalInTimeZone
+} from '@/utils/dateFormatting';
 import type { Issue, CreateIssueRequest, UpdateIssueRequest, IssueContentType, AbTest } from '@/types/issues';
 import type { TemplateSummary } from '@/types/api';
 
@@ -70,15 +75,17 @@ const validateContent = (value: string, contentType: IssueContentType): string |
 /**
  * Builds the API-ready A/B test payload from the form's working state:
  * converts variant send times from datetime-local to ISO and strips
- * server-managed fields (testId/status/winner/evaluation).
+ * server-managed fields (testId/status/winner/evaluation). Send times are read
+ * as wall-clock times in `timeZone` — the newsletter's zone — matching the
+ * schedule field above them.
  */
-const buildAbTestRequest = (abTest: AbTest): AbTest => ({
+const buildAbTestRequest = (abTest: AbTest, timeZone: string): AbTest => ({
   dimension: abTest.dimension,
   variants: abTest.variants.map((v) => ({
     variantId: v.variantId,
     ...(abTest.dimension === 'subject'
       ? { subject: v.subject }
-      : { sendAt: v.sendAt ? new Date(v.sendAt).toISOString() : v.sendAt }),
+      : { sendAt: v.sendAt ? fromDatetimeLocalInTimeZone(v.sendAt, timeZone) : v.sendAt }),
   })),
   winMetric: abTest.winMetric,
   confidence: abTest.confidence,
@@ -93,6 +100,8 @@ export const IssueFormPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const { addToast } = useToast();
+  const settings = useTenantSettings();
+  const { timeZone, timeZoneLabel } = useTenantDateFormat();
   const isEditMode = !!id;
 
   const [formData, setFormData] = useState<FormData>({
@@ -131,6 +140,14 @@ export const IssueFormPage: React.FC = () => {
   const [showCancelDialog, setShowCancelDialog] = useState(false);
   const [existingIssue, setExistingIssue] = useState<Issue | null>(null);
   const [isFormDisabled, setIsFormDisabled] = useState(false);
+
+  // Schedule fields work in the newsletter's timezone rather than the author's
+  // browser zone, so what's typed here is the wall-clock time subscribers get
+  // — and matches how the API resolves a date-only schedule.
+  const toDatetimeLocal = useCallback(
+    (isoString: string): string => toDatetimeLocalInTimeZone(isoString, timeZone),
+    [timeZone]
+  );
 
   const loadIssue = useCallback(async (issueId: string) => {
     setIsLoading(true);
@@ -202,7 +219,7 @@ export const IssueFormPage: React.FC = () => {
     } finally {
       setIsLoading(false);
     }
-  }, [navigate, addToast]);
+  }, [navigate, addToast, toDatetimeLocal]);
 
   // Load existing issue data for edit mode
   useEffect(() => {
@@ -230,18 +247,6 @@ export const IssueFormPage: React.FC = () => {
       cancelled = true;
     };
   }, []);
-
-  // Convert ISO datetime to datetime-local format
-  const toDatetimeLocal = (isoString: string): string => {
-    if (!isoString) return '';
-    const date = new Date(isoString);
-    const year = date.getFullYear();
-    const month = String(date.getMonth() + 1).padStart(2, '0');
-    const day = String(date.getDate()).padStart(2, '0');
-    const hours = String(date.getHours()).padStart(2, '0');
-    const minutes = String(date.getMinutes()).padStart(2, '0');
-    return `${year}-${month}-${day}T${hours}:${minutes}`;
-  };
 
   // Handle input changes
   const handleInputChange = useCallback((field: keyof FormData, value: string) => {
@@ -290,10 +295,11 @@ export const IssueFormPage: React.FC = () => {
 
       case 'scheduledAt':
         if (value && value.trim()) {
-          const scheduledDate = new Date(value);
+          const instant = fromDatetimeLocalInTimeZone(value, timeZone);
+          const scheduledDate = new Date(instant);
           const now = new Date();
 
-          if (isNaN(scheduledDate.getTime())) {
+          if (!instant || isNaN(scheduledDate.getTime())) {
             return 'Invalid date format';
           }
 
@@ -304,7 +310,7 @@ export const IssueFormPage: React.FC = () => {
         break;
     }
     return undefined;
-  }, []);
+  }, [timeZone]);
 
   // Validate entire form
   const validateForm = useCallback((): boolean => {
@@ -395,7 +401,7 @@ export const IssueFormPage: React.FC = () => {
         };
 
         if (formData.scheduledAt) {
-          updateData.scheduledAt = new Date(formData.scheduledAt).toISOString();
+          updateData.scheduledAt = fromDatetimeLocalInTimeZone(formData.scheduledAt, timeZone);
         }
 
         // Always send templateId so selecting "Default template" (empty value)
@@ -403,7 +409,7 @@ export const IssueFormPage: React.FC = () => {
         updateData.templateId = formData.templateId ?? DEFAULT_TEMPLATE_VALUE;
 
         if (abTest) {
-          updateData.abTest = buildAbTestRequest(abTest);
+          updateData.abTest = buildAbTestRequest(abTest, timeZone);
         } else if (existingIssue?.abTest) {
           // The test was turned off after being saved — send an explicit null so
           // the API clears the stored config (omitting it leaves it in place).
@@ -477,7 +483,7 @@ export const IssueFormPage: React.FC = () => {
         }
 
         if (formData.scheduledAt) {
-          createData.scheduledAt = new Date(formData.scheduledAt).toISOString();
+          createData.scheduledAt = fromDatetimeLocalInTimeZone(formData.scheduledAt, timeZone);
         }
 
         if (formData.templateId) {
@@ -485,7 +491,7 @@ export const IssueFormPage: React.FC = () => {
         }
 
         if (abTest) {
-          createData.abTest = buildAbTestRequest(abTest);
+          createData.abTest = buildAbTestRequest(abTest, timeZone);
         }
 
         if (localSendEnabled && !abTest) {
@@ -542,7 +548,7 @@ export const IssueFormPage: React.FC = () => {
     } finally {
       setIsSubmitting(false);
     }
-  }, [validateForm, isEditMode, id, formData, abTest, localSendEnabled, localSendTimeZone, localSendMode, personalizedOrder, existingIssue, navigate, addToast]);
+  }, [validateForm, isEditMode, id, formData, abTest, localSendEnabled, localSendTimeZone, localSendMode, personalizedOrder, existingIssue, navigate, addToast, timeZone]);
 
   // Handle cancel with unsaved changes confirmation
   const handleCancel = useCallback(() => {
@@ -687,7 +693,14 @@ export const IssueFormPage: React.FC = () => {
                 </p>
               )}
               <p className="mt-1 text-xs text-muted-foreground">
-                Leave empty to save as draft. Set a future date/time to schedule automatic publication. Time is in your local timezone.
+                Leave empty to save as draft. Set a future date/time to schedule automatic
+                publication. Times are in your newsletter&rsquo;s timezone &mdash; {timeZone}
+                {timeZoneLabel() ? ` (${timeZoneLabel()})` : ''}. An API request that sends a date
+                without a time uses {settings.defaultSendTime} in that zone. Both are set in{' '}
+                <Link to="/settings" className="underline hover:text-foreground">
+                  Settings
+                </Link>
+                .
               </p>
             </div>
 

--- a/dashboard-ui/src/pages/issues/IssueFormPage.tsx
+++ b/dashboard-ui/src/pages/issues/IssueFormPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import { Eye, EyeOff, FileText, FileJson } from 'lucide-react';
 import { Input } from '@/components/ui/Input';
@@ -120,13 +120,12 @@ export const IssueFormPage: React.FC = () => {
 
   const [localSendEnabled, setLocalSendEnabled] = useState(false);
   const [localSendMode, setLocalSendMode] = useState<'timezone' | 'peak-hour'>('timezone');
-  const [localSendTimeZone, setLocalSendTimeZone] = useState(() => {
-    // Default to the author's browser timezone when it's one of the options.
-    const browserZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    return timezoneOptions.some((option) => option.value === browserZone)
-      ? browserZone
-      : 'America/New_York';
-  });
+  // Defaults to the newsletter's own timezone — the same zone the schedule
+  // field above is read in, and the one the API falls back to when a local-send
+  // config omits it. An author can still pick a different zone per issue.
+  const [localSendTimeZone, setLocalSendTimeZone] = useState(timeZone);
+  /** Set once the author (or a saved issue) picks a zone explicitly. */
+  const localSendTouched = useRef(false);
   // Interest-aware assembly: personalized section order (contentAssembly).
   const [personalizedOrder, setPersonalizedOrder] = useState(false);
 
@@ -140,6 +139,27 @@ export const IssueFormPage: React.FC = () => {
   const [showCancelDialog, setShowCancelDialog] = useState(false);
   const [existingIssue, setExistingIssue] = useState<Issue | null>(null);
   const [isFormDisabled, setIsFormDisabled] = useState(false);
+
+  // Follow the tenant setting once it loads, unless this issue already carries
+  // its own saved zone (edit mode sets it explicitly below).
+  useEffect(() => {
+    if (!localSendTouched.current) {
+      setLocalSendTimeZone(timeZone);
+    }
+  }, [timeZone]);
+
+  // The local-send picker offers a curated shortlist; the newsletter's own zone
+  // may not be on it, and a `<select>` whose value isn't an option silently
+  // shows a different one.
+  const localSendTimeZoneOptions = useMemo(() => {
+    if (timezoneOptions.some((option) => option.value === localSendTimeZone)) {
+      return timezoneOptions;
+    }
+    return [
+      { value: localSendTimeZone, label: localSendTimeZone.replace(/_/g, ' ') },
+      ...timezoneOptions
+    ];
+  }, [localSendTimeZone]);
 
   // Schedule fields work in the newsletter's timezone rather than the author's
   // browser zone, so what's typed here is the wall-clock time subscribers get
@@ -185,6 +205,7 @@ export const IssueFormPage: React.FC = () => {
         if (issue.localSend?.enabled) {
           setLocalSendEnabled(true);
           if (issue.localSend.defaultTimeZone) {
+            localSendTouched.current = true;
             setLocalSendTimeZone(issue.localSend.defaultTimeZone);
           }
           setLocalSendMode(issue.localSend.mode === 'peak-hour' ? 'peak-hour' : 'timezone');
@@ -786,20 +807,22 @@ export const IssueFormPage: React.FC = () => {
                     id="localSendTimeZone"
                     value={localSendTimeZone}
                     onChange={(e) => {
+                      localSendTouched.current = true;
                       setLocalSendTimeZone(e.target.value);
                       setIsDirty(true);
                     }}
                     disabled={isFormDisabled}
                     className="w-full px-3 py-2 border border-border rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent disabled:opacity-50 disabled:cursor-not-allowed"
                   >
-                    {timezoneOptions.map((option) => (
+                    {localSendTimeZoneOptions.map((option) => (
                       <option key={option.value} value={option.value}>
                         {option.label}
                       </option>
                     ))}
                   </select>
                   <p className="mt-1 text-xs text-muted-foreground">
-                    The scheduled time is read as a wall-clock time in this timezone.
+                    The scheduled time is read as a wall-clock time in this timezone. Defaults to
+                    your newsletter&rsquo;s timezone.
                   </p>
                 </div>
               )}

--- a/dashboard-ui/src/pages/issues/IssuesListPage.tsx
+++ b/dashboard-ui/src/pages/issues/IssuesListPage.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/components/issues';
 import { issuesService } from '@/services/issuesService';
 import type { IssueListItem, IssueStatus, Issue } from '@/types/issues';
+import { useTenantDateFormat } from '@/contexts/SettingsContext';
 
 export const IssuesListPage: React.FC = () => {
   const navigate = useNavigate();
@@ -231,13 +232,9 @@ export const IssuesListPage: React.FC = () => {
     return filtered;
   }, [issues, sortField, sortDirection]);
 
-  const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString('en-US', {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric'
-    });
-  };
+  // Dates read in the newsletter's timezone (see SettingsPage), so the list
+  // agrees with the schedule that produced it.
+  const { formatDate } = useTenantDateFormat();
 
   const statusOptions = useMemo(() => [
     { value: 'all', label: 'All Issues' },

--- a/dashboard-ui/src/pages/issues/__tests__/IssueFormPage.test.tsx
+++ b/dashboard-ui/src/pages/issues/__tests__/IssueFormPage.test.tsx
@@ -25,6 +25,13 @@ let mockParams: Record<string, string> = {};
 vi.mock('react-router-dom', () => ({
   useNavigate: () => mockNavigate,
   useParams: () => mockParams,
+  // The schedule field links to Settings; render it as a plain anchor so these
+  // tests don't need a Router.
+  Link: ({ to, children, ...props }: { to: string; children: React.ReactNode }) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  ),
 }));
 
 const mockAddToast = vi.fn();

--- a/dashboard-ui/src/pages/issues/__tests__/IssueFormPage.test.tsx
+++ b/dashboard-ui/src/pages/issues/__tests__/IssueFormPage.test.tsx
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { IssueFormPage } from '../IssueFormPage';
 import { issuesService } from '@/services/issuesService';
 import { templateService } from '@/services/templateService';
+import { settingsService } from '@/services/settingsService';
+import { SettingsProvider } from '@/contexts/SettingsContext';
 
 vi.mock('@/services/issuesService', () => ({
   issuesService: {
@@ -37,6 +39,17 @@ vi.mock('react-router-dom', () => ({
 const mockAddToast = vi.fn();
 vi.mock('@/components/ui/Toast', () => ({
   useToast: () => ({ addToast: mockAddToast }),
+}));
+
+// Only the tenant-timezone block below renders a SettingsProvider; everywhere
+// else these mocks are inert and the form falls back to UTC as before.
+vi.mock('@/services/settingsService', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/services/settingsService')>()),
+  settingsService: { getSettings: vi.fn(), updateSettings: vi.fn() },
+}));
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({ isAuthenticated: true }),
 }));
 
 // MDXEditor (lexical) is too heavy for jsdom; replace the wrapper with a plain
@@ -482,5 +495,121 @@ describe('IssueFormPage personalized section order (contentAssembly)', () => {
     });
     const payload = vi.mocked(issuesService.updateIssue).mock.calls[0][1];
     expect('contentAssembly' in payload).toBe(false);
+  });
+});
+
+describe('IssueFormPage tenant timezone', () => {
+  const scheduledIssue = {
+    id: '5',
+    issueNumber: 5,
+    subject: 'Existing Issue',
+    content: '# Existing content',
+    status: 'draft' as const,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    // 09:00 in Chicago, 14:00 in UTC — the two render differently, so which
+    // zone the form used is visible in the field.
+    scheduledAt: '2026-08-01T14:00:00Z',
+  };
+
+  const chicagoSettings = {
+    success: true as const,
+    data: {
+      settings: { timezone: 'America/Chicago', defaultSendTime: '09:00' },
+      defaults: { timezone: 'UTC', defaultSendTime: '09:00' },
+      configured: ['timezone', 'defaultSendTime'],
+      updatedAt: '2026-07-25T00:00:00Z',
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockParams = { id: '5' };
+    vi.mocked(templateService.listTemplates).mockResolvedValue({
+      success: true,
+      data: { total: 0, templates: [] },
+    });
+    vi.mocked(issuesService.getIssue).mockResolvedValue({
+      success: true,
+      data: scheduledIssue as never,
+    });
+  });
+
+  const renderWithSettings = () =>
+    render(
+      <SettingsProvider>
+        <IssueFormPage />
+      </SettingsProvider>
+    );
+
+  it('fetches the issue once even though settings arrive afterwards', async () => {
+    // The timezone landing late changes the date formatter, which used to
+    // change `loadIssue` and re-run the load effect: a second GET that reset
+    // the form and could race the first response.
+    let releaseSettings: (value: unknown) => void = () => {};
+    vi.mocked(settingsService.getSettings).mockReturnValue(
+      new Promise((resolve) => {
+        releaseSettings = resolve;
+      }) as never
+    );
+
+    renderWithSettings();
+
+    const field = await screen.findByLabelText<HTMLInputElement>(/schedule publication/i);
+    await waitFor(() => expect(field.value).toBe('2026-08-01T14:00'));
+    expect(issuesService.getIssue).toHaveBeenCalledTimes(1);
+
+    releaseSettings(chicagoSettings);
+
+    await waitFor(() => expect(field.value).toBe('2026-08-01T09:00'));
+    expect(issuesService.getIssue).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-expresses a loaded schedule when the timezone resolves late', async () => {
+    let releaseSettings: (value: unknown) => void = () => {};
+    vi.mocked(settingsService.getSettings).mockReturnValue(
+      new Promise((resolve) => {
+        releaseSettings = resolve;
+      }) as never
+    );
+
+    renderWithSettings();
+
+    const field = await screen.findByLabelText<HTMLInputElement>(/schedule publication/i);
+    await waitFor(() => expect(field.value).toBe('2026-08-01T14:00'));
+
+    releaseSettings(chicagoSettings);
+
+    // Same instant, now shown as the newsletter's wall clock.
+    await waitFor(() => expect(field.value).toBe('2026-08-01T09:00'));
+  });
+
+  it('never overwrites an edit the author already made', async () => {
+    // Reprojection is a correction to an untouched form, not a licence to
+    // discard typing that happened while settings were in flight.
+    let releaseSettings: (value: unknown) => void = () => {};
+    vi.mocked(settingsService.getSettings).mockReturnValue(
+      new Promise((resolve) => {
+        releaseSettings = resolve;
+      }) as never
+    );
+
+    renderWithSettings();
+
+    const field = await screen.findByLabelText<HTMLInputElement>(/schedule publication/i);
+    await waitFor(() => expect(field.value).toBe('2026-08-01T14:00'));
+
+    fireEvent.change(field, { target: { value: '2026-09-15T07:45' } });
+    releaseSettings(chicagoSettings);
+
+    // The helper text under the field names the newsletter's zone, so it only
+    // says "America/Chicago" once settings have landed and re-rendered. Waiting
+    // on that is what makes this a real test rather than a race.
+    expect(await screen.findByText(/America\/Chicago/)).toBeInTheDocument();
+    // Flush anything the zone change queued — without this the assertion can
+    // run before a stray refetch lands and pass for the wrong reason.
+    await act(async () => {});
+
+    expect(field.value).toBe('2026-09-15T07:45');
   });
 });

--- a/dashboard-ui/src/pages/settings/SettingsPage.tsx
+++ b/dashboard-ui/src/pages/settings/SettingsPage.tsx
@@ -1,0 +1,295 @@
+import { useEffect, useMemo, useState } from 'react';
+import { ClockIcon, GlobeAltIcon } from '@heroicons/react/24/outline';
+import { Button } from '@/components/ui/Button';
+import { Card } from '@/components/ui/Card';
+import { ErrorDisplay } from '@/components/ui/ErrorDisplay';
+import { Input } from '@/components/ui/Input';
+import { Select } from '@/components/ui/Select';
+import { SkeletonLoader } from '@/components/ui/LoadingStates';
+import { useToast } from '@/components/ui/Toast';
+import { useSettings } from '@/contexts/SettingsContext';
+import {
+  SEND_TIME_PRESETS,
+  getTimezoneOptions,
+  tenantSettingsSchema,
+  type TenantSettingsFormData
+} from '@/schemas/settingsSchema';
+import { padSendTime } from '@/services/settingsService';
+import {
+  combineDateAndTimeInTimeZone,
+  formatDateTimeInTimeZone,
+  getBrowserTimeZone
+} from '@/utils/dateFormatting';
+
+/**
+ * Tenant-wide defaults. Everything here answers the same question: what should
+ * the platform do when a request doesn't say?
+ *
+ * The page deliberately shows a live preview of the resolved send instant —
+ * "a date-only send lands here" — because the whole point of these two
+ * settings is that they combine into a moment in time, and a timezone picker
+ * on its own gives no feedback about whether you picked the right one.
+ */
+export function SettingsPage() {
+  const { settings, defaults, updatedAt, isLoading, error, refresh, save } = useSettings();
+  const { addToast } = useToast();
+
+  const browserTimeZone = useMemo(() => getBrowserTimeZone(), []);
+
+  const [form, setForm] = useState<TenantSettingsFormData>(settings);
+  const [errors, setErrors] = useState<Partial<Record<keyof TenantSettingsFormData, string>>>({});
+  const [isSaving, setIsSaving] = useState(false);
+
+  // Adopt whatever the provider settles on (initial load, or a refresh).
+  useEffect(() => {
+    setForm(settings);
+    setErrors({});
+  }, [settings]);
+
+  /**
+   * A `<select>` whose value isn't among its options silently displays the
+   * first one instead — which would show the wrong zone and save it on the
+   * next submit. Whatever the tenant currently has is always offered, even if
+   * this browser doesn't enumerate it.
+   */
+  const timezoneOptions = useMemo(() => {
+    const options = getTimezoneOptions();
+    if (!form.timezone || options.some((option) => option.value === form.timezone)) {
+      return options;
+    }
+    return [{ value: form.timezone, label: form.timezone.replace(/_/g, ' ') }, ...options];
+  }, [form.timezone]);
+
+  const isDirty =
+    form.timezone !== settings.timezone || form.defaultSendTime !== settings.defaultSendTime;
+
+  const usingDefaultTimezone = settings.timezone === defaults.timezone && !updatedAt;
+  const usingDefaultSendTime = settings.defaultSendTime === defaults.defaultSendTime && !updatedAt;
+
+  /**
+   * Where a date-only send would land under the values currently in the form.
+   * Uses tomorrow's date so the example is always a real upcoming send rather
+   * than a time that has already passed today.
+   */
+  const preview = useMemo(() => {
+    const parsed = tenantSettingsSchema.safeParse(form);
+    if (!parsed.success) return null;
+
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    const date = tomorrow.toISOString().slice(0, 10);
+
+    const instant = combineDateAndTimeInTimeZone(
+      date,
+      padSendTime(form.defaultSendTime),
+      form.timezone
+    );
+    if (!instant) return null;
+
+    return {
+      date,
+      inTenantZone: formatDateTimeInTimeZone(instant, form.timezone),
+      inUtc: formatDateTimeInTimeZone(instant, 'UTC')
+    };
+  }, [form]);
+
+  const handleChange = <K extends keyof TenantSettingsFormData>(
+    field: K,
+    value: TenantSettingsFormData[K]
+  ) => {
+    setForm((prev) => ({ ...prev, [field]: value }));
+    setErrors((prev) => ({ ...prev, [field]: undefined }));
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+
+    const parsed = tenantSettingsSchema.safeParse(form);
+    if (!parsed.success) {
+      const fieldErrors: Partial<Record<keyof TenantSettingsFormData, string>> = {};
+      for (const issue of parsed.error.issues) {
+        const field = issue.path[0] as keyof TenantSettingsFormData;
+        fieldErrors[field] = fieldErrors[field] ?? issue.message;
+      }
+      setErrors(fieldErrors);
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      await save({
+        timezone: parsed.data.timezone,
+        defaultSendTime: padSendTime(parsed.data.defaultSendTime)
+      });
+      addToast({
+        type: 'success',
+        title: 'Settings saved',
+        message: 'New issues will use these defaults.'
+      });
+    } catch (err) {
+      addToast({
+        type: 'error',
+        title: 'Could not save settings',
+        message: err instanceof Error ? err.message : 'Please try again.'
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleReset = () => {
+    setForm(settings);
+    setErrors({});
+  };
+
+  if (isLoading && !updatedAt) {
+    return (
+      <div className="space-y-6">
+        <SkeletonLoader count={3} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl sm:text-3xl font-bold text-foreground">Settings</h1>
+        <p className="text-muted-foreground mt-2 text-sm sm:text-base">
+          Defaults the platform falls back to when an API request doesn&rsquo;t spell a value out.
+          Anything a request does specify always wins.
+        </p>
+      </div>
+
+      {error && (
+        <ErrorDisplay
+          title="Could not load settings"
+          message={error}
+          severity="error"
+          retryable
+          onRetry={() => {
+            void refresh();
+          }}
+        />
+      )}
+
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <Card className="p-6">
+          <div className="flex items-start gap-3 mb-6">
+            <GlobeAltIcon className="h-6 w-6 text-muted-foreground shrink-0 mt-0.5" aria-hidden="true" />
+            <div>
+              <h2 className="text-lg font-semibold text-foreground">Timezone</h2>
+              <p className="text-sm text-muted-foreground mt-1">
+                Dates and times across the dashboard are shown in this zone, and it&rsquo;s the zone a
+                send date is read against.
+              </p>
+            </div>
+          </div>
+
+          <Select
+            label="Newsletter timezone"
+            value={form.timezone}
+            onChange={(event) => handleChange('timezone', event.target.value)}
+            options={timezoneOptions}
+            error={errors.timezone}
+            disabled={isSaving}
+            helperText={
+              usingDefaultTimezone
+                ? `Currently using the system default (${defaults.timezone}).`
+                : undefined
+            }
+          />
+
+          {form.timezone !== browserTimeZone && (
+            <p className="text-sm text-muted-foreground mt-3">
+              Your browser is in {browserTimeZone}.{' '}
+              <button
+                type="button"
+                className="text-primary-600 hover:text-primary-700 underline"
+                onClick={() => handleChange('timezone', browserTimeZone)}
+                disabled={isSaving}
+              >
+                Use that instead
+              </button>
+            </p>
+          )}
+        </Card>
+
+        <Card className="p-6">
+          <div className="flex items-start gap-3 mb-6">
+            <ClockIcon className="h-6 w-6 text-muted-foreground shrink-0 mt-0.5" aria-hidden="true" />
+            <div>
+              <h2 className="text-lg font-semibold text-foreground">Default send time</h2>
+              <p className="text-sm text-muted-foreground mt-1">
+                When a request schedules an issue with a date but no time &mdash; a bare{' '}
+                <code className="text-xs">2026-08-01</code> &mdash; the send lands at this time of
+                day in your newsletter timezone.
+              </p>
+            </div>
+          </div>
+
+          <div className="max-w-xs">
+            <Input
+              label="Time of day"
+              type="time"
+              value={form.defaultSendTime}
+              onChange={(event) => handleChange('defaultSendTime', event.target.value)}
+              error={errors.defaultSendTime}
+              disabled={isSaving}
+              helperText={
+                usingDefaultSendTime
+                  ? `Currently using the system default (${defaults.defaultSendTime}).`
+                  : undefined
+              }
+            />
+          </div>
+
+          <div className="flex flex-wrap gap-2 mt-4">
+            {SEND_TIME_PRESETS.map((preset) => (
+              <button
+                key={preset.value}
+                type="button"
+                onClick={() => handleChange('defaultSendTime', preset.value)}
+                disabled={isSaving}
+                aria-pressed={padSendTime(form.defaultSendTime) === preset.value}
+                className={
+                  padSendTime(form.defaultSendTime) === preset.value
+                    ? 'px-3 py-1 text-sm rounded-full border border-primary-500 bg-primary-50 text-primary-700'
+                    : 'px-3 py-1 text-sm rounded-full border border-border text-muted-foreground hover:bg-surface'
+                }
+              >
+                {preset.label}
+              </button>
+            ))}
+          </div>
+
+          {preview && (
+            <div className="mt-6 rounded-lg border border-border bg-surface p-4">
+              <p className="text-sm font-medium text-foreground">
+                An issue scheduled for <code className="text-xs">{preview.date}</code> would send at
+              </p>
+              <p className="text-sm text-muted-foreground mt-1">{preview.inTenantZone}</p>
+              <p className="text-xs text-muted-foreground mt-0.5">{preview.inUtc}</p>
+            </div>
+          )}
+        </Card>
+
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <p className="text-sm text-muted-foreground">
+            {updatedAt
+              ? `Last saved ${formatDateTimeInTimeZone(updatedAt, settings.timezone)}`
+              : 'These settings have never been saved — everything is on system defaults.'}
+          </p>
+
+          <div className="flex gap-3">
+            <Button type="button" variant="secondary" onClick={handleReset} disabled={!isDirty || isSaving}>
+              Discard changes
+            </Button>
+            <Button type="submit" disabled={!isDirty || isSaving} isLoading={isSaving}>
+              {isSaving ? 'Saving...' : 'Save settings'}
+            </Button>
+          </div>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/dashboard-ui/src/pages/settings/SettingsPage.tsx
+++ b/dashboard-ui/src/pages/settings/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { ClockIcon, GlobeAltIcon } from '@heroicons/react/24/outline';
+import { ClockIcon, EnvelopeIcon, GlobeAltIcon, LinkIcon } from '@heroicons/react/24/outline';
 import { Button } from '@/components/ui/Button';
 import { Card } from '@/components/ui/Card';
 import { ErrorDisplay } from '@/components/ui/ErrorDisplay';
@@ -10,6 +10,9 @@ import { useToast } from '@/components/ui/Toast';
 import { useSettings } from '@/contexts/SettingsContext';
 import {
   SEND_TIME_PRESETS,
+  SUBJECT_TOKENS,
+  URL_TOKENS,
+  findUnknownToken,
   getTimezoneOptions,
   tenantSettingsSchema,
   type TenantSettingsFormData
@@ -18,8 +21,10 @@ import { padSendTime } from '@/services/settingsService';
 import {
   combineDateAndTimeInTimeZone,
   formatDateTimeInTimeZone,
+  formatLongDateInTimeZone,
   getBrowserTimeZone
 } from '@/utils/dateFormatting';
+import { renderTokens } from '@/utils/renderTokens';
 
 /**
  * Tenant-wide defaults. Everything here answers the same question: what should
@@ -36,13 +41,27 @@ export function SettingsPage() {
 
   const browserTimeZone = useMemo(() => getBrowserTimeZone(), []);
 
-  const [form, setForm] = useState<TenantSettingsFormData>(settings);
+  // The optional templates are absent when unset; the form works in empty
+  // strings and converts back on save.
+  const toForm = (value: typeof settings): TenantSettingsFormData => ({
+    timezone: value.timezone,
+    defaultSendTime: value.defaultSendTime,
+    subjectTemplate: value.subjectTemplate ?? '',
+    issueUrlPattern: value.issueUrlPattern ?? ''
+  });
+
+  const [form, setForm] = useState<TenantSettingsFormData>(() => toForm(settings));
   const [errors, setErrors] = useState<Partial<Record<keyof TenantSettingsFormData, string>>>({});
   const [isSaving, setIsSaving] = useState(false);
 
   // Adopt whatever the provider settles on (initial load, or a refresh).
   useEffect(() => {
-    setForm(settings);
+    setForm({
+      timezone: settings.timezone,
+      defaultSendTime: settings.defaultSendTime,
+      subjectTemplate: settings.subjectTemplate ?? '',
+      issueUrlPattern: settings.issueUrlPattern ?? ''
+    });
     setErrors({});
   }, [settings]);
 
@@ -61,7 +80,10 @@ export function SettingsPage() {
   }, [form.timezone]);
 
   const isDirty =
-    form.timezone !== settings.timezone || form.defaultSendTime !== settings.defaultSendTime;
+    form.timezone !== settings.timezone ||
+    form.defaultSendTime !== settings.defaultSendTime ||
+    form.subjectTemplate !== (settings.subjectTemplate ?? '') ||
+    form.issueUrlPattern !== (settings.issueUrlPattern ?? '');
 
   const usingDefaultTimezone = settings.timezone === defaults.timezone && !updatedAt;
   const usingDefaultSendTime = settings.defaultSendTime === defaults.defaultSendTime && !updatedAt;
@@ -93,6 +115,26 @@ export function SettingsPage() {
     };
   }, [form]);
 
+  /**
+   * Sample renderings, so the effect of a placeholder is visible before an
+   * issue goes out with it. Sample values are obviously fake on purpose.
+   */
+  const subjectPreview = useMemo(() => {
+    const template = form.subjectTemplate.trim();
+    if (!template || findUnknownToken(template, SUBJECT_TOKENS)) return null;
+    return renderTokens(template, {
+      title: 'Serverless Patterns That Scale',
+      number: 128,
+      date: formatLongDateInTimeZone(new Date(), form.timezone)
+    });
+  }, [form.subjectTemplate, form.timezone]);
+
+  const urlPreview = useMemo(() => {
+    const pattern = form.issueUrlPattern.trim();
+    if (!pattern || findUnknownToken(pattern, URL_TOKENS)) return null;
+    return renderTokens(pattern, { number: 128 });
+  }, [form.issueUrlPattern]);
+
   const handleChange = <K extends keyof TenantSettingsFormData>(
     field: K,
     value: TenantSettingsFormData[K]
@@ -119,7 +161,10 @@ export function SettingsPage() {
     try {
       await save({
         timezone: parsed.data.timezone,
-        defaultSendTime: padSendTime(parsed.data.defaultSendTime)
+        defaultSendTime: padSendTime(parsed.data.defaultSendTime),
+        // Empty means "clear this"; the service turns it into an explicit null.
+        subjectTemplate: parsed.data.subjectTemplate,
+        issueUrlPattern: parsed.data.issueUrlPattern
       });
       addToast({
         type: 'success',
@@ -138,7 +183,7 @@ export function SettingsPage() {
   };
 
   const handleReset = () => {
-    setForm(settings);
+    setForm(toForm(settings));
     setErrors({});
   };
 
@@ -269,6 +314,67 @@ export function SettingsPage() {
               </p>
               <p className="text-sm text-muted-foreground mt-1">{preview.inTenantZone}</p>
               <p className="text-xs text-muted-foreground mt-0.5">{preview.inUtc}</p>
+            </div>
+          )}
+        </Card>
+
+        <Card className="p-6">
+          <div className="flex items-start gap-3 mb-6">
+            <EnvelopeIcon className="h-6 w-6 text-muted-foreground shrink-0 mt-0.5" aria-hidden="true" />
+            <div>
+              <h2 className="text-lg font-semibold text-foreground">Subject line format</h2>
+              <p className="text-sm text-muted-foreground mt-1">
+                Used when the request that stages an issue doesn&rsquo;t supply a subject &mdash;
+                which is every issue imported from GitHub. A subject sent with the request always
+                wins. Leave empty to use the issue title on its own.
+              </p>
+            </div>
+          </div>
+
+          <Input
+            label="Format"
+            value={form.subjectTemplate}
+            onChange={(event) => handleChange('subjectTemplate', event.target.value)}
+            error={errors.subjectTemplate}
+            disabled={isSaving}
+            placeholder="{{title}} | Picks of the Week #{{number}}"
+            helperText={`Available placeholders: ${SUBJECT_TOKENS.map((t) => `{{${t}}}`).join(', ')}`}
+          />
+
+          {subjectPreview && (
+            <div className="mt-4 rounded-lg border border-border bg-surface p-4">
+              <p className="text-xs text-muted-foreground">A subject would look like</p>
+              <p className="text-sm font-medium text-foreground mt-1">{subjectPreview}</p>
+            </div>
+          )}
+        </Card>
+
+        <Card className="p-6">
+          <div className="flex items-start gap-3 mb-6">
+            <LinkIcon className="h-6 w-6 text-muted-foreground shrink-0 mt-0.5" aria-hidden="true" />
+            <div>
+              <h2 className="text-lg font-semibold text-foreground">Issue URL</h2>
+              <p className="text-sm text-muted-foreground mt-1">
+                Where issues live on your own site. It becomes the &ldquo;view online&rdquo; link in
+                the email. Leave empty and the link is left out entirely.
+              </p>
+            </div>
+          </div>
+
+          <Input
+            label="URL pattern"
+            value={form.issueUrlPattern}
+            onChange={(event) => handleChange('issueUrlPattern', event.target.value)}
+            error={errors.issueUrlPattern}
+            disabled={isSaving}
+            placeholder="https://example.com/newsletter/{{number}}"
+            helperText="Must include {{number}} so each issue links to its own page."
+          />
+
+          {urlPreview && (
+            <div className="mt-4 rounded-lg border border-border bg-surface p-4">
+              <p className="text-xs text-muted-foreground">Issue 128 would link to</p>
+              <p className="text-sm font-medium text-foreground mt-1 break-all">{urlPreview}</p>
             </div>
           )}
         </Card>

--- a/dashboard-ui/src/pages/settings/SettingsPage.tsx
+++ b/dashboard-ui/src/pages/settings/SettingsPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { ClockIcon, EnvelopeIcon, GlobeAltIcon, LinkIcon } from '@heroicons/react/24/outline';
 import { Button } from '@/components/ui/Button';
+import { cn } from '@/utils/cn';
 import { Card } from '@/components/ui/Card';
 import { ErrorDisplay } from '@/components/ui/ErrorDisplay';
 import { Input } from '@/components/ui/Input';
@@ -36,7 +37,8 @@ import { renderTokens } from '@/utils/renderTokens';
  * on its own gives no feedback about whether you picked the right one.
  */
 export function SettingsPage() {
-  const { settings, defaults, updatedAt, isLoading, error, refresh, save } = useSettings();
+  const { settings, configured, isTimeZoneInferred, defaults, updatedAt, isLoading, error, refresh, save } =
+    useSettings();
   const { addToast } = useToast();
 
   const browserTimeZone = useMemo(() => getBrowserTimeZone(), []);
@@ -54,15 +56,16 @@ export function SettingsPage() {
   const [errors, setErrors] = useState<Partial<Record<keyof TenantSettingsFormData, string>>>({});
   const [isSaving, setIsSaving] = useState(false);
 
-  // Adopt whatever the provider settles on (initial load, or a refresh).
+  // Adopt whatever the provider settles on (initial load, or a refresh). The
+  // provider already substitutes the browser zone when the tenant has never
+  // picked one, so an unconfigured newsletter opens on a sensible suggestion
+  // that one Save turns into a real setting.
   useEffect(() => {
-    setForm({
-      timezone: settings.timezone,
-      defaultSendTime: settings.defaultSendTime,
-      subjectTemplate: settings.subjectTemplate ?? '',
-      issueUrlPattern: settings.issueUrlPattern ?? ''
-    });
+    setForm(toForm(settings));
     setErrors({});
+    // toForm is a pure projection of `settings`; re-running on its identity
+    // would loop.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [settings]);
 
   /**
@@ -80,13 +83,15 @@ export function SettingsPage() {
   }, [form.timezone]);
 
   const isDirty =
+    // A zone inferred from the browser has never been saved, so the form is
+    // meaningfully ahead of the stored settings from the first render.
+    isTimeZoneInferred ||
     form.timezone !== settings.timezone ||
     form.defaultSendTime !== settings.defaultSendTime ||
     form.subjectTemplate !== (settings.subjectTemplate ?? '') ||
     form.issueUrlPattern !== (settings.issueUrlPattern ?? '');
 
-  const usingDefaultTimezone = settings.timezone === defaults.timezone && !updatedAt;
-  const usingDefaultSendTime = settings.defaultSendTime === defaults.defaultSendTime && !updatedAt;
+  const usingDefaultSendTime = !configured.includes('defaultSendTime');
 
   /**
    * Where a date-only send would land under the values currently in the form.
@@ -196,7 +201,7 @@ export function SettingsPage() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-4 sm:space-y-6">
       <div>
         <h1 className="text-2xl sm:text-3xl font-bold text-foreground">Settings</h1>
         <p className="text-muted-foreground mt-2 text-sm sm:text-base">
@@ -217,9 +222,9 @@ export function SettingsPage() {
         />
       )}
 
-      <form onSubmit={handleSubmit} className="space-y-6">
-        <Card className="p-6">
-          <div className="flex items-start gap-3 mb-6">
+      <form onSubmit={handleSubmit} className="space-y-4 sm:space-y-6">
+        <Card className="p-4 sm:p-6">
+          <div className="flex items-start gap-3 mb-4 sm:mb-6">
             <GlobeAltIcon className="h-6 w-6 text-muted-foreground shrink-0 mt-0.5" aria-hidden="true" />
             <div>
               <h2 className="text-lg font-semibold text-foreground">Timezone</h2>
@@ -238,8 +243,8 @@ export function SettingsPage() {
             error={errors.timezone}
             disabled={isSaving}
             helperText={
-              usingDefaultTimezone
-                ? `Currently using the system default (${defaults.timezone}).`
+              isTimeZoneInferred
+                ? `Detected from your browser. Save to use it for scheduling too — until then, dates without a time send at ${defaults.defaultSendTime} ${defaults.timezone}.`
                 : undefined
             }
           />
@@ -249,7 +254,7 @@ export function SettingsPage() {
               Your browser is in {browserTimeZone}.{' '}
               <button
                 type="button"
-                className="text-primary-600 hover:text-primary-700 underline"
+                className="text-primary-600 hover:text-primary-700 underline min-h-[44px] sm:min-h-0 inline-flex items-center"
                 onClick={() => handleChange('timezone', browserTimeZone)}
                 disabled={isSaving}
               >
@@ -259,8 +264,8 @@ export function SettingsPage() {
           )}
         </Card>
 
-        <Card className="p-6">
-          <div className="flex items-start gap-3 mb-6">
+        <Card className="p-4 sm:p-6">
+          <div className="flex items-start gap-3 mb-4 sm:mb-6">
             <ClockIcon className="h-6 w-6 text-muted-foreground shrink-0 mt-0.5" aria-hidden="true" />
             <div>
               <h2 className="text-lg font-semibold text-foreground">Default send time</h2>
@@ -272,7 +277,7 @@ export function SettingsPage() {
             </div>
           </div>
 
-          <div className="max-w-xs">
+          <div className="w-full sm:max-w-xs">
             <Input
               label="Time of day"
               type="time"
@@ -296,11 +301,13 @@ export function SettingsPage() {
                 onClick={() => handleChange('defaultSendTime', preset.value)}
                 disabled={isSaving}
                 aria-pressed={padSendTime(form.defaultSendTime) === preset.value}
-                className={
+                className={cn(
+                  // 44px minimum so the chips are comfortably tappable.
+                  'min-h-[44px] px-4 text-sm rounded-full border transition-colors',
                   padSendTime(form.defaultSendTime) === preset.value
-                    ? 'px-3 py-1 text-sm rounded-full border border-primary-500 bg-primary-50 text-primary-700'
-                    : 'px-3 py-1 text-sm rounded-full border border-border text-muted-foreground hover:bg-surface'
-                }
+                    ? 'border-primary-500 bg-primary-50 text-primary-700'
+                    : 'border-border text-muted-foreground hover:bg-surface'
+                )}
               >
                 {preset.label}
               </button>
@@ -318,8 +325,8 @@ export function SettingsPage() {
           )}
         </Card>
 
-        <Card className="p-6">
-          <div className="flex items-start gap-3 mb-6">
+        <Card className="p-4 sm:p-6">
+          <div className="flex items-start gap-3 mb-4 sm:mb-6">
             <EnvelopeIcon className="h-6 w-6 text-muted-foreground shrink-0 mt-0.5" aria-hidden="true" />
             <div>
               <h2 className="text-lg font-semibold text-foreground">Subject line format</h2>
@@ -339,18 +346,20 @@ export function SettingsPage() {
             disabled={isSaving}
             placeholder="{{title}} | Picks of the Week #{{number}}"
             helperText={`Available placeholders: ${SUBJECT_TOKENS.map((t) => `{{${t}}}`).join(', ')}`}
+            autoCorrect="off"
+            spellCheck={false}
           />
 
           {subjectPreview && (
             <div className="mt-4 rounded-lg border border-border bg-surface p-4">
               <p className="text-xs text-muted-foreground">A subject would look like</p>
-              <p className="text-sm font-medium text-foreground mt-1">{subjectPreview}</p>
+              <p className="text-sm font-medium text-foreground mt-1 break-words">{subjectPreview}</p>
             </div>
           )}
         </Card>
 
-        <Card className="p-6">
-          <div className="flex items-start gap-3 mb-6">
+        <Card className="p-4 sm:p-6">
+          <div className="flex items-start gap-3 mb-4 sm:mb-6">
             <LinkIcon className="h-6 w-6 text-muted-foreground shrink-0 mt-0.5" aria-hidden="true" />
             <div>
               <h2 className="text-lg font-semibold text-foreground">Issue URL</h2>
@@ -369,6 +378,11 @@ export function SettingsPage() {
             disabled={isSaving}
             placeholder="https://example.com/newsletter/{{number}}"
             helperText="Must include {{number}} so each issue links to its own page."
+            // A phone keyboard would otherwise capitalize and autocorrect a URL.
+            inputMode="url"
+            autoCapitalize="none"
+            autoCorrect="off"
+            spellCheck={false}
           />
 
           {urlPreview && (
@@ -379,18 +393,31 @@ export function SettingsPage() {
           )}
         </Card>
 
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <p className="text-sm text-muted-foreground">
+        <div className="flex flex-col sm:flex-row sm:flex-wrap sm:items-center sm:justify-between gap-3">
+          <p className="text-sm text-muted-foreground order-2 sm:order-1">
             {updatedAt
               ? `Last saved ${formatDateTimeInTimeZone(updatedAt, settings.timezone)}`
               : 'These settings have never been saved — everything is on system defaults.'}
           </p>
 
-          <div className="flex gap-3">
-            <Button type="button" variant="secondary" onClick={handleReset} disabled={!isDirty || isSaving}>
+          {/* Stacked and full-width on a phone, with the primary action on top
+              so it sits under the thumb rather than below a secondary button. */}
+          <div className="flex flex-col-reverse sm:flex-row gap-3 order-1 sm:order-2">
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={handleReset}
+              disabled={!isDirty || isSaving}
+              className="w-full sm:w-auto"
+            >
               Discard changes
             </Button>
-            <Button type="submit" disabled={!isDirty || isSaving} isLoading={isSaving}>
+            <Button
+              type="submit"
+              disabled={!isDirty || isSaving}
+              isLoading={isSaving}
+              className="w-full sm:w-auto"
+            >
               {isSaving ? 'Saving...' : 'Save settings'}
             </Button>
           </div>

--- a/dashboard-ui/src/pages/settings/__tests__/SettingsPage.test.tsx
+++ b/dashboard-ui/src/pages/settings/__tests__/SettingsPage.test.tsx
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { SettingsPage } from '../SettingsPage';
+import { SettingsProvider } from '@/contexts/SettingsContext';
+import { settingsService } from '@/services/settingsService';
+
+vi.mock('@/services/settingsService', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/services/settingsService')>();
+  return {
+    ...actual,
+    settingsService: {
+      getSettings: vi.fn(),
+      updateSettings: vi.fn(),
+    },
+  };
+});
+
+const mockAddToast = vi.fn();
+vi.mock('@/components/ui/Toast', () => ({
+  useToast: () => ({ addToast: mockAddToast }),
+}));
+
+// The provider only fetches for a signed-in user.
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({ isAuthenticated: true }),
+}));
+
+const mockedService = vi.mocked(settingsService);
+
+const DEFAULTS = { timezone: 'UTC', defaultSendTime: '09:00' };
+
+function settingsResponse(
+  settings: { timezone: string; defaultSendTime: string },
+  updatedAt?: string
+) {
+  return {
+    success: true as const,
+    data: { settings, defaults: DEFAULTS, ...(updatedAt ? { updatedAt } : {}) },
+  };
+}
+
+function renderPage() {
+  return render(
+    <SettingsProvider>
+      <SettingsPage />
+    </SettingsProvider>
+  );
+}
+
+describe('SettingsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedService.getSettings.mockResolvedValue(
+      settingsResponse({ timezone: 'America/Chicago', defaultSendTime: '09:00' }, '2026-07-25T00:00:00Z')
+    );
+  });
+
+  it('shows the tenant’s saved timezone and send time', async () => {
+    renderPage();
+
+    const timezone = await screen.findByLabelText<HTMLSelectElement>('Newsletter timezone');
+    await waitFor(() => expect(timezone.value).toBe('America/Chicago'));
+
+    const sendTime = screen.getByLabelText<HTMLInputElement>('Time of day');
+    expect(sendTime.value).toBe('09:00');
+  });
+
+  it('says when a value is only inherited from the system default', async () => {
+    mockedService.getSettings.mockResolvedValue(settingsResponse(DEFAULTS));
+
+    renderPage();
+
+    expect(
+      await screen.findByText(/These settings have never been saved/i)
+    ).toBeInTheDocument();
+  });
+
+  it('previews where a date-only send would land in both zones', async () => {
+    renderPage();
+
+    // 09:00 Chicago, shown alongside the same instant in UTC so the effect of
+    // the zone choice is visible.
+    await waitFor(() => {
+      expect(screen.getByText(/9:00 AM (CDT|CST)/)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/would send at/i)).toBeInTheDocument();
+  });
+
+  it('saves both settings and reports success', async () => {
+    mockedService.updateSettings.mockResolvedValue(
+      settingsResponse({ timezone: 'Europe/London', defaultSendTime: '07:30' }, '2026-07-26T00:00:00Z')
+    );
+
+    renderPage();
+
+    const timezone = await screen.findByLabelText<HTMLSelectElement>('Newsletter timezone');
+    await waitFor(() => expect(timezone.value).toBe('America/Chicago'));
+
+    fireEvent.change(timezone, { target: { value: 'Europe/London' } });
+    fireEvent.change(screen.getByLabelText('Time of day'), { target: { value: '07:30' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /save settings/i }));
+
+    await waitFor(() => {
+      expect(mockedService.updateSettings).toHaveBeenCalledWith({
+        timezone: 'Europe/London',
+        defaultSendTime: '07:30',
+      });
+    });
+    expect(mockAddToast).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'success' })
+    );
+  });
+
+  it('keeps save disabled until something actually changes', async () => {
+    renderPage();
+
+    const timezone = await screen.findByLabelText<HTMLSelectElement>('Newsletter timezone');
+    await waitFor(() => expect(timezone.value).toBe('America/Chicago'));
+
+    const save = screen.getByRole('button', { name: /save settings/i });
+    expect(save).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText('Time of day'), { target: { value: '10:00' } });
+    expect(save).toBeEnabled();
+  });
+
+  it('applies a send-time preset', async () => {
+    renderPage();
+
+    const sendTime = await screen.findByLabelText<HTMLInputElement>('Time of day');
+    await waitFor(() => expect(sendTime.value).toBe('09:00'));
+
+    fireEvent.click(screen.getByRole('button', { name: '6:00 AM' }));
+
+    expect(screen.getByLabelText<HTMLInputElement>('Time of day').value).toBe('06:00');
+  });
+
+  it('discards edits back to what is saved', async () => {
+    renderPage();
+
+    const sendTime = await screen.findByLabelText<HTMLInputElement>('Time of day');
+    await waitFor(() => expect(sendTime.value).toBe('09:00'));
+
+    fireEvent.change(sendTime, { target: { value: '11:11' } });
+    expect(sendTime.value).toBe('11:11');
+
+    fireEvent.click(screen.getByRole('button', { name: /discard changes/i }));
+    expect(screen.getByLabelText<HTMLInputElement>('Time of day').value).toBe('09:00');
+  });
+
+  it('surfaces a save failure without losing the edit', async () => {
+    mockedService.updateSettings.mockResolvedValue({
+      success: false,
+      error: 'Tenant access required',
+    });
+
+    renderPage();
+
+    const sendTime = await screen.findByLabelText<HTMLInputElement>('Time of day');
+    await waitFor(() => expect(sendTime.value).toBe('09:00'));
+
+    fireEvent.change(sendTime, { target: { value: '10:00' } });
+    fireEvent.click(screen.getByRole('button', { name: /save settings/i }));
+
+    await waitFor(() => {
+      expect(mockAddToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+    });
+    expect(screen.getByLabelText<HTMLInputElement>('Time of day').value).toBe('10:00');
+  });
+
+  it('reports a failed load with a retry', async () => {
+    mockedService.getSettings.mockResolvedValue({
+      success: false,
+      error: 'Network error',
+    });
+
+    renderPage();
+
+    expect(await screen.findByText(/Could not load settings/i)).toBeInTheDocument();
+  });
+});

--- a/dashboard-ui/src/pages/settings/__tests__/SettingsPage.test.tsx
+++ b/dashboard-ui/src/pages/settings/__tests__/SettingsPage.test.tsx
@@ -4,6 +4,17 @@ import { SettingsPage } from '../SettingsPage';
 import { SettingsProvider } from '@/contexts/SettingsContext';
 import { settingsService } from '@/services/settingsService';
 
+/**
+ * CI runs in UTC, which is also the server-side default for an unset zone — so
+ * a real browser zone is stubbed in, otherwise the substitution tests below
+ * would pass without proving anything.
+ */
+const BROWSER_TIME_ZONE = 'America/Chicago';
+vi.mock('@/utils/dateFormatting', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/utils/dateFormatting')>()),
+  getBrowserTimeZone: () => BROWSER_TIME_ZONE,
+}));
+
 vi.mock('@/services/settingsService', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/services/settingsService')>();
   return {
@@ -36,10 +47,19 @@ type Settings = {
   issueUrlPattern?: string;
 };
 
-function settingsResponse(settings: Settings, updatedAt?: string) {
+/**
+ * Mirrors the backend: `configured` lists the settings actually present on the
+ * record, which is what tells the UI a value was chosen rather than inherited.
+ */
+function settingsResponse(settings: Settings, updatedAt?: string, configured?: string[]) {
   return {
     success: true as const,
-    data: { settings, defaults: DEFAULTS, ...(updatedAt ? { updatedAt } : {}) },
+    data: {
+      settings,
+      defaults: DEFAULTS,
+      configured: configured ?? (Object.keys(settings) as string[]),
+      ...(updatedAt ? { updatedAt } : {}),
+    },
   };
 }
 
@@ -70,7 +90,7 @@ describe('SettingsPage', () => {
   });
 
   it('says when a value is only inherited from the system default', async () => {
-    mockedService.getSettings.mockResolvedValue(settingsResponse(DEFAULTS));
+    mockedService.getSettings.mockResolvedValue(settingsResponse(DEFAULTS, undefined, []));
 
     renderPage();
 
@@ -229,7 +249,10 @@ describe('SettingsPage', () => {
         )
       );
       mockedService.updateSettings.mockResolvedValue(
-        settingsResponse({ timezone: 'America/Chicago', defaultSendTime: '09:00' })
+        settingsResponse({ timezone: 'America/Chicago', defaultSendTime: '09:00' }, undefined, [
+          'timezone',
+          'defaultSendTime',
+        ])
       );
 
       renderPage();
@@ -274,6 +297,116 @@ describe('SettingsPage', () => {
       expect(await screen.findByText(/Include \{\{number\}\}/)).toBeInTheDocument();
 
       expect(mockedService.updateSettings).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('unconfigured timezone', () => {
+    const unconfigured = () =>
+      mockedService.getSettings.mockResolvedValue(
+        settingsResponse({ timezone: 'UTC', defaultSendTime: '09:00' }, undefined, [])
+      );
+
+    it("suggests the browser's timezone instead of the server default", async () => {
+      // The server can't know where anyone is, so an unset zone comes back as
+      // UTC. The browser does know, and one Save turns the guess into a real
+      // setting.
+      unconfigured();
+
+      renderPage();
+
+      const timezone = await screen.findByLabelText<HTMLSelectElement>('Newsletter timezone');
+      await waitFor(() => expect(timezone.value).toBe(BROWSER_TIME_ZONE));
+    });
+
+    it('says the zone was detected rather than chosen', async () => {
+      unconfigured();
+
+      renderPage();
+
+      expect(await screen.findByText(/Detected from your browser/i)).toBeInTheDocument();
+    });
+
+    it('saves the detected zone as the tenant choice', async () => {
+      unconfigured();
+      mockedService.updateSettings.mockResolvedValue(
+        settingsResponse({ timezone: BROWSER_TIME_ZONE, defaultSendTime: '09:00' })
+      );
+
+      renderPage();
+
+      const timezone = await screen.findByLabelText<HTMLSelectElement>('Newsletter timezone');
+      await waitFor(() => expect(timezone.value).toBe(BROWSER_TIME_ZONE));
+
+      fireEvent.click(screen.getByRole('button', { name: /save settings/i }));
+
+      await waitFor(() => {
+        expect(mockedService.updateSettings).toHaveBeenCalledWith(
+          expect.objectContaining({ timezone: BROWSER_TIME_ZONE })
+        );
+      });
+    });
+
+    it('offers to save the suggestion without further edits', async () => {
+      // The form is meaningfully ahead of what's stored, so Save is live.
+      unconfigured();
+
+      renderPage();
+
+      await screen.findByLabelText('Newsletter timezone');
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: /save settings/i })).toBeEnabled()
+      );
+    });
+
+    it('leaves a zone the tenant did choose alone', async () => {
+      mockedService.getSettings.mockResolvedValue(
+        settingsResponse({ timezone: 'UTC', defaultSendTime: '09:00' }, '2026-07-25T00:00:00Z', [
+          'timezone',
+        ])
+      );
+
+      renderPage();
+
+      // An explicit UTC is a choice, not an absent value to override.
+      const timezone = await screen.findByLabelText<HTMLSelectElement>('Newsletter timezone');
+      await waitFor(() => expect(timezone.value).toBe('UTC'));
+      expect(screen.queryByText(/Detected from your browser/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('mobile layout', () => {
+    it('gives the send-time presets a 44px touch target', async () => {
+      renderPage();
+
+      const preset = await screen.findByRole('button', { name: '6:00 AM' });
+      expect(preset.className).toContain('min-h-[44px]');
+    });
+
+    it('stacks the actions full-width on small screens only', async () => {
+      renderPage();
+
+      const save = await screen.findByRole('button', { name: /save settings/i });
+      const discard = screen.getByRole('button', { name: /discard changes/i });
+
+      for (const button of [save, discard]) {
+        expect(button.className).toContain('w-full');
+        expect(button.className).toContain('sm:w-auto');
+      }
+
+      // Reversed column order puts the primary action above the secondary one
+      // on a phone, where the thumb reaches the bottom of the screen first.
+      expect(save.parentElement?.className).toContain('flex-col-reverse');
+      expect(save.parentElement?.className).toContain('sm:flex-row');
+    });
+
+    it('tightens card padding below the sm breakpoint', async () => {
+      renderPage();
+
+      const heading = await screen.findByRole('heading', { name: 'Timezone' });
+      const card = heading.closest('div.p-4');
+
+      expect(card).not.toBeNull();
+      expect(card!.className).toContain('sm:p-6');
     });
   });
 });

--- a/dashboard-ui/src/pages/settings/__tests__/SettingsPage.test.tsx
+++ b/dashboard-ui/src/pages/settings/__tests__/SettingsPage.test.tsx
@@ -29,10 +29,14 @@ const mockedService = vi.mocked(settingsService);
 
 const DEFAULTS = { timezone: 'UTC', defaultSendTime: '09:00' };
 
-function settingsResponse(
-  settings: { timezone: string; defaultSendTime: string },
-  updatedAt?: string
-) {
+type Settings = {
+  timezone: string;
+  defaultSendTime: string;
+  subjectTemplate?: string;
+  issueUrlPattern?: string;
+};
+
+function settingsResponse(settings: Settings, updatedAt?: string) {
   return {
     success: true as const,
     data: { settings, defaults: DEFAULTS, ...(updatedAt ? { updatedAt } : {}) },
@@ -105,6 +109,8 @@ describe('SettingsPage', () => {
       expect(mockedService.updateSettings).toHaveBeenCalledWith({
         timezone: 'Europe/London',
         defaultSendTime: '07:30',
+        subjectTemplate: '',
+        issueUrlPattern: '',
       });
     });
     expect(mockAddToast).toHaveBeenCalledWith(
@@ -178,5 +184,96 @@ describe('SettingsPage', () => {
     renderPage();
 
     expect(await screen.findByText(/Could not load settings/i)).toBeInTheDocument();
+  });
+
+  describe('subject line format', () => {
+    it('shows the saved template and previews a rendered subject', async () => {
+      mockedService.getSettings.mockResolvedValue(
+        settingsResponse(
+          {
+            timezone: 'America/Chicago',
+            defaultSendTime: '09:00',
+            subjectTemplate: '{{title}} | Weekly #{{number}}',
+          },
+          '2026-07-25T00:00:00Z'
+        )
+      );
+
+      renderPage();
+
+      const field = await screen.findByLabelText<HTMLInputElement>('Format');
+      await waitFor(() => expect(field.value).toBe('{{title}} | Weekly #{{number}}'));
+      expect(screen.getByText(/Serverless Patterns That Scale \| Weekly #128/)).toBeInTheDocument();
+    });
+
+    it('rejects an unsupported placeholder before saving', async () => {
+      renderPage();
+
+      const field = await screen.findByLabelText<HTMLInputElement>('Format');
+      fireEvent.change(field, { target: { value: '{{title}} from {{brand}}' } });
+      fireEvent.click(screen.getByRole('button', { name: /save settings/i }));
+
+      expect(await screen.findByText(/\{\{brand\}\} isn't available/)).toBeInTheDocument();
+      expect(mockedService.updateSettings).not.toHaveBeenCalled();
+    });
+
+    it('sends an empty template to clear it', async () => {
+      mockedService.getSettings.mockResolvedValue(
+        settingsResponse(
+          {
+            timezone: 'America/Chicago',
+            defaultSendTime: '09:00',
+            subjectTemplate: '{{title}}',
+          },
+          '2026-07-25T00:00:00Z'
+        )
+      );
+      mockedService.updateSettings.mockResolvedValue(
+        settingsResponse({ timezone: 'America/Chicago', defaultSendTime: '09:00' })
+      );
+
+      renderPage();
+
+      const field = await screen.findByLabelText<HTMLInputElement>('Format');
+      await waitFor(() => expect(field.value).toBe('{{title}}'));
+
+      fireEvent.change(field, { target: { value: '' } });
+      fireEvent.click(screen.getByRole('button', { name: /save settings/i }));
+
+      await waitFor(() => {
+        expect(mockedService.updateSettings).toHaveBeenCalledWith(
+          expect.objectContaining({ subjectTemplate: '' })
+        );
+      });
+    });
+  });
+
+  describe('issue URL', () => {
+    it('previews the URL a specific issue would get', async () => {
+      renderPage();
+
+      const field = await screen.findByLabelText<HTMLInputElement>('URL pattern');
+      fireEvent.change(field, {
+        target: { value: 'https://example.com/newsletter/{{number}}' },
+      });
+
+      expect(await screen.findByText('https://example.com/newsletter/128')).toBeInTheDocument();
+    });
+
+    it('requires an absolute URL containing the issue number', async () => {
+      renderPage();
+
+      const field = await screen.findByLabelText<HTMLInputElement>('URL pattern');
+
+      fireEvent.change(field, { target: { value: '/newsletter/{{number}}' } });
+      fireEvent.click(screen.getByRole('button', { name: /save settings/i }));
+      expect(await screen.findByText(/full URL starting with https/i)).toBeInTheDocument();
+
+      fireEvent.change(field, { target: { value: 'https://example.com/newsletter' } });
+      fireEvent.click(screen.getByRole('button', { name: /save settings/i }));
+      expect(await screen.findByText(/Include \{\{number\}\}/)).toBeInTheDocument();
+
+      expect(mockedService.updateSettings).not.toHaveBeenCalled();
+    });
   });
 });

--- a/dashboard-ui/src/pages/settings/index.ts
+++ b/dashboard-ui/src/pages/settings/index.ts
@@ -1,0 +1,1 @@
+export { SettingsPage } from './SettingsPage';

--- a/dashboard-ui/src/schemas/settingsSchema.ts
+++ b/dashboard-ui/src/schemas/settingsSchema.ts
@@ -7,6 +7,25 @@ import { timezoneOptions } from './profileSchema';
  */
 export const SEND_TIME_PATTERN = /^([01]?[0-9]|2[0-3]):[0-5][0-9]$/;
 
+/**
+ * Placeholders each template understands. Mirrors the backend's token
+ * validation so a typo is caught in the form rather than coming back as a 400.
+ */
+export const SUBJECT_TOKENS = ['title', 'number', 'date'] as const;
+export const URL_TOKENS = ['number'] as const;
+
+const TOKEN_PATTERN = /\{\{\s*([a-zA-Z][a-zA-Z0-9_]*)\s*\}\}/g;
+
+/** Returns the first placeholder in `value` that isn't in `allowed`. */
+export function findUnknownToken(value: string, allowed: readonly string[]): string | null {
+  for (const match of value.matchAll(TOKEN_PATTERN)) {
+    if (!allowed.includes(match[1])) {
+      return match[1];
+    }
+  }
+  return null;
+}
+
 export const tenantSettingsSchema = z.object({
   timezone: z
     .string()
@@ -14,7 +33,42 @@ export const tenantSettingsSchema = z.object({
   defaultSendTime: z
     .string()
     .min(1, 'Enter a default send time')
-    .regex(SEND_TIME_PATTERN, 'Enter a 24-hour time, like 09:00')
+    .regex(SEND_TIME_PATTERN, 'Enter a 24-hour time, like 09:00'),
+  // Both templates are optional: an empty field clears the setting rather than
+  // saving a blank one.
+  subjectTemplate: z
+    .string()
+    .max(300, 'Keep the subject format under 300 characters')
+    .refine((value) => !/[\r\n]/.test(value), 'Subject formats cannot contain line breaks')
+    .superRefine((value, ctx) => {
+      const unknown = findUnknownToken(value, SUBJECT_TOKENS);
+      if (unknown) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `{{${unknown}}} isn't available — use ${SUBJECT_TOKENS.map((t) => `{{${t}}}`).join(', ')}`
+        });
+      }
+    }),
+  issueUrlPattern: z
+    .string()
+    .max(500, 'Keep the URL under 500 characters')
+    .refine(
+      (value) => value === '' || /^https?:\/\//.test(value),
+      'Enter a full URL starting with https://'
+    )
+    .refine(
+      (value) => value === '' || value.includes('{{number}}'),
+      'Include {{number}} so each issue links to its own page'
+    )
+    .superRefine((value, ctx) => {
+      const unknown = findUnknownToken(value, URL_TOKENS);
+      if (unknown) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `{{${unknown}}} isn't available here — only {{number}}`
+        });
+      }
+    })
 });
 
 export type TenantSettingsFormData = z.infer<typeof tenantSettingsSchema>;

--- a/dashboard-ui/src/schemas/settingsSchema.ts
+++ b/dashboard-ui/src/schemas/settingsSchema.ts
@@ -1,0 +1,59 @@
+import { z } from 'zod';
+import { timezoneOptions } from './profileSchema';
+
+/**
+ * Mirrors the backend's `HH:MM` validation so a bad value is caught in the
+ * form rather than coming back as a 400.
+ */
+export const SEND_TIME_PATTERN = /^([01]?[0-9]|2[0-3]):[0-5][0-9]$/;
+
+export const tenantSettingsSchema = z.object({
+  timezone: z
+    .string()
+    .min(1, 'Select a timezone'),
+  defaultSendTime: z
+    .string()
+    .min(1, 'Enter a default send time')
+    .regex(SEND_TIME_PATTERN, 'Enter a 24-hour time, like 09:00')
+});
+
+export type TenantSettingsFormData = z.infer<typeof tenantSettingsSchema>;
+
+/**
+ * The full IANA zone list when the browser can enumerate it (Chrome 99+,
+ * Safari 15.4+, Firefox 93+), falling back to the curated shortlist the
+ * profile form already uses. A newsletter's zone is a one-time choice, so
+ * offering every zone beats making someone settle for the nearest listed one.
+ */
+export function getTimezoneOptions(): Array<{ value: string; label: string }> {
+  const supported = (
+    Intl as typeof Intl & { supportedValuesOf?: (key: string) => string[] }
+  ).supportedValuesOf;
+
+  if (typeof supported !== 'function') {
+    return timezoneOptions;
+  }
+
+  try {
+    const zones = supported.call(Intl, 'timeZone');
+    if (!Array.isArray(zones) || zones.length === 0) {
+      return timezoneOptions;
+    }
+    return zones.map((zone) => ({ value: zone, label: zone.replace(/_/g, ' ') }));
+  } catch {
+    return timezoneOptions;
+  }
+}
+
+/**
+ * Common newsletter send times, offered as quick picks alongside the free-form
+ * time input.
+ */
+export const SEND_TIME_PRESETS = [
+  { value: '06:00', label: '6:00 AM' },
+  { value: '08:00', label: '8:00 AM' },
+  { value: '09:00', label: '9:00 AM' },
+  { value: '10:00', label: '10:00 AM' },
+  { value: '12:00', label: '12:00 PM' },
+  { value: '17:00', label: '5:00 PM' }
+];

--- a/dashboard-ui/src/services/__tests__/settingsService.test.ts
+++ b/dashboard-ui/src/services/__tests__/settingsService.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { settingsService, padSendTime, isValidTimeZone } from '../settingsService';
+import { apiClient } from '../api';
+
+vi.mock('../api', () => ({
+  apiClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+const mockedClient = vi.mocked(apiClient);
+
+const successResponse = {
+  success: true as const,
+  data: {
+    settings: { timezone: 'America/Chicago', defaultSendTime: '09:00' },
+    defaults: { timezone: 'UTC', defaultSendTime: '09:00' },
+    updatedAt: '2026-07-25T00:00:00Z',
+  },
+};
+
+describe('SettingsService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getSettings', () => {
+    it('reads from /settings', async () => {
+      mockedClient.get.mockResolvedValue(successResponse);
+
+      const result = await settingsService.getSettings();
+
+      expect(mockedClient.get).toHaveBeenCalledWith('/settings');
+      expect(result).toEqual(successResponse);
+    });
+  });
+
+  describe('updateSettings', () => {
+    it('sends only the settings that were provided', async () => {
+      mockedClient.put.mockResolvedValue(successResponse);
+
+      await settingsService.updateSettings({ timezone: 'Europe/London' });
+
+      expect(mockedClient.put).toHaveBeenCalledWith('/settings', { timezone: 'Europe/London' });
+    });
+
+    it('normalizes the send time to the canonical zero-padded form', async () => {
+      mockedClient.put.mockResolvedValue(successResponse);
+
+      await settingsService.updateSettings({ defaultSendTime: ' 9:05 ' });
+
+      expect(mockedClient.put).toHaveBeenCalledWith('/settings', { defaultSendTime: '09:05' });
+    });
+
+    it('turns an empty value into an explicit null so the backend resets it', async () => {
+      mockedClient.put.mockResolvedValue(successResponse);
+
+      await settingsService.updateSettings({ timezone: '' });
+
+      expect(mockedClient.put).toHaveBeenCalledWith('/settings', { timezone: null });
+    });
+
+    it('passes an explicit null through as a reset', async () => {
+      mockedClient.put.mockResolvedValue(successResponse);
+
+      await settingsService.updateSettings({ defaultSendTime: null });
+
+      expect(mockedClient.put).toHaveBeenCalledWith('/settings', { defaultSendTime: null });
+    });
+
+    it('rejects an unknown timezone without calling the API', async () => {
+      const result = await settingsService.updateSettings({ timezone: 'Not/AZone' });
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('VALIDATION_ERROR');
+      expect(mockedClient.put).not.toHaveBeenCalled();
+    });
+
+    it('rejects a malformed send time without calling the API', async () => {
+      for (const bad of ['9am', '25:00', '09:60', 'noon']) {
+        const result = await settingsService.updateSettings({ defaultSendTime: bad });
+        expect(result.success, `${bad} should be rejected`).toBe(false);
+      }
+      expect(mockedClient.put).not.toHaveBeenCalled();
+    });
+
+    it('rejects an empty update rather than sending a no-op request', async () => {
+      const result = await settingsService.updateSettings({});
+
+      expect(result.success).toBe(false);
+      expect(mockedClient.put).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('padSendTime', () => {
+    it('zero-pads the hour', () => {
+      expect(padSendTime('9:05')).toBe('09:05');
+      expect(padSendTime('09:05')).toBe('09:05');
+      expect(padSendTime('23:59')).toBe('23:59');
+    });
+
+    it('leaves anything unrecognized alone for the API to reject', () => {
+      expect(padSendTime('9am')).toBe('9am');
+      expect(padSendTime('')).toBe('');
+    });
+  });
+
+  describe('isValidTimeZone', () => {
+    it('accepts IANA names and rejects everything else', () => {
+      expect(isValidTimeZone('America/Chicago')).toBe(true);
+      expect(isValidTimeZone('UTC')).toBe(true);
+      expect(isValidTimeZone('Not/AZone')).toBe(false);
+      expect(isValidTimeZone('CST')).toBe(false);
+    });
+  });
+});

--- a/dashboard-ui/src/services/__tests__/settingsService.test.ts
+++ b/dashboard-ui/src/services/__tests__/settingsService.test.ts
@@ -95,6 +95,62 @@ describe('SettingsService', () => {
     });
   });
 
+  describe('template validation', () => {
+    it('rejects a subject template with a line break', async () => {
+      // A newline in a subject line is a second email header.
+      const result = await settingsService.updateSettings({
+        subjectTemplate: 'Hi\r\nBcc: someone@example.com',
+      });
+
+      expect(result.success).toBe(false);
+      expect(mockedClient.put).not.toHaveBeenCalled();
+    });
+
+    it('rejects an unsupported subject placeholder', async () => {
+      const result = await settingsService.updateSettings({
+        subjectTemplate: '{{title}} from {{brand}}',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('{{brand}}');
+      expect(mockedClient.put).not.toHaveBeenCalled();
+    });
+
+    it('accepts the supported subject placeholders', async () => {
+      mockedClient.put.mockResolvedValue(successResponse);
+
+      await settingsService.updateSettings({ subjectTemplate: '{{title}} #{{number}} {{date}}' });
+
+      expect(mockedClient.put).toHaveBeenCalledWith('/settings', {
+        subjectTemplate: '{{title}} #{{number}} {{date}}',
+      });
+    });
+
+    it('requires the issue URL to be absolute and per-issue', async () => {
+      for (const bad of [
+        '/newsletter/{{number}}',
+        'example.com/{{number}}',
+        'https://example.com/newsletter',
+        'https://example.com/{{slug}}/{{number}}',
+      ]) {
+        const result = await settingsService.updateSettings({ issueUrlPattern: bad });
+        expect(result.success, `${bad} should be rejected`).toBe(false);
+      }
+      expect(mockedClient.put).not.toHaveBeenCalled();
+    });
+
+    it('sends an emptied template as an explicit null', async () => {
+      mockedClient.put.mockResolvedValue(successResponse);
+
+      await settingsService.updateSettings({ subjectTemplate: '  ', issueUrlPattern: '' });
+
+      expect(mockedClient.put).toHaveBeenCalledWith('/settings', {
+        subjectTemplate: null,
+        issueUrlPattern: null,
+      });
+    });
+  });
+
   describe('padSendTime', () => {
     it('zero-pads the hour', () => {
       expect(padSendTime('9:05')).toBe('09:05');

--- a/dashboard-ui/src/services/index.ts
+++ b/dashboard-ui/src/services/index.ts
@@ -1,6 +1,7 @@
 // Services export
 export * from './api';
 export * from './profileService';
+export * from './settingsService';
 export * from './apiKeyService';
 export * from './dashboardService';
 export * from './billingService';

--- a/dashboard-ui/src/services/settingsService.ts
+++ b/dashboard-ui/src/services/settingsService.ts
@@ -1,0 +1,122 @@
+import { apiClient } from './api';
+import { SEND_TIME_PATTERN } from '@/schemas/settingsSchema';
+import type { ApiResponse } from '@/types/api';
+import type { SettingsResponse, UpdateSettingsRequest } from '@/types/settings';
+
+/**
+ * Settings Service — the tenant-wide defaults used when a request doesn't
+ * specify a value (see `/settings` in `openapi.yaml`).
+ */
+export class SettingsService {
+  /**
+   * Load the tenant's effective settings along with the system defaults they
+   * fall back to.
+   */
+  async getSettings(): Promise<ApiResponse<SettingsResponse>> {
+    return apiClient.get<SettingsResponse>('/settings');
+  }
+
+  /**
+   * Update one or more settings. Omitted keys are left unchanged; a key sent
+   * as `null` resets that setting to the system default.
+   */
+  async updateSettings(data: UpdateSettingsRequest): Promise<ApiResponse<SettingsResponse>> {
+    const validationError = this.validateSettings(data);
+    if (validationError) {
+      return { success: false, error: validationError, errorCode: 'VALIDATION_ERROR' };
+    }
+
+    if (Object.keys(data).length === 0) {
+      return {
+        success: false,
+        error: 'At least one setting must be provided',
+        errorCode: 'VALIDATION_ERROR'
+      };
+    }
+
+    return apiClient.put<SettingsResponse>('/settings', this.normalize(data));
+  }
+
+  /**
+   * Validate the settings that are present. Returns an error message or null.
+   * `null` values are resets and are always valid.
+   */
+  validateSettings(data: UpdateSettingsRequest): string | null {
+    if (typeof data.timezone === 'string' && data.timezone.trim()) {
+      if (!isValidTimeZone(data.timezone.trim())) {
+        return `"${data.timezone}" is not a recognized timezone`;
+      }
+    }
+
+    if (typeof data.defaultSendTime === 'string' && data.defaultSendTime.trim()) {
+      if (!SEND_TIME_PATTERN.test(data.defaultSendTime.trim())) {
+        return 'Default send time must be a 24-hour time, like 09:00';
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Trim strings and zero-pad the send time so what we send matches the
+   * canonical form the backend stores.
+   */
+  private normalize(data: UpdateSettingsRequest): UpdateSettingsRequest {
+    const normalized: UpdateSettingsRequest = {};
+
+    if ('timezone' in data) {
+      const value = typeof data.timezone === 'string' ? data.timezone.trim() : data.timezone;
+      normalized.timezone = value ? value : null;
+    }
+
+    if ('defaultSendTime' in data) {
+      const value =
+        typeof data.defaultSendTime === 'string' ? data.defaultSendTime.trim() : data.defaultSendTime;
+      normalized.defaultSendTime = value ? padSendTime(value) : null;
+    }
+
+    return normalized;
+  }
+}
+
+/** `9:05` → `09:05`. Leaves anything unrecognized alone for the API to reject. */
+export function padSendTime(value: string): string {
+  const match = /^(\d{1,2}):(\d{2})$/.exec(value);
+  if (!match) return value;
+  return `${match[1].padStart(2, '0')}:${match[2]}`;
+}
+
+/**
+ * Whether the backend will accept this zone.
+ *
+ * `Intl` alone is too lenient: it takes legacy aliases like `CST` that the
+ * backend's IANA database rejects. When the browser can enumerate zones, the
+ * name must be one of the canonical ones; otherwise we fall back to asking
+ * `Intl` whether it can construct a formatter at all.
+ */
+export function isValidTimeZone(timeZone: string): boolean {
+  const supported = (
+    Intl as typeof Intl & { supportedValuesOf?: (key: string) => string[] }
+  ).supportedValuesOf;
+
+  if (typeof supported === 'function') {
+    try {
+      const zones = supported.call(Intl, 'timeZone');
+      if (Array.isArray(zones) && zones.length > 0) {
+        // UTC is universally valid but is not always in the enumerated list.
+        return timeZone === 'UTC' || zones.includes(timeZone);
+      }
+    } catch {
+      // Fall through to the permissive check below.
+    }
+  }
+
+  try {
+    new Intl.DateTimeFormat(undefined, { timeZone });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export const settingsService = new SettingsService();

--- a/dashboard-ui/src/services/settingsService.ts
+++ b/dashboard-ui/src/services/settingsService.ts
@@ -1,5 +1,10 @@
 import { apiClient } from './api';
-import { SEND_TIME_PATTERN } from '@/schemas/settingsSchema';
+import {
+  SEND_TIME_PATTERN,
+  SUBJECT_TOKENS,
+  URL_TOKENS,
+  findUnknownToken
+} from '@/schemas/settingsSchema';
 import type { ApiResponse } from '@/types/api';
 import type { SettingsResponse, UpdateSettingsRequest } from '@/types/settings';
 
@@ -54,6 +59,33 @@ export class SettingsService {
       }
     }
 
+    if (typeof data.subjectTemplate === 'string' && data.subjectTemplate.trim()) {
+      const template = data.subjectTemplate.trim();
+      // A newline in a subject line is an extra email header, so this one is a
+      // hard rule rather than a nicety (the backend rejects it too).
+      if (/[\r\n]/.test(template)) {
+        return 'Subject format cannot contain line breaks';
+      }
+      const unknown = findUnknownToken(template, SUBJECT_TOKENS);
+      if (unknown) {
+        return `Subject format uses {{${unknown}}}, which isn't available`;
+      }
+    }
+
+    if (typeof data.issueUrlPattern === 'string' && data.issueUrlPattern.trim()) {
+      const pattern = data.issueUrlPattern.trim();
+      if (!/^https?:\/\//.test(pattern)) {
+        return 'Issue URL must start with https://';
+      }
+      if (!pattern.includes('{{number}}')) {
+        return 'Issue URL must include {{number}}';
+      }
+      const unknown = findUnknownToken(pattern, URL_TOKENS);
+      if (unknown) {
+        return `Issue URL uses {{${unknown}}}, which isn't available`;
+      }
+    }
+
     return null;
   }
 
@@ -73,6 +105,14 @@ export class SettingsService {
       const value =
         typeof data.defaultSendTime === 'string' ? data.defaultSendTime.trim() : data.defaultSendTime;
       normalized.defaultSendTime = value ? padSendTime(value) : null;
+    }
+
+    // An emptied field is a reset, not a blank value to store.
+    for (const key of ['subjectTemplate', 'issueUrlPattern'] as const) {
+      if (key in data) {
+        const value = typeof data[key] === 'string' ? data[key]!.trim() : data[key];
+        normalized[key] = value ? value : null;
+      }
     }
 
     return normalized;

--- a/dashboard-ui/src/types/index.ts
+++ b/dashboard-ui/src/types/index.ts
@@ -4,6 +4,7 @@ export * from './app';
 export * from './billing';
 export * from './pricing';
 export * from './report';
+export * from './settings';
 export * from './subscribers';
 
 // Export issues types with explicit names to avoid conflicts

--- a/dashboard-ui/src/types/settings.ts
+++ b/dashboard-ui/src/types/settings.ts
@@ -7,6 +7,17 @@ export interface TenantSettings {
   timezone: string;
   /** 24-hour `HH:MM` time of day, expressed in {@link timezone}. */
   defaultSendTime: string;
+  /**
+   * Subject format used when the request that staged an issue didn't supply
+   * one. Supports `{{title}}`, `{{number}}` and `{{date}}`. Absent means the
+   * issue title is used — there is no system default.
+   */
+  subjectTemplate?: string;
+  /**
+   * Absolute URL where issues live on the tenant's site, containing
+   * `{{number}}`. Absent means the "view online" link is omitted.
+   */
+  issueUrlPattern?: string;
 }
 
 export interface SettingsResponse {

--- a/dashboard-ui/src/types/settings.ts
+++ b/dashboard-ui/src/types/settings.ts
@@ -20,11 +20,20 @@ export interface TenantSettings {
   issueUrlPattern?: string;
 }
 
+/** The settings a tenant can explicitly configure. */
+export type SettingName = keyof TenantSettings;
+
 export interface SettingsResponse {
   /** Effective settings: stored values where set, system defaults elsewhere. */
   settings: TenantSettings;
   /** The system defaults, so the UI can mark inherited values as such. */
   defaults: TenantSettings;
+  /**
+   * Which settings the tenant has explicitly chosen. `settings` alone can't
+   * say — a stored `UTC` and an unset timezone are indistinguishable — so this
+   * is what tells the UI it's free to suggest something better.
+   */
+  configured: SettingName[];
   /** When settings were last saved; absent if they never have been. */
   updatedAt?: string;
 }

--- a/dashboard-ui/src/types/settings.ts
+++ b/dashboard-ui/src/types/settings.ts
@@ -1,0 +1,27 @@
+/**
+ * Tenant-wide defaults the platform falls back to when a request doesn't
+ * specify a value. Mirrors the `/settings` contract in `openapi.yaml`.
+ */
+export interface TenantSettings {
+  /** IANA timezone name, e.g. `America/Chicago`. */
+  timezone: string;
+  /** 24-hour `HH:MM` time of day, expressed in {@link timezone}. */
+  defaultSendTime: string;
+}
+
+export interface SettingsResponse {
+  /** Effective settings: stored values where set, system defaults elsewhere. */
+  settings: TenantSettings;
+  /** The system defaults, so the UI can mark inherited values as such. */
+  defaults: TenantSettings;
+  /** When settings were last saved; absent if they never have been. */
+  updatedAt?: string;
+}
+
+/**
+ * A partial update. An omitted key is left unchanged; a key sent as `null`
+ * resets that setting to the system default.
+ */
+export type UpdateSettingsRequest = Partial<{
+  [K in keyof TenantSettings]: TenantSettings[K] | null;
+}>;

--- a/dashboard-ui/src/utils/__tests__/dateFormatting.test.ts
+++ b/dashboard-ui/src/utils/__tests__/dateFormatting.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+import {
+  combineDateAndTimeInTimeZone,
+  formatDateInTimeZone,
+  formatDateTimeInTimeZone,
+  formatTimeInTimeZone,
+  fromDatetimeLocalInTimeZone,
+  getTimeZoneAbbreviation,
+  toDatetimeLocalInTimeZone
+} from '../dateFormatting';
+
+describe('dateFormatting', () => {
+  describe('formatting', () => {
+    it('renders an instant as wall-clock time in the given zone', () => {
+      // 14:00Z is 9am in Chicago during daylight saving.
+      const instant = '2026-08-01T14:00:00Z';
+
+      expect(formatDateInTimeZone(instant, 'America/Chicago')).toBe('Aug 1, 2026');
+      expect(formatTimeInTimeZone(instant, 'America/Chicago')).toBe('9:00 AM');
+      expect(formatDateTimeInTimeZone(instant, 'America/Chicago')).toContain('9:00 AM');
+    });
+
+    it('shows a different day when the zone puts the instant on one', () => {
+      // 23:00 Chicago on Jul 31 is already Aug 1 in UTC.
+      const instant = '2026-08-01T04:00:00Z';
+
+      expect(formatDateInTimeZone(instant, 'UTC')).toBe('Aug 1, 2026');
+      expect(formatDateInTimeZone(instant, 'America/Chicago')).toBe('Jul 31, 2026');
+    });
+
+    it('labels the zone on a date-time so the reader knows whose clock it is', () => {
+      expect(formatDateTimeInTimeZone('2026-08-01T14:00:00Z', 'America/Chicago')).toContain('CDT');
+      expect(formatDateTimeInTimeZone('2026-01-15T15:00:00Z', 'America/Chicago')).toContain('CST');
+    });
+
+    it('formats empty and unparseable values as an empty string', () => {
+      for (const bad of ['', '   not a date', null, undefined]) {
+        expect(formatDateInTimeZone(bad, 'UTC')).toBe('');
+        expect(formatDateTimeInTimeZone(bad, 'UTC')).toBe('');
+        expect(formatTimeInTimeZone(bad, 'UTC')).toBe('');
+      }
+    });
+
+    it('falls back to the browser zone rather than throwing on a bad zone', () => {
+      expect(formatDateInTimeZone('2026-08-01T14:00:00Z', 'Not/AZone')).not.toBe('');
+    });
+
+    it('reports the zone abbreviation in effect at the given instant', () => {
+      expect(getTimeZoneAbbreviation('America/Chicago', '2026-08-01T14:00:00Z')).toBe('CDT');
+      expect(getTimeZoneAbbreviation('America/Chicago', '2026-01-15T15:00:00Z')).toBe('CST');
+    });
+  });
+
+  describe('datetime-local conversion', () => {
+    it('renders an instant as the zone wall clock a date input expects', () => {
+      expect(toDatetimeLocalInTimeZone('2026-08-01T14:00:00Z', 'America/Chicago')).toBe(
+        '2026-08-01T09:00'
+      );
+      expect(toDatetimeLocalInTimeZone('2026-08-01T14:00:00Z', 'UTC')).toBe('2026-08-01T14:00');
+      expect(toDatetimeLocalInTimeZone('2026-08-01T14:00:00Z', 'Asia/Tokyo')).toBe(
+        '2026-08-01T23:00'
+      );
+    });
+
+    it('reads a wall-clock string back as the instant it names', () => {
+      expect(fromDatetimeLocalInTimeZone('2026-08-01T09:00', 'America/Chicago')).toBe(
+        '2026-08-01T14:00:00.000Z'
+      );
+      expect(fromDatetimeLocalInTimeZone('2026-08-01T09:00', 'UTC')).toBe(
+        '2026-08-01T09:00:00.000Z'
+      );
+    });
+
+    it('round-trips through both directions', () => {
+      const instant = '2026-11-14T23:30:00.000Z';
+      for (const zone of ['UTC', 'America/Chicago', 'Asia/Tokyo', 'Australia/Sydney']) {
+        const local = toDatetimeLocalInTimeZone(instant, zone);
+        expect(fromDatetimeLocalInTimeZone(local, zone)).toBe(instant);
+      }
+    });
+
+    it('uses the offset in effect on the date, not today\'s offset', () => {
+      // The same wall-clock time is UTC-5 in summer and UTC-6 in winter. A
+      // single fixed offset would put one of these an hour off.
+      expect(fromDatetimeLocalInTimeZone('2026-07-01T09:00', 'America/Chicago')).toBe(
+        '2026-07-01T14:00:00.000Z'
+      );
+      expect(fromDatetimeLocalInTimeZone('2026-01-01T09:00', 'America/Chicago')).toBe(
+        '2026-01-01T15:00:00.000Z'
+      );
+    });
+
+    it('resolves a wall-clock time an hour after the spring-forward gap correctly', () => {
+      // US spring forward 2026 is March 8. 03:30 local exists and is CDT.
+      expect(fromDatetimeLocalInTimeZone('2026-03-08T03:30', 'America/Chicago')).toBe(
+        '2026-03-08T08:30:00.000Z'
+      );
+    });
+
+    it('returns an empty string for empty input', () => {
+      expect(toDatetimeLocalInTimeZone('', 'UTC')).toBe('');
+      expect(fromDatetimeLocalInTimeZone('', 'UTC')).toBe('');
+      expect(fromDatetimeLocalInTimeZone('not-a-date', 'UTC')).toBe('');
+    });
+  });
+
+  describe('combineDateAndTimeInTimeZone', () => {
+    it('mirrors how the API resolves a date-only send', () => {
+      // The browser-side equivalent of settings.rs `resolve_date_only`.
+      expect(combineDateAndTimeInTimeZone('2026-08-01', '09:00', 'America/Chicago')).toBe(
+        '2026-08-01T14:00:00.000Z'
+      );
+      expect(combineDateAndTimeInTimeZone('2026-01-15', '09:00', 'America/Chicago')).toBe(
+        '2026-01-15T15:00:00.000Z'
+      );
+      expect(combineDateAndTimeInTimeZone('2026-08-01', '09:00', 'UTC')).toBe(
+        '2026-08-01T09:00:00.000Z'
+      );
+    });
+
+    it('returns an empty string when either half is missing', () => {
+      expect(combineDateAndTimeInTimeZone('', '09:00', 'UTC')).toBe('');
+      expect(combineDateAndTimeInTimeZone('2026-08-01', '', 'UTC')).toBe('');
+    });
+  });
+});

--- a/dashboard-ui/src/utils/__tests__/dateFormatting.test.ts
+++ b/dashboard-ui/src/utils/__tests__/dateFormatting.test.ts
@@ -97,6 +97,45 @@ describe('dateFormatting', () => {
       );
     });
 
+    it('resolves a time inside the spring-forward gap forward, never backward', () => {
+      // 02:00–02:59 never happens on 2026-03-08 in Chicago. Naively applying
+      // offsets lands on 01:30 CST — an hour EARLIER than asked for, which
+      // would send an issue before its scheduled time. The first minute that
+      // exists is 03:00 CDT.
+      const resolved = fromDatetimeLocalInTimeZone('2026-03-08T02:30', 'America/Chicago');
+
+      expect(resolved).toBe('2026-03-08T08:00:00.000Z');
+      expect(new Date(resolved).getTime()).toBeGreaterThan(
+        new Date('2026-03-08T07:30:00.000Z').getTime()
+      );
+    });
+
+    it('matches the API for every minute of a spring-forward gap', () => {
+      // The dashboard and settings.rs must agree on what a gap time means, or
+      // the preview would disagree with the send.
+      for (const minute of ['02:00', '02:01', '02:30', '02:59']) {
+        expect(
+          fromDatetimeLocalInTimeZone(`2026-03-08T${minute}`, 'America/Chicago'),
+          `${minute} should resolve to the first valid minute`
+        ).toBe('2026-03-08T08:00:00.000Z');
+      }
+    });
+
+    it('resolves a gap time in a zone with a half-hour offset', () => {
+      // Lord Howe springs forward by 30 minutes, so the gap is 02:00–02:29.
+      const resolved = fromDatetimeLocalInTimeZone('2026-10-04T02:15', 'Australia/Lord_Howe');
+
+      expect(resolved).toBe('2026-10-03T15:30:00.000Z');
+    });
+
+    it('keeps the earlier instant for an ambiguous fall-back hour', () => {
+      // 01:30 happens twice on 2026-11-01; the earlier one (CDT) is closest to
+      // the requested wall clock, matching the Rust resolver.
+      expect(fromDatetimeLocalInTimeZone('2026-11-01T01:30', 'America/Chicago')).toBe(
+        '2026-11-01T06:30:00.000Z'
+      );
+    });
+
     it('returns an empty string for empty input', () => {
       expect(toDatetimeLocalInTimeZone('', 'UTC')).toBe('');
       expect(fromDatetimeLocalInTimeZone('', 'UTC')).toBe('');

--- a/dashboard-ui/src/utils/dateFormatting.ts
+++ b/dashboard-ui/src/utils/dateFormatting.ts
@@ -1,0 +1,233 @@
+/**
+ * Timezone-aware date formatting.
+ *
+ * Everything the API returns is an instant (RFC3339, almost always UTC). What
+ * a person wants to see is that instant as wall-clock time in *their*
+ * newsletter's timezone — the same zone the backend anchors date-only sends
+ * to. These helpers take that zone explicitly; components normally reach them
+ * through `useTenantDateFormat()`, which supplies the tenant's configured zone
+ * from settings.
+ *
+ * Every formatter is defensive about bad input: an empty, missing, or
+ * unparseable value formats as an empty string rather than "Invalid Date", and
+ * an unusable timezone falls back to the viewer's browser zone instead of
+ * throwing.
+ */
+
+/** Rendered in place of a date that can't be parsed. */
+const EMPTY = '';
+
+/** The `YYYY-MM-DDTHH:mm` shape an `<input type="datetime-local">` produces. */
+const DATETIME_LOCAL_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/;
+
+export type DateInput = string | number | Date | null | undefined;
+
+function toDate(value: DateInput): Date | null {
+  if (value === null || value === undefined || value === '') {
+    return null;
+  }
+
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+/**
+ * `Intl` throws on an unknown timezone, and a bad stored value shouldn't take
+ * a page down. Falling back to `undefined` lets `Intl` use the browser zone.
+ */
+function safeFormatter(
+  timeZone: string | undefined,
+  options: Intl.DateTimeFormatOptions,
+  locale?: string
+): Intl.DateTimeFormat {
+  try {
+    return new Intl.DateTimeFormat(locale, { ...options, timeZone });
+  } catch {
+    return new Intl.DateTimeFormat(locale, options);
+  }
+}
+
+/**
+ * Formats an instant as wall-clock time in `timeZone`. The escape hatch for
+ * anything the named helpers below don't cover.
+ */
+export function formatInTimeZone(
+  value: DateInput,
+  timeZone: string | undefined,
+  options: Intl.DateTimeFormatOptions,
+  locale?: string
+): string {
+  const date = toDate(value);
+  if (!date) return EMPTY;
+
+  return safeFormatter(timeZone, options, locale).format(date);
+}
+
+/** `Aug 1, 2026` */
+export function formatDateInTimeZone(value: DateInput, timeZone?: string, locale?: string): string {
+  return formatInTimeZone(
+    value,
+    timeZone,
+    { year: 'numeric', month: 'short', day: 'numeric' },
+    locale
+  );
+}
+
+/** `August 1, 2026` */
+export function formatLongDateInTimeZone(
+  value: DateInput,
+  timeZone?: string,
+  locale?: string
+): string {
+  return formatInTimeZone(
+    value,
+    timeZone,
+    { year: 'numeric', month: 'long', day: 'numeric' },
+    locale
+  );
+}
+
+/** `9:00 AM` */
+export function formatTimeInTimeZone(value: DateInput, timeZone?: string, locale?: string): string {
+  return formatInTimeZone(value, timeZone, { hour: 'numeric', minute: '2-digit' }, locale);
+}
+
+/**
+ * `Aug 1, 2026, 9:00 AM CDT` — the zone abbreviation matters here because the
+ * time shown is deliberately *not* the viewer's own clock.
+ */
+export function formatDateTimeInTimeZone(
+  value: DateInput,
+  timeZone?: string,
+  locale?: string
+): string {
+  return formatInTimeZone(
+    value,
+    timeZone,
+    {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+      timeZoneName: 'short',
+    },
+    locale
+  );
+}
+
+/**
+ * The short zone name in effect at `value` (`CDT`, `GMT+9`, …). Useful as a
+ * suffix on inputs whose value is a wall-clock time in the tenant's zone.
+ */
+export function getTimeZoneAbbreviation(timeZone?: string, value: DateInput = new Date()): string {
+  const date = toDate(value) ?? new Date();
+  const parts = safeFormatter(timeZone, {
+    hour: 'numeric',
+    timeZoneName: 'short',
+  }).formatToParts(date);
+
+  return parts.find((part) => part.type === 'timeZoneName')?.value ?? EMPTY;
+}
+
+/**
+ * The offset of `timeZone` at a given instant, in milliseconds east of UTC.
+ * Derived by reading the zone's own wall clock at that instant and comparing
+ * it to the instant itself — the only way to get a historically correct,
+ * DST-aware offset out of `Intl`.
+ */
+function timeZoneOffsetMs(instantMs: number, timeZone: string): number {
+  const parts = safeFormatter(timeZone, {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hourCycle: 'h23',
+  }).formatToParts(new Date(instantMs));
+
+  const read = (type: Intl.DateTimeFormatPartTypes): number =>
+    Number(parts.find((part) => part.type === type)?.value ?? '0');
+
+  const wallClockAsUtc = Date.UTC(
+    read('year'),
+    read('month') - 1,
+    read('day'),
+    read('hour'),
+    read('minute'),
+    read('second')
+  );
+
+  return wallClockAsUtc - instantMs;
+}
+
+/**
+ * Converts an instant into the `YYYY-MM-DDTHH:mm` string an
+ * `<input type="datetime-local">` expects, expressed in `timeZone` rather than
+ * the browser's zone.
+ */
+export function toDatetimeLocalInTimeZone(value: DateInput, timeZone?: string): string {
+  const date = toDate(value);
+  if (!date) return EMPTY;
+
+  if (!timeZone) {
+    // Browser-zone equivalent: shift by the local offset, then slice the ISO.
+    const shifted = new Date(date.getTime() - date.getTimezoneOffset() * 60_000);
+    return shifted.toISOString().slice(0, 16);
+  }
+
+  const shifted = new Date(date.getTime() + timeZoneOffsetMs(date.getTime(), timeZone));
+  return shifted.toISOString().slice(0, 16);
+}
+
+/**
+ * The inverse: reads a `YYYY-MM-DDTHH:mm` wall-clock string as a time in
+ * `timeZone` and returns the corresponding instant as an ISO string.
+ *
+ * The offset is applied twice on purpose. The first pass uses the offset at
+ * the wall-clock time treated as UTC, which is wrong by up to an hour when the
+ * value sits near a DST boundary; re-reading the offset at that first estimate
+ * lands on the correct instant.
+ */
+export function fromDatetimeLocalInTimeZone(value: string, timeZone?: string): string {
+  // `Date.parse` is lenient enough to find a date in strings that are nothing
+  // of the sort, so the shape is checked before anything is parsed.
+  if (!DATETIME_LOCAL_PATTERN.test(value)) return EMPTY;
+
+  if (!timeZone) {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? EMPTY : date.toISOString();
+  }
+
+  const asUtc = Date.parse(`${value.slice(0, 16)}:00Z`);
+  if (Number.isNaN(asUtc)) return EMPTY;
+
+  const firstPass = asUtc - timeZoneOffsetMs(asUtc, timeZone);
+  const instant = asUtc - timeZoneOffsetMs(firstPass, timeZone);
+
+  return new Date(instant).toISOString();
+}
+
+/**
+ * Combines a `YYYY-MM-DD` date and an `HH:MM` time into the instant they name
+ * in `timeZone` — the browser-side mirror of how the API resolves a date-only
+ * `scheduledAt` against the tenant's default send time.
+ */
+export function combineDateAndTimeInTimeZone(
+  date: string,
+  time: string,
+  timeZone?: string
+): string {
+  if (!date || !time) return EMPTY;
+  return fromDatetimeLocalInTimeZone(`${date}T${time}`, timeZone);
+}
+
+/** The browser's own timezone, used to seed a tenant that hasn't picked one. */
+export function getBrowserTimeZone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+  } catch {
+    return 'UTC';
+  }
+}

--- a/dashboard-ui/src/utils/dateFormatting.ts
+++ b/dashboard-ui/src/utils/dateFormatting.ts
@@ -189,6 +189,12 @@ export function toDatetimeLocalInTimeZone(value: DateInput, timeZone?: string): 
  * the wall-clock time treated as UTC, which is wrong by up to an hour when the
  * value sits near a DST boundary; re-reading the offset at that first estimate
  * lands on the correct instant.
+ *
+ * A wall-clock time inside a spring-forward gap never happens, and no offset
+ * makes it happen — the two-pass result lands *before* the requested time,
+ * which would send an issue an hour early. Those are resolved forward to the
+ * first minute that does exist, matching `resolve_date_only` in `settings.rs`
+ * so the dashboard and the API agree on what a gap time means.
  */
 export function fromDatetimeLocalInTimeZone(value: string, timeZone?: string): string {
   // `Date.parse` is lenient enough to find a date in strings that are nothing
@@ -200,14 +206,52 @@ export function fromDatetimeLocalInTimeZone(value: string, timeZone?: string): s
     return Number.isNaN(date.getTime()) ? EMPTY : date.toISOString();
   }
 
-  const asUtc = Date.parse(`${value.slice(0, 16)}:00Z`);
+  const wallClock = value.slice(0, 16);
+  const asUtc = Date.parse(`${wallClock}:00Z`);
   if (Number.isNaN(asUtc)) return EMPTY;
 
-  const firstPass = asUtc - timeZoneOffsetMs(asUtc, timeZone);
-  const instant = asUtc - timeZoneOffsetMs(firstPass, timeZone);
+  const instant = resolveWallClock(asUtc, timeZone);
+  if (instant === null) return EMPTY;
 
   return new Date(instant).toISOString();
 }
+
+/**
+ * Turns a wall-clock time (expressed as though it were UTC) into the instant it
+ * names in `timeZone`, or null if the input isn't a usable time.
+ */
+function resolveWallClock(asUtc: number, timeZone: string): number | null {
+  const firstPass = asUtc - timeZoneOffsetMs(asUtc, timeZone);
+  const instant = asUtc - timeZoneOffsetMs(firstPass, timeZone);
+
+  // Round-trip check: if reading the instant back in the zone doesn't give the
+  // wall clock we asked for, that wall clock doesn't exist on that day.
+  if (wallClockOf(instant, timeZone) === asUtc) {
+    return instant;
+  }
+
+  // Walk forward to the first wall-clock minute that does exist. DST gaps are
+  // at most a couple of hours, so the bound is generous rather than tight.
+  for (let minutes = 1; minutes <= GAP_SEARCH_LIMIT_MINUTES; minutes += 1) {
+    const candidate = asUtc + minutes * 60_000;
+    const resolved = candidate - timeZoneOffsetMs(candidate - timeZoneOffsetMs(candidate, timeZone), timeZone);
+    if (wallClockOf(resolved, timeZone) === candidate) {
+      return resolved;
+    }
+  }
+
+  // No valid time found (should be unreachable for real zones) — the two-pass
+  // estimate is still a real instant, so prefer it over failing outright.
+  return instant;
+}
+
+/** The zone's wall clock at `instant`, as though that wall clock were UTC. */
+function wallClockOf(instant: number, timeZone: string): number {
+  return instant + timeZoneOffsetMs(instant, timeZone);
+}
+
+/** Longest spring-forward gap we'll search past. Real gaps are 30–120 minutes. */
+const GAP_SEARCH_LIMIT_MINUTES = 180;
 
 /**
  * Combines a `YYYY-MM-DD` date and an `HH:MM` time into the instant they name

--- a/dashboard-ui/src/utils/lazyImports.ts
+++ b/dashboard-ui/src/utils/lazyImports.ts
@@ -41,6 +41,14 @@ export const LazyProfilePage = lazy(() =>
     })
 );
 
+export const LazySettingsPage = lazy(() =>
+  import('@/pages/settings').then(module => ({ default: module.SettingsPage }))
+    .catch(error => {
+      console.error('Failed to load SettingsPage:', error);
+      throw error;
+    })
+);
+
 export const LazyApiKeysPage = lazy(() =>
   import('@/pages/api-keys').then(module => ({ default: module.ApiKeysPage }))
     .catch(error => {

--- a/dashboard-ui/src/utils/renderTokens.ts
+++ b/dashboard-ui/src/utils/renderTokens.ts
@@ -1,0 +1,21 @@
+/**
+ * Substitutes `{{token}}` placeholders — the dashboard's mirror of
+ * `renderTokens` in `functions/utils/tenant-settings.mjs`, used to preview
+ * what a subject line or issue URL will actually look like.
+ *
+ * Deliberately not a template engine: these values produce an email subject
+ * and a URL, where literal substitution is the whole requirement. Unknown
+ * tokens are left in place so a typo stays visible rather than silently
+ * blanking part of the preview.
+ */
+export function renderTokens(
+  template: string,
+  tokens: Record<string, string | number | undefined>
+): string {
+  if (typeof template !== 'string') return '';
+
+  return template.replace(/\{\{\s*([a-zA-Z][a-zA-Z0-9_]*)\s*\}\}/g, (match, name: string) => {
+    const value = tokens[name];
+    return value === undefined || value === null ? match : String(value);
+  });
+}

--- a/functions/__tests__/import-issue-from-github.test.mjs
+++ b/functions/__tests__/import-issue-from-github.test.mjs
@@ -1,0 +1,160 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+
+// The import builds the Step Functions execution input; these tests mock the
+// SFN client to inspect it, plus the GitHub/tenant lookups it does first.
+
+let handler;
+let startExecution;
+let ddbSend;
+
+const MARKDOWN = [
+  '---',
+  'title: Test Issue',
+  'date: 2026-06-25',
+  'slug: /newsletter/128',
+  '---',
+  '',
+  '### A Section',
+  'Body copy.',
+  ''
+].join('\n');
+
+const loadIsolated = async (settingsItem = null) => {
+  await jest.isolateModulesAsync(async () => {
+    startExecution = jest.fn(() => Promise.resolve({}));
+    ddbSend = jest.fn((command) => {
+      if (command.Key?.sk === 'settings') {
+        return Promise.resolve(settingsItem ? { Item: settingsItem } : {});
+      }
+      return Promise.resolve({});
+    });
+
+    jest.unstable_mockModule('@aws-sdk/client-sfn', () => ({
+      SFNClient: jest.fn(() => ({ send: startExecution })),
+      StartExecutionCommand: jest.fn((params) => params)
+    }));
+
+    jest.unstable_mockModule('@aws-sdk/client-dynamodb', () => ({
+      DynamoDBClient: jest.fn(() => ({ send: ddbSend })),
+      GetItemCommand: jest.fn((params) => ({ __type: 'GetItem', ...params })),
+      QueryCommand: jest.fn((params) => ({ __type: 'Query', ...params }))
+    }));
+
+    jest.unstable_mockModule('@aws-sdk/util-dynamodb', () => ({
+      marshall: jest.fn((obj) => obj),
+      unmarshall: jest.fn((item) => item)
+    }));
+
+    jest.unstable_mockModule('../utils/helpers.mjs', () => ({
+      getTenant: jest.fn(() => Promise.resolve({ pk: 'tenant-1', email: 'owner@example.com', github: { owner: 'o', repo: 'r' } })),
+      getOctokit: jest.fn(() => Promise.resolve({
+        request: jest.fn(() => Promise.resolve({
+          data: { content: Buffer.from(MARKDOWN, 'utf8').toString('base64') }
+        }))
+      }))
+    }));
+
+    jest.unstable_mockModule('../utils/event-publisher.mjs', () => ({
+      publishIssueEvent: jest.fn(() => Promise.resolve()),
+      EVENT_TYPES: { ISSUE_DRAFT_SAVED: 'ISSUE_DRAFT_SAVED' }
+    }));
+
+    ({ handler } = await import('../import-issue-from-github.mjs'));
+  });
+};
+
+const runImport = async () => {
+  await handler({ detail: { github: { fileName: 'issue.md' }, tenantId: 'tenant-1' } });
+  expect(startExecution).toHaveBeenCalled();
+  return JSON.parse(startExecution.mock.calls[0][0].input);
+};
+
+/** Depth-first search for a named state's `Parameters.Payload` in an ASL doc. */
+const findStatePayload = (node, stateName) => {
+  if (!node || typeof node !== 'object') return undefined;
+
+  if (node.States && Object.hasOwn(node.States, stateName)) {
+    return node.States[stateName].Parameters?.Payload;
+  }
+
+  for (const value of Object.values(node)) {
+    const found = findStatePayload(value, stateName);
+    if (found) return found;
+  }
+
+  return undefined;
+};
+
+describe('import-issue-from-github', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    // The fixture issue is dated 2026-06-25; stay ahead of it so the send is
+    // still in the future.
+    jest.useFakeTimers().setSystemTime(new Date('2026-06-01T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('carries every execution-input field the markdown parser dereferences', async () => {
+    // "Parse Markdown to Json" pulls fields off the execution input with `.$`
+    // references. Those are not optional lookups: a missing field fails the
+    // whole execution at runtime, and a GitHub import is the one caller that
+    // doesn't go through the API's request validation. Reading the contract
+    // out of the ASL keeps this honest when the payload gains a field.
+    //
+    // Scoped to that one state on purpose. Elsewhere the machine either guards
+    // a reference with `IsPresent` (contentType, in the routing Choice) or
+    // sits on the json branch, which a GitHub import never reaches.
+    const asl = JSON.parse(
+      readFileSync(new URL('../../state-machines/stage-issue.asl.json', import.meta.url), 'utf8')
+    );
+
+    // Undefined would mean the state was renamed and this test stopped
+    // checking anything, so assert it was found before reading it.
+    const payload = findStatePayload(asl, 'Parse Markdown to Json');
+    expect(payload).toBeDefined();
+
+    const referenced = Object.values(payload)
+      .filter((value) => typeof value === 'string')
+      .map((value) => /^\$\$\.Execution\.Input\.([a-zA-Z0-9_]+)/.exec(value)?.[1])
+      .filter(Boolean);
+
+    expect(referenced).toContain('subject');
+
+    await loadIsolated();
+    const input = await runImport();
+
+    const missing = referenced.filter((field) => !Object.hasOwn(input, field));
+
+    expect(missing).toEqual([]);
+  });
+
+  it('carries a null subject so the tenant template applies', async () => {
+    await loadIsolated();
+
+    const input = await runImport();
+
+    expect(input.subject).toBeNull();
+  });
+
+  it('schedules a bare frontmatter date at the tenant default send time', async () => {
+    await loadIsolated({ timezone: 'America/Chicago', defaultSendTime: '09:00' });
+
+    const input = await runImport();
+
+    // 2026-06-25 at 09:00 CDT is 14:00Z — not the hardcoded 12:00Z this used
+    // to produce.
+    expect(input.futureDate).toBe('2026-06-25T14:00:00.000Z');
+  });
+
+  it('defaults a bare frontmatter date to 09:00 UTC', async () => {
+    await loadIsolated();
+
+    const input = await runImport();
+
+    expect(input.futureDate).toBe('2026-06-25T09:00:00.000Z');
+  });
+});

--- a/functions/__tests__/parse-json-issue.test.mjs
+++ b/functions/__tests__/parse-json-issue.test.mjs
@@ -40,9 +40,11 @@ describe('parse-json-issue handler', () => {
     });
 
     expect(result.sendAtDate).toBe('now');
-    // Cleanup +3 days and report +5 days from the send day at 14:00.
-    expect(result.listCleanupDate).toBe('2026-06-22T14:00:00');
-    expect(result.reportStatsDate).toBe('2026-06-24T14:00:00');
+    // Cleanup +3 days and report +5 days from the send instant. Sending "now"
+    // makes that the current time (the suite's fake clock, 09:00Z) rather than
+    // a fixed hour of the day.
+    expect(result.listCleanupDate).toBe('2026-06-22T09:00:00');
+    expect(result.reportStatsDate).toBe('2026-06-24T09:00:00');
   });
 
   it('uses the future date for scheduling when it is ahead of now', async () => {
@@ -54,8 +56,10 @@ describe('parse-json-issue handler', () => {
     });
 
     expect(result.sendAtDate).toBe(new Date('2026-07-01T12:00:00Z').toISOString());
-    expect(result.listCleanupDate).toBe('2026-07-04T14:00:00');
-    expect(result.reportStatsDate).toBe('2026-07-06T14:00:00');
+    // Offsets follow the scheduled send, so they track the time the issue
+    // actually goes out instead of a hardcoded 14:00.
+    expect(result.listCleanupDate).toBe('2026-07-04T12:00:00');
+    expect(result.reportStatsDate).toBe('2026-07-06T12:00:00');
   });
 
   it('falls back to the data title for the subject when none is supplied', async () => {

--- a/functions/__tests__/parse-md-to-json.test.mjs
+++ b/functions/__tests__/parse-md-to-json.test.mjs
@@ -266,6 +266,26 @@ describe('parse-md-to-json tenant settings', () => {
     expect(result.subject).toBe('Test Issue | Picks of the Week #12');
   });
 
+  it('prefers a subject the caller supplied over the tenant template', async () => {
+    // The API sets `subject` on every issue it stages, and the state machine
+    // forwards it here. A tenant template is a default, not an override.
+    await loadIsolated([], { subjectTemplate: '{{title}} | Picks of the Week #{{number}}' });
+
+    const result = await handler(issue({ subject: 'A subject the caller chose' }));
+
+    expect(result.subject).toBe('A subject the caller chose');
+  });
+
+  it('uses the tenant template when the caller subject is null', async () => {
+    // GitHub imports carry `subject: null` so the state machine can reference
+    // the field unconditionally.
+    await loadIsolated([], { subjectTemplate: '{{title}} | Picks of the Week #{{number}}' });
+
+    const result = await handler(issue({ subject: null }));
+
+    expect(result.subject).toBe('Test Issue | Picks of the Week #12');
+  });
+
   it('falls back to the issue title when no template is configured', async () => {
     // The subject used to be a hardcoded "Ready, Set, Cloud" string that every
     // tenant inherited; with nothing configured it is now just the title.

--- a/functions/__tests__/parse-md-to-json.test.mjs
+++ b/functions/__tests__/parse-md-to-json.test.mjs
@@ -7,11 +7,16 @@ import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 let handler;
 let ddbSend;
 
-const loadIsolated = async (snippets = []) => {
+const loadIsolated = async (snippets = [], settingsItem = null) => {
   await jest.isolateModulesAsync(async () => {
     ddbSend = jest.fn((command) => {
       if (command.__type === 'Query') {
         return Promise.resolve({ Items: snippets.map((s) => ({ __snippet: s })) });
+      }
+      // The tenant settings record, when a test supplies one; absent means the
+      // handler falls back to the system defaults.
+      if (command.__type === 'GetItem' && command.Key?.sk === 'settings') {
+        return Promise.resolve(settingsItem ? { Item: settingsItem } : {});
       }
       // GetItem for sponsor/author — not exercised by these tests.
       return Promise.resolve({});
@@ -231,5 +236,108 @@ describe('parse-md-to-json content assembly marker injection', () => {
     for (const section of result.data.content.sections) {
       expect(section.markerStart).toBeUndefined();
     }
+  });
+});
+
+describe('parse-md-to-json tenant settings', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    // The fixture issue is dated 2026-06-25; freeze the clock ahead of that so
+    // it stays a future send and sendAtDate isn't collapsed to "now".
+    jest.useFakeTimers().setSystemTime(new Date('2026-06-01T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  const issue = (overrides = {}) => ({
+    content: md('Some body copy.'),
+    issueId: 12,
+    tenantId: 'tenant-1',
+    ...overrides,
+  });
+
+  it('builds the subject from the tenant template', async () => {
+    await loadIsolated([], { subjectTemplate: '{{title}} | Picks of the Week #{{number}}' });
+
+    const result = await handler(issue());
+
+    expect(result.subject).toBe('Test Issue | Picks of the Week #12');
+  });
+
+  it('falls back to the issue title when no template is configured', async () => {
+    // The subject used to be a hardcoded "Ready, Set, Cloud" string that every
+    // tenant inherited; with nothing configured it is now just the title.
+    await loadIsolated([]);
+
+    const result = await handler(issue());
+
+    expect(result.subject).toBe('Test Issue');
+  });
+
+  it('omits the public URL until the tenant configures where issues live', async () => {
+    await loadIsolated([]);
+
+    const result = await handler(issue());
+
+    expect(result.data.metadata.url).toBeUndefined();
+  });
+
+  it('builds the public URL from the tenant pattern', async () => {
+    await loadIsolated([], { issueUrlPattern: 'https://example.com/newsletter/{{number}}' });
+
+    const result = await handler(issue());
+
+    expect(result.data.metadata.url).toBe('https://example.com/newsletter/12');
+  });
+
+  it('sends a bare frontmatter date at the tenant default send time', async () => {
+    await loadIsolated([], { timezone: 'America/Chicago', defaultSendTime: '09:00' });
+
+    const result = await handler(issue());
+
+    // The frontmatter date is 2026-06-25 with no time; 09:00 CDT is 14:00Z.
+    expect(result.sendAtDate).toBe('2026-06-25T14:00:00.000Z');
+  });
+
+  it('defaults a bare frontmatter date to 09:00 UTC', async () => {
+    await loadIsolated([]);
+
+    const result = await handler(issue());
+
+    expect(result.sendAtDate).toBe('2026-06-25T09:00:00.000Z');
+  });
+
+  it('hangs the cleanup and report jobs off the send instant', async () => {
+    await loadIsolated([], { timezone: 'America/Chicago', defaultSendTime: '09:00' });
+
+    const result = await handler(issue());
+
+    expect(result.listCleanupDate).toBe('2026-06-28T14:00:00');
+    expect(result.reportStatsDate).toBe('2026-06-30T14:00:00');
+  });
+
+  it('formats the display date in the tenant timezone', async () => {
+    await loadIsolated([], { timezone: 'America/Chicago', defaultSendTime: '09:00' });
+
+    const result = await handler(issue());
+
+    expect(result.data.metadata.date).toBe('June 25, 2026');
+  });
+
+  it('still works when the tenant settings read fails', async () => {
+    // A preferences lookup must never take down a publish.
+    await loadIsolated([]);
+    ddbSend.mockImplementation((command) => {
+      if (command.__type === 'Query') return Promise.resolve({ Items: [] });
+      if (command.Key?.sk === 'settings') return Promise.reject(new Error('boom'));
+      return Promise.resolve({});
+    });
+
+    const result = await handler(issue());
+
+    expect(result.subject).toBe('Test Issue');
+    expect(result.sendAtDate).toBe('2026-06-25T09:00:00.000Z');
   });
 });

--- a/functions/__tests__/tenant-settings.test.mjs
+++ b/functions/__tests__/tenant-settings.test.mjs
@@ -90,6 +90,55 @@ describe('tenant-settings', () => {
       expect(resolved.toISOString()).toBe('2026-08-01T09:00:00.000Z');
     });
 
+    it('resolves a gap send time forward, never backward', () => {
+      // 02:00–02:59 never happens on 2026-03-08 in Chicago. Applying offsets
+      // naively lands on 01:30 CST — an hour EARLIER than the tenant asked
+      // for, which would send a GitHub-imported issue ahead of schedule. The
+      // first minute that exists is 03:00 CDT.
+      const resolved = resolveSendInstant(
+        '2026-03-08',
+        settings({ timezone: 'America/Chicago', defaultSendTime: '02:30' })
+      );
+
+      expect(resolved.toISOString()).toBe('2026-03-08T08:00:00.000Z');
+      expect(resolved.getTime()).toBeGreaterThan(new Date('2026-03-08T07:30:00.000Z').getTime());
+    });
+
+    it('agrees with the Rust and dashboard resolvers across a whole gap', () => {
+      // settings.rs, dateFormatting.ts and this module all resolve a gap to
+      // the same instant; if they drifted, the settings preview would
+      // contradict the send.
+      for (const sendTime of ['02:00', '02:01', '02:30', '02:59']) {
+        expect(
+          resolveSendInstant(
+            '2026-03-08',
+            settings({ timezone: 'America/Chicago', defaultSendTime: sendTime })
+          ).toISOString()
+        ).toBe('2026-03-08T08:00:00.000Z');
+      }
+    });
+
+    it('resolves a gap in a zone that shifts by half an hour', () => {
+      // Lord Howe springs forward 30 minutes, so its gap is 02:00–02:29.
+      const resolved = resolveSendInstant(
+        '2026-10-04',
+        settings({ timezone: 'Australia/Lord_Howe', defaultSendTime: '02:15' })
+      );
+
+      expect(resolved.toISOString()).toBe('2026-10-03T15:30:00.000Z');
+    });
+
+    it('keeps the earlier instant for an ambiguous fall-back hour', () => {
+      // 01:30 happens twice on 2026-11-01; the earlier occurrence is closest
+      // to the requested wall clock, matching the Rust resolver.
+      const resolved = resolveSendInstant(
+        '2026-11-01',
+        settings({ timezone: 'America/Chicago', defaultSendTime: '01:30' })
+      );
+
+      expect(resolved.toISOString()).toBe('2026-11-01T06:30:00.000Z');
+    });
+
     it('returns null for missing or unusable values', () => {
       for (const bad of [null, undefined, '', 'tomorrow', new Date('nope')]) {
         expect(resolveSendInstant(bad, DEFAULT_SETTINGS)).toBeNull();

--- a/functions/__tests__/tenant-settings.test.mjs
+++ b/functions/__tests__/tenant-settings.test.mjs
@@ -1,0 +1,179 @@
+import { jest } from '@jest/globals';
+import {
+  DEFAULT_SETTINGS,
+  isDateOnly,
+  resolveSendInstant,
+  renderTokens,
+  buildSubject,
+  buildIssueUrl
+} from '../utils/tenant-settings.mjs';
+
+const settings = (overrides = {}) => ({ ...DEFAULT_SETTINGS, ...overrides });
+
+describe('tenant-settings', () => {
+  describe('isDateOnly', () => {
+    it('recognizes a bare date string', () => {
+      expect(isDateOnly('2026-08-01')).toBe(true);
+      expect(isDateOnly('  2026-08-01  ')).toBe(true);
+      expect(isDateOnly('2026-08-01T09:00:00Z')).toBe(false);
+      expect(isDateOnly('not a date')).toBe(false);
+    });
+
+    it('recognizes the UTC-midnight Date a YAML parser produces from a bare date', () => {
+      expect(isDateOnly(new Date('2026-08-01T00:00:00.000Z'))).toBe(true);
+      expect(isDateOnly(new Date('2026-08-01T12:00:00.000Z'))).toBe(false);
+      expect(isDateOnly(new Date('nope'))).toBe(false);
+    });
+  });
+
+  describe('resolveSendInstant', () => {
+    it('anchors a bare date to the default send time in the tenant zone', () => {
+      const resolved = resolveSendInstant(
+        '2026-08-01',
+        settings({ timezone: 'America/Chicago', defaultSendTime: '09:00' })
+      );
+
+      // 09:00 CDT is 14:00Z.
+      expect(resolved.toISOString()).toBe('2026-08-01T14:00:00.000Z');
+    });
+
+    it('follows daylight saving rather than a fixed offset', () => {
+      const winter = resolveSendInstant(
+        '2026-01-15',
+        settings({ timezone: 'America/Chicago', defaultSendTime: '09:00' })
+      );
+
+      expect(winter.toISOString()).toBe('2026-01-15T15:00:00.000Z');
+    });
+
+    it('defaults to 09:00 UTC when the tenant has configured nothing', () => {
+      expect(resolveSendInstant('2026-08-01', DEFAULT_SETTINGS).toISOString())
+        .toBe('2026-08-01T09:00:00.000Z');
+    });
+
+    it('resolves the UTC-midnight Date form the same way', () => {
+      const resolved = resolveSendInstant(
+        new Date('2026-08-01T00:00:00.000Z'),
+        settings({ timezone: 'America/Chicago', defaultSendTime: '09:00' })
+      );
+
+      expect(resolved.toISOString()).toBe('2026-08-01T14:00:00.000Z');
+    });
+
+    it('respects a date that already names a time', () => {
+      // Settings fill in what the caller left out; they don't override a
+      // caller who was specific.
+      const resolved = resolveSendInstant(
+        '2026-08-01T18:30:00Z',
+        settings({ timezone: 'America/Chicago', defaultSendTime: '09:00' })
+      );
+
+      expect(resolved.toISOString()).toBe('2026-08-01T18:30:00.000Z');
+    });
+
+    it('zero-pads a single-digit send time', () => {
+      const resolved = resolveSendInstant('2026-08-01', settings({ defaultSendTime: '7:05' }));
+      expect(resolved.toISOString()).toBe('2026-08-01T07:05:00.000Z');
+    });
+
+    it('falls back to UTC when the stored zone is unusable', () => {
+      const resolved = resolveSendInstant(
+        '2026-08-01',
+        settings({ timezone: 'Not/AZone', defaultSendTime: '09:00' })
+      );
+
+      expect(resolved.toISOString()).toBe('2026-08-01T09:00:00.000Z');
+    });
+
+    it('falls back to the system send time when the stored one is malformed', () => {
+      const resolved = resolveSendInstant('2026-08-01', settings({ defaultSendTime: '9am' }));
+      expect(resolved.toISOString()).toBe('2026-08-01T09:00:00.000Z');
+    });
+
+    it('returns null for missing or unusable values', () => {
+      for (const bad of [null, undefined, '', 'tomorrow', new Date('nope')]) {
+        expect(resolveSendInstant(bad, DEFAULT_SETTINGS)).toBeNull();
+      }
+    });
+  });
+
+  describe('renderTokens', () => {
+    it('substitutes known tokens, with or without inner spaces', () => {
+      expect(renderTokens('{{title}} #{{number}}', { title: 'Hi', number: 7 })).toBe('Hi #7');
+      expect(renderTokens('{{ title }}', { title: 'Hi' })).toBe('Hi');
+    });
+
+    it('leaves an unknown token visible instead of blanking it', () => {
+      // A typo should look wrong, not silently swallow part of the subject.
+      expect(renderTokens('{{title}} {{brand}}', { title: 'Hi' })).toBe('Hi {{brand}}');
+    });
+
+    it('returns an empty string for a non-string template', () => {
+      expect(renderTokens(undefined, {})).toBe('');
+      expect(renderTokens(null, {})).toBe('');
+    });
+  });
+
+  describe('buildSubject', () => {
+    it('prefers a subject the caller actually supplied', () => {
+      const subject = buildSubject(settings({ subjectTemplate: '{{title}} | Weekly' }), {
+        callerSubject: 'Explicit subject',
+        title: 'The Title',
+        number: 12
+      });
+
+      expect(subject).toBe('Explicit subject');
+    });
+
+    it('falls back to the tenant template when no subject was supplied', () => {
+      const subject = buildSubject(
+        settings({ subjectTemplate: '{{title}} | Picks of the Week #{{number}}' }),
+        { title: 'The Title', number: 12 }
+      );
+
+      expect(subject).toBe('The Title | Picks of the Week #12');
+    });
+
+    it('falls back to the title when there is no template either', () => {
+      expect(buildSubject(DEFAULT_SETTINGS, { title: 'The Title', number: 12 }))
+        .toBe('The Title');
+    });
+
+    it('falls back to a generic subject when there is no title', () => {
+      expect(buildSubject(DEFAULT_SETTINGS, { number: 12 })).toBe('Newsletter Issue #12');
+    });
+
+    it('treats a blank caller subject as absent', () => {
+      expect(buildSubject(settings({ subjectTemplate: 'From the template' }), {
+        callerSubject: '   ',
+        title: 'The Title'
+      })).toBe('From the template');
+    });
+  });
+
+  describe('buildIssueUrl', () => {
+    it('expands the tenant pattern', () => {
+      expect(buildIssueUrl(settings({ issueUrlPattern: 'https://example.com/n/{{number}}' }), {
+        number: 42
+      })).toBe('https://example.com/n/42');
+    });
+
+    it('returns null when no pattern is configured', () => {
+      // Better no link than a link to somebody else's site.
+      expect(buildIssueUrl(DEFAULT_SETTINGS, { number: 42 })).toBeNull();
+      expect(buildIssueUrl(settings({ issueUrlPattern: '  ' }), { number: 42 })).toBeNull();
+      expect(buildIssueUrl(undefined, { number: 42 })).toBeNull();
+    });
+  });
+
+  describe('getTenantSettings', () => {
+    afterEach(() => {
+      jest.resetModules();
+    });
+
+    it('returns the defaults without a lookup when there is no tenant id', async () => {
+      const { getTenantSettings } = await import('../utils/tenant-settings.mjs');
+      await expect(getTenantSettings(undefined)).resolves.toEqual(DEFAULT_SETTINGS);
+    });
+  });
+});

--- a/functions/import-issue-from-github.mjs
+++ b/functions/import-issue-from-github.mjs
@@ -2,6 +2,7 @@ import { SFNClient, StartExecutionCommand } from '@aws-sdk/client-sfn';
 import frontmatter from '@github-docs/frontmatter';
 import { getOctokit, getTenant } from './utils/helpers.mjs';
 import { publishIssueEvent, EVENT_TYPES } from './utils/event-publisher.mjs';
+import { getTenantSettings, resolveSendInstant } from './utils/tenant-settings.mjs';
 
 const sfn = new SFNClient();
 let octokit;
@@ -50,14 +51,16 @@ const getIssueData = async (tenant, github) => {
 const processNewIssue = async (data) => {
   const today = new Date();
   const metadata = frontmatter(data.content);
-  let postDate = metadata.data.date;
-  if (postDate.toISOString().indexOf('T00:00:00.000Z') > -1) {
-    postDate = `${postDate.toISOString().split('T')[0]}T12:00:00Z`;
-  }
 
-  const date = new Date(postDate);
-  if (date > today) {
-    data.futureDate = `${metadata.data.date.toISOString().split('T')[0]}T12:00:00Z`;
+  // A frontmatter `date:` with no time attached (which YAML hands back as UTC
+  // midnight) is a day, not a moment. It gets the tenant's configured default
+  // send time in the tenant's timezone; a date that already names a time is
+  // taken as written.
+  const settings = await getTenantSettings(data.tenant.id);
+  const date = resolveSendInstant(metadata.data.date, settings);
+
+  if (date && date > today) {
+    data.futureDate = date.toISOString();
   }
 
   const slugSource = (metadata.data.slug || github.slug || '').toString();
@@ -82,7 +85,7 @@ const processNewIssue = async (data) => {
       issueId: data.key,
       fileName: data.fileName,
       title: metadata.data.title || 'Untitled Issue',
-      scheduledDate: date > today ? date.toISOString() : null,
+      scheduledDate: date && date > today ? date.toISOString() : null,
       isPreview: data.isPreview,
       metadata: metadata.data
     }

--- a/functions/import-issue-from-github.mjs
+++ b/functions/import-issue-from-github.mjs
@@ -25,6 +25,11 @@ export const handler = async (event) => {
       // Always present (null when no template selected) so the state machine can
       // reference it unconditionally; GitHub-imported issues use the default template.
       templateId: null,
+      // Same reason: the state machine forwards `subject` to the markdown
+      // parser with a `.$` path reference, which fails the execution outright
+      // if the field is absent. Null means "no caller subject", so the parser
+      // falls back to the tenant's subjectTemplate.
+      subject: null,
       ...email && { email }
     };
     await processNewIssue(issueData);

--- a/functions/parse-json-issue.mjs
+++ b/functions/parse-json-issue.mjs
@@ -12,6 +12,8 @@
  *
  *   { data, sendAtDate, listCleanupDate, reportStatsDate, subject }
  */
+import { getTenantSettings, resolveSendInstant } from './utils/tenant-settings.mjs';
+
 export const handler = async (state) => {
   const issueNumber = Number(state.issueId);
   if (!Number.isFinite(issueNumber) || issueNumber < 1) {
@@ -42,15 +44,21 @@ export const handler = async (state) => {
   }
 
   const now = new Date();
-  const scheduled = state.futureDate ? new Date(state.futureDate) : null;
+  // A `futureDate` that is a bare date gets the tenant's default send time in
+  // the tenant's timezone, the same as a date-only `scheduledAt` on the API.
+  // The state machine waits out the schedule before this step and doesn't
+  // currently forward `futureDate`, so this is a safety net for callers that
+  // do — hence the settings read only happening when there's a date to resolve.
+  const scheduled = state.futureDate
+    ? resolveSendInstant(state.futureDate, await getTenantSettings(state.tenantId))
+    : null;
   const hasFutureSend = scheduled && !Number.isNaN(scheduled.getTime()) && scheduled > now;
 
   const sendAtDate = hasFutureSend ? scheduled.toISOString() : 'now';
 
-  // Mirror parse-md-to-json: schedule downstream jobs relative to the send day
-  // at 14:00, cleanup +3 days and stats report +5 days.
+  // Mirror parse-md-to-json: downstream jobs hang off the send instant,
+  // cleanup +3 days and the stats report +5.
   const baseDate = hasFutureSend ? new Date(scheduled) : new Date(now);
-  baseDate.setHours(14, 0, 0, 0);
 
   const listCleanupDate = new Date(baseDate);
   listCleanupDate.setDate(listCleanupDate.getDate() + 3);

--- a/functions/parse-md-to-json.mjs
+++ b/functions/parse-md-to-json.mjs
@@ -153,8 +153,9 @@ export const handler = async (state) => {
     listCleanupDate: listCleanupDate.toISOString().split('.')[0],
     reportStatsDate: reportStatsDate.toISOString().split('.')[0],
     subject: buildSubject(settings, {
-      // The markdown path is reached from the GitHub import, which carries no
-      // subject of its own, so this is normally the tenant's subjectTemplate.
+      // Null for GitHub imports, which have no subject of their own — those
+      // fall through to the tenant's subjectTemplate. An API-created issue
+      // always supplies one, and an explicit subject outranks the template.
       callerSubject: state.subject,
       title: dataTemplate.metadata.title,
       number: issueNumber,

--- a/functions/parse-md-to-json.mjs
+++ b/functions/parse-md-to-json.mjs
@@ -6,6 +6,12 @@ import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
 import { renderWithSnippets } from './utils/render-template.mjs';
 import { resolveParameters } from './utils/snippet-parameters.mjs';
 import { sectionStartMarker, sectionEndMarker } from './utils/interest-assembly.mjs';
+import {
+  getTenantSettings,
+  resolveSendInstant,
+  buildSubject,
+  buildIssueUrl
+} from './utils/tenant-settings.mjs';
 
 const ddb = new DynamoDBClient();
 const converter = new showdown.Converter();
@@ -33,6 +39,7 @@ export const handler = async (state) => {
   const author = await getAuthor(newsletter.data.author);
   const snippets = await getSnippets(state.tenantId);
   const snippetsByName = new Map(snippets.filter(s => s.name).map(s => [s.name, s]));
+  const settings = await getTenantSettings(state.tenantId);
   const issueNumber = Number(state.issueId);
 
   if (!Number.isFinite(issueNumber) || issueNumber < 1) {
@@ -47,8 +54,23 @@ export const handler = async (state) => {
     delete sponsor.ad;
   }
 
-  const newsletterDate = new Date(newsletter.data.date);
-  const formattedDate = newsletterDate.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
+  // The frontmatter `date` is the day the issue goes out. A bare date carries
+  // no time, so it is anchored to the tenant's default send time in the
+  // tenant's timezone; a date that already names a time is respected as-is.
+  const sendInstant = resolveSendInstant(newsletter.data.date, settings);
+  const formattedDate = sendInstant
+    ? sendInstant.toLocaleDateString('en-US', {
+      timeZone: settings.timezone,
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric'
+    })
+    : '';
+
+  // Omitted when the tenant hasn't configured where issues live on their site
+  // — the template drops the "view online" link rather than pointing every
+  // tenant's subscribers at somebody else's domain.
+  const issueUrl = buildIssueUrl(settings, { number: issueNumber });
 
   const dataTemplate = {
     metadata: {
@@ -56,7 +78,7 @@ export const handler = async (state) => {
       title: newsletter.data.title,
       description: newsletter.data.description,
       date: formattedDate,
-      url: `https://readysetcloud.io/newsletter/${issueNumber}`,
+      ...(issueUrl && { url: issueUrl }),
       ...(author && { author })
     },
     ...(sponsor && { sponsor }),
@@ -112,23 +134,32 @@ export const handler = async (state) => {
     console.error('Failed to apply content assembly markers, sending canonical order', { error: err.message });
   }
 
-  newsletterDate.setHours(14);
+  // Downstream jobs hang off the send instant: list cleanup three days later,
+  // the stats report five.
+  const baseDate = sendInstant ?? new Date();
 
-  const listCleanupDate = new Date(newsletterDate);
+  const listCleanupDate = new Date(baseDate);
   listCleanupDate.setDate(listCleanupDate.getDate() + 3);
 
-  const reportStatsDate = new Date(newsletterDate);
+  const reportStatsDate = new Date(baseDate);
   reportStatsDate.setDate(reportStatsDate.getDate() + 5);
 
   const now = new Date();
-  const sendAtDate = newsletterDate < now ? 'now' : newsletterDate.toISOString();
+  const sendAtDate = !sendInstant || sendInstant < now ? 'now' : sendInstant.toISOString();
 
   return {
     data: dataTemplate,
     sendAtDate,
     listCleanupDate: listCleanupDate.toISOString().split('.')[0],
     reportStatsDate: reportStatsDate.toISOString().split('.')[0],
-    subject: `${dataTemplate.metadata.title} | Ready, Set, Cloud Picks of the Week #${dataTemplate.metadata.number}`
+    subject: buildSubject(settings, {
+      // The markdown path is reached from the GitHub import, which carries no
+      // subject of its own, so this is normally the tenant's subjectTemplate.
+      callerSubject: state.subject,
+      title: dataTemplate.metadata.title,
+      number: issueNumber,
+      date: formattedDate
+    })
   };
 };
 

--- a/functions/src/api/controllers/issues.rs
+++ b/functions/src/api/controllers/issues.rs
@@ -7,6 +7,8 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 
+use super::settings::{self, TenantSettings};
+
 // Request/Response types for list issues endpoint
 #[derive(Deserialize)]
 pub struct ListIssuesQuery {
@@ -1787,7 +1789,8 @@ async fn handle_create_issue(event: Request) -> Result<Response<Body>, AppError>
 
     let idempotency_key = get_idempotency_key(&event);
 
-    let normalized_scheduled_at = normalize_scheduled_at(body.scheduled_at.as_deref())?;
+    let normalized_scheduled_at =
+        normalize_scheduled_at(&tenant_id, body.scheduled_at.as_deref()).await?;
 
     // Set when an exact replay's recorded issue no longer exists and the
     // request falls through to a fresh create: the idempotency record for the
@@ -1947,8 +1950,20 @@ async fn handle_update_issue(
     let issue_id =
         issue_id.ok_or_else(|| AppError::BadRequest("Issue ID is required".to_string()))?;
 
-    let body: UpdateIssueRequest = serde_json::from_slice(event.body())
+    let mut body: UpdateIssueRequest = serde_json::from_slice(event.body())
         .map_err(|e| AppError::BadRequest(format!("Invalid JSON: {}", e)))?;
+
+    // A date-only reschedule gets the tenant's default send time, same as on
+    // create. Anything else is stored as sent — including past timestamps,
+    // which an update is allowed to set.
+    if let Some(scheduled_at) = body.scheduled_at.as_deref() {
+        let trimmed = scheduled_at.trim();
+        if settings::is_date_only(trimmed) {
+            let tenant_settings = settings::get_tenant_settings(&tenant_id).await;
+            body.scheduled_at =
+                Some(settings::resolve_date_only(trimmed, &tenant_settings)?.to_rfc3339());
+        }
+    }
 
     let ab_test = extract_ab_test(event.body().as_ref())?
         .map(|value| validate_and_normalize_ab_test(&value))
@@ -3322,7 +3337,38 @@ fn get_idempotency_key(event: &Request) -> Option<String> {
         .filter(|value| !value.is_empty())
 }
 
-fn normalize_scheduled_at(value: Option<&str>) -> Result<Option<String>, AppError> {
+async fn normalize_scheduled_at(
+    tenant_id: &str,
+    value: Option<&str>,
+) -> Result<Option<String>, AppError> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let trimmed = value.trim();
+
+    // The tenant's defaults are only needed to fill in a missing time, so a
+    // caller that already supplied a full timestamp doesn't pay for the read.
+    let settings = if settings::is_date_only(trimmed) {
+        settings::get_tenant_settings(tenant_id).await
+    } else {
+        TenantSettings::default()
+    };
+
+    resolve_scheduled_at(Some(trimmed), &settings)
+}
+
+/// Normalizes a caller-supplied `scheduledAt` into the instant stored on the
+/// issue. `None` means "send immediately" — an absent value, `"now"`, or a
+/// time that has already passed.
+///
+/// A date-only value (`YYYY-MM-DD`) carries no time of day, so rather than
+/// rejecting it or guessing midnight UTC, it is anchored to the tenant's
+/// configured default send time, read as wall-clock time in the tenant's
+/// timezone (see [`super::settings`]).
+fn resolve_scheduled_at(
+    value: Option<&str>,
+    settings: &TenantSettings,
+) -> Result<Option<String>, AppError> {
     let Some(value) = value else {
         return Ok(None);
     };
@@ -3332,8 +3378,15 @@ fn normalize_scheduled_at(value: Option<&str>) -> Result<Option<String>, AppErro
         return Ok(None);
     }
 
-    let parsed = chrono::DateTime::parse_from_rfc3339(trimmed)
-        .map_err(|_| AppError::BadRequest("scheduledAt must be RFC3339 or \"now\"".to_string()))?;
+    let parsed = if settings::is_date_only(trimmed) {
+        settings::resolve_date_only(trimmed, settings)?.fixed_offset()
+    } else {
+        chrono::DateTime::parse_from_rfc3339(trimmed).map_err(|_| {
+            AppError::BadRequest(
+                "scheduledAt must be RFC3339, a YYYY-MM-DD date, or \"now\"".to_string(),
+            )
+        })?
+    };
 
     if parsed.with_timezone(&chrono::Utc) <= chrono::Utc::now() {
         return Ok(None);
@@ -4545,6 +4598,88 @@ Thanks!"#;
             content_type: content_type.map(|c| c.to_string()),
             ttl_seconds: None,
         }
+    }
+
+    fn tenant_settings(timezone: &str, send_time: &str) -> TenantSettings {
+        TenantSettings {
+            timezone: timezone.to_string(),
+            default_send_time: send_time.to_string(),
+        }
+    }
+
+    /// A date far enough out that these assertions don't start failing when
+    /// the clock passes them — `resolve_scheduled_at` drops past times.
+    fn future_year() -> i32 {
+        chrono::Utc::now()
+            .format("%Y")
+            .to_string()
+            .parse::<i32>()
+            .unwrap()
+            + 2
+    }
+
+    #[test]
+    fn test_resolve_scheduled_at_treats_absent_and_now_as_immediate() {
+        let settings = TenantSettings::default();
+        assert_eq!(resolve_scheduled_at(None, &settings).unwrap(), None);
+        assert_eq!(resolve_scheduled_at(Some(""), &settings).unwrap(), None);
+        assert_eq!(resolve_scheduled_at(Some("  "), &settings).unwrap(), None);
+        assert_eq!(resolve_scheduled_at(Some("now"), &settings).unwrap(), None);
+        assert_eq!(resolve_scheduled_at(Some("NOW"), &settings).unwrap(), None);
+    }
+
+    #[test]
+    fn test_resolve_scheduled_at_passes_through_full_timestamps() {
+        let value = format!("{}-08-01T12:34:00+00:00", future_year());
+        let resolved =
+            resolve_scheduled_at(Some(&value), &tenant_settings("America/Chicago", "09:00"))
+                .unwrap();
+
+        // An explicit instant wins over the tenant default; settings only fill
+        // in what the caller left out.
+        assert_eq!(resolved, Some(value));
+    }
+
+    #[test]
+    fn test_resolve_scheduled_at_applies_default_send_time_to_a_bare_date() {
+        let date = format!("{}-08-01", future_year());
+        let resolved =
+            resolve_scheduled_at(Some(&date), &tenant_settings("America/Chicago", "09:00"))
+                .unwrap()
+                .expect("a future date should stay scheduled");
+
+        // 09:00 CDT is 14:00Z.
+        assert_eq!(resolved, format!("{}-08-01T14:00:00+00:00", future_year()));
+    }
+
+    #[test]
+    fn test_resolve_scheduled_at_uses_utc_at_nine_without_configured_settings() {
+        let date = format!("{}-08-01", future_year());
+        let resolved = resolve_scheduled_at(Some(&date), &TenantSettings::default())
+            .unwrap()
+            .expect("a future date should stay scheduled");
+
+        assert_eq!(resolved, format!("{}-08-01T09:00:00+00:00", future_year()));
+    }
+
+    #[test]
+    fn test_resolve_scheduled_at_drops_past_dates() {
+        // A bare date in the past resolves to a past instant, which means the
+        // same thing an explicit past timestamp does: send now.
+        let resolved = resolve_scheduled_at(
+            Some("2020-01-01"),
+            &tenant_settings("America/Chicago", "09:00"),
+        )
+        .unwrap();
+        assert_eq!(resolved, None);
+    }
+
+    #[test]
+    fn test_resolve_scheduled_at_rejects_unparseable_values() {
+        let settings = TenantSettings::default();
+        assert!(resolve_scheduled_at(Some("tomorrow"), &settings).is_err());
+        assert!(resolve_scheduled_at(Some("2026-13-01"), &settings).is_err());
+        assert!(resolve_scheduled_at(Some("08/01/2026"), &settings).is_err());
     }
 
     #[test]

--- a/functions/src/api/controllers/issues.rs
+++ b/functions/src/api/controllers/issues.rs
@@ -3104,13 +3104,10 @@ fn parse_issue_stats(item: &HashMap<String, AttributeValue>) -> Result<IssueStat
 fn extract_analytics_summary(stats: &IssueStats) -> Option<IssueAnalyticsSummary> {
     let analytics = stats.analytics.as_ref()?;
     let parsed: Result<IssueAnalyticsSummary, _> = serde_json::from_value(analytics.clone());
-    parsed.ok().and_then(|summary| {
-        if summary.engagement_type.is_none() && summary.traffic_source.is_none() {
-            None
-        } else {
-            Some(summary)
-        }
-    })
+    // A summary with neither breakdown carries no information worth returning.
+    parsed
+        .ok()
+        .filter(|summary| summary.engagement_type.is_some() || summary.traffic_source.is_some())
 }
 
 fn parse_insights_map(

--- a/functions/src/api/controllers/issues.rs
+++ b/functions/src/api/controllers/issues.rs
@@ -1762,9 +1762,20 @@ async fn handle_create_issue(event: Request) -> Result<Response<Body>, AppError>
         .transpose()?;
 
     let raw_local_send = extract_local_send(event.body().as_ref())?;
+
+    // Both a date-only `scheduledAt` and a local-send config without an
+    // explicit zone are filled in from the tenant's settings; load them once,
+    // and only when this request actually needs them.
+    let tenant_settings = load_settings_if_needed(
+        &tenant_id,
+        body.scheduled_at.as_deref(),
+        raw_local_send.is_some(),
+    )
+    .await;
+
     let local_send = raw_local_send
         .as_ref()
-        .map(validate_and_normalize_local_send)
+        .map(|value| validate_and_normalize_local_send(value, &tenant_settings.timezone))
         .transpose()?
         .flatten();
     let raw_content_assembly = extract_content_assembly(event.body().as_ref())?;
@@ -1790,7 +1801,7 @@ async fn handle_create_issue(event: Request) -> Result<Response<Body>, AppError>
     let idempotency_key = get_idempotency_key(&event);
 
     let normalized_scheduled_at =
-        normalize_scheduled_at(&tenant_id, body.scheduled_at.as_deref()).await?;
+        resolve_scheduled_at(body.scheduled_at.as_deref(), &tenant_settings)?;
 
     // Set when an exact replay's recorded issue no longer exists and the
     // request falls through to a fresh create: the idempotency record for the
@@ -1953,13 +1964,22 @@ async fn handle_update_issue(
     let mut body: UpdateIssueRequest = serde_json::from_slice(event.body())
         .map_err(|e| AppError::BadRequest(format!("Invalid JSON: {}", e)))?;
 
+    let raw_local_send = extract_local_send(event.body().as_ref())?;
+    let local_send_provided = raw_local_send.is_some();
+
+    let tenant_settings = load_settings_if_needed(
+        &tenant_id,
+        body.scheduled_at.as_deref(),
+        local_send_provided,
+    )
+    .await;
+
     // A date-only reschedule gets the tenant's default send time, same as on
     // create. Anything else is stored as sent — including past timestamps,
     // which an update is allowed to set.
     if let Some(scheduled_at) = body.scheduled_at.as_deref() {
         let trimmed = scheduled_at.trim();
         if settings::is_date_only(trimmed) {
-            let tenant_settings = settings::get_tenant_settings(&tenant_id).await;
             body.scheduled_at =
                 Some(settings::resolve_date_only(trimmed, &tenant_settings)?.to_rfc3339());
         }
@@ -1972,10 +1992,8 @@ async fn handle_update_issue(
     // An explicit `abTest: null` is a request to clear a previously-saved test.
     let clear_ab_test = ab_test.is_none() && ab_test_explicitly_cleared(event.body().as_ref());
 
-    let raw_local_send = extract_local_send(event.body().as_ref())?;
-    let local_send_provided = raw_local_send.is_some();
     let local_send = raw_local_send
-        .map(|value| validate_and_normalize_local_send(&value))
+        .map(|value| validate_and_normalize_local_send(&value, &tenant_settings.timezone))
         .transpose()?
         .flatten();
 
@@ -2245,8 +2263,14 @@ fn is_plausible_iana_time_zone(tz: &str) -> bool {
 /// delivers at each subscriber's personal peak open hour instead. Returns
 /// Ok(None) when `enabled` is false — a disabled config is stored as no
 /// config at all.
+///
+/// `defaultTimeZone` is also optional: it names the zone whose wall clock
+/// defines the target send time, which is exactly what the tenant's own
+/// timezone setting already says, so `fallback_time_zone` fills it in when the
+/// caller doesn't.
 fn validate_and_normalize_local_send(
     value: &serde_json::Value,
+    fallback_time_zone: &str,
 ) -> Result<Option<serde_json::Value>, AppError> {
     let obj = value
         .as_object()
@@ -2266,11 +2290,7 @@ fn validate_and_normalize_local_send(
         .and_then(|v| v.as_str())
         .map(str::trim)
         .filter(|tz| !tz.is_empty())
-        .ok_or_else(|| {
-            AppError::BadRequest(
-                "localSend.defaultTimeZone is required when localSend is enabled".to_string(),
-            )
-        })?;
+        .unwrap_or(fallback_time_zone);
 
     if !is_plausible_iana_time_zone(default_time_zone) {
         return Err(AppError::BadRequest(
@@ -3337,24 +3357,24 @@ fn get_idempotency_key(event: &Request) -> Option<String> {
         .filter(|value| !value.is_empty())
 }
 
-async fn normalize_scheduled_at(
+/// Loads the tenant's settings only when something on this request actually
+/// needs them — a date-only `scheduledAt` to expand, or a local-send config
+/// whose zone may need filling in. A request that spelled everything out
+/// doesn't pay for the read.
+async fn load_settings_if_needed(
     tenant_id: &str,
-    value: Option<&str>,
-) -> Result<Option<String>, AppError> {
-    let Some(value) = value else {
-        return Ok(None);
-    };
-    let trimmed = value.trim();
+    scheduled_at: Option<&str>,
+    has_local_send: bool,
+) -> TenantSettings {
+    let needs_send_time = scheduled_at
+        .map(|value| settings::is_date_only(value.trim()))
+        .unwrap_or(false);
 
-    // The tenant's defaults are only needed to fill in a missing time, so a
-    // caller that already supplied a full timestamp doesn't pay for the read.
-    let settings = if settings::is_date_only(trimmed) {
+    if needs_send_time || has_local_send {
         settings::get_tenant_settings(tenant_id).await
     } else {
         TenantSettings::default()
-    };
-
-    resolve_scheduled_at(Some(trimmed), &settings)
+    }
 }
 
 /// Normalizes a caller-supplied `scheduledAt` into the instant stored on the
@@ -4434,6 +4454,10 @@ Thanks!"#;
 
     // ── Local-send config validation ────────────────────────────────────
 
+    /// Stands in for the tenant timezone setting in tests that supply their
+    /// own zone and don't care about the fallback.
+    const FALLBACK_ZONE: &str = "UTC";
+
     #[test]
     fn test_validate_local_send_normalizes_valid_config() {
         let input = serde_json::json!({
@@ -4441,7 +4465,9 @@ Thanks!"#;
             "defaultTimeZone": " America/New_York ",
             "extraneous": "dropped"
         });
-        let normalized = validate_and_normalize_local_send(&input).unwrap().unwrap();
+        let normalized = validate_and_normalize_local_send(&input, FALLBACK_ZONE)
+            .unwrap()
+            .unwrap();
         assert_eq!(
             normalized,
             serde_json::json!({
@@ -4468,15 +4494,20 @@ Thanks!"#;
                 "mode": "timezone"
             }),
         ] {
-            let normalized = validate_and_normalize_local_send(&input).unwrap().unwrap();
+            let normalized = validate_and_normalize_local_send(&input, FALLBACK_ZONE)
+                .unwrap()
+                .unwrap();
             assert_eq!(normalized["mode"], "timezone", "{input}");
         }
 
-        let normalized = validate_and_normalize_local_send(&serde_json::json!({
-            "enabled": true,
-            "defaultTimeZone": "America/New_York",
-            "mode": "peak-hour"
-        }))
+        let normalized = validate_and_normalize_local_send(
+            &serde_json::json!({
+                "enabled": true,
+                "defaultTimeZone": "America/New_York",
+                "mode": "peak-hour"
+            }),
+            FALLBACK_ZONE,
+        )
         .unwrap()
         .unwrap();
         assert_eq!(
@@ -4504,7 +4535,7 @@ Thanks!"#;
                 "mode": mode
             });
             assert!(
-                validate_and_normalize_local_send(&input).is_err(),
+                validate_and_normalize_local_send(&input, FALLBACK_ZONE).is_err(),
                 "{input}"
             );
         }
@@ -4513,7 +4544,9 @@ Thanks!"#;
     #[test]
     fn test_validate_local_send_disabled_becomes_none() {
         let input = serde_json::json!({ "enabled": false, "defaultTimeZone": "America/New_York" });
-        assert!(validate_and_normalize_local_send(&input).unwrap().is_none());
+        assert!(validate_and_normalize_local_send(&input, FALLBACK_ZONE)
+            .unwrap()
+            .is_none());
     }
 
     #[test]
@@ -4523,21 +4556,44 @@ Thanks!"#;
             serde_json::json!({ "enabled": "yes", "defaultTimeZone": "America/New_York" }),
             serde_json::json!("not-an-object"),
         ] {
-            assert!(validate_and_normalize_local_send(&input).is_err());
+            assert!(validate_and_normalize_local_send(&input, FALLBACK_ZONE).is_err());
         }
     }
 
     #[test]
-    fn test_validate_local_send_requires_timezone_when_enabled() {
+    fn test_validate_local_send_falls_back_to_the_tenant_timezone() {
+        // An omitted or blank zone means "the one this newsletter already
+        // runs on" — the tenant timezone setting — rather than an error.
         for input in [
             serde_json::json!({ "enabled": true }),
             serde_json::json!({ "enabled": true, "defaultTimeZone": "" }),
             serde_json::json!({ "enabled": true, "defaultTimeZone": "  " }),
+            serde_json::json!({ "enabled": true, "defaultTimeZone": null }),
+        ] {
+            let normalized = validate_and_normalize_local_send(&input, "Europe/London")
+                .unwrap()
+                .unwrap();
+            assert_eq!(normalized["defaultTimeZone"], "Europe/London", "{input}");
+        }
+    }
+
+    #[test]
+    fn test_validate_local_send_explicit_zone_beats_the_fallback() {
+        let input = serde_json::json!({ "enabled": true, "defaultTimeZone": "Asia/Tokyo" });
+        let normalized = validate_and_normalize_local_send(&input, "Europe/London")
+            .unwrap()
+            .unwrap();
+        assert_eq!(normalized["defaultTimeZone"], "Asia/Tokyo");
+    }
+
+    #[test]
+    fn test_validate_local_send_rejects_an_unusable_zone() {
+        for input in [
             serde_json::json!({ "enabled": true, "defaultTimeZone": "Not A Zone" }),
             serde_json::json!({ "enabled": true, "defaultTimeZone": "nozone" }),
         ] {
             assert!(
-                validate_and_normalize_local_send(&input).is_err(),
+                validate_and_normalize_local_send(&input, FALLBACK_ZONE).is_err(),
                 "{input}"
             );
         }
@@ -4604,6 +4660,7 @@ Thanks!"#;
         TenantSettings {
             timezone: timezone.to_string(),
             default_send_time: send_time.to_string(),
+            ..Default::default()
         }
     }
 

--- a/functions/src/api/controllers/issues.rs
+++ b/functions/src/api/controllers/issues.rs
@@ -582,16 +582,16 @@ async fn handle_resend_issue(
         ));
     }
 
-    start_issue_schedule(
-        &tenant_id,
-        user_context.email.as_str(),
-        issue.issue_number,
-        &issue.content,
-        None,
-        issue.template_id.as_deref(),
-        &normalize_content_type(issue.content_type.as_deref()),
-        &issue.subject,
-    )
+    start_issue_schedule(IssueScheduleInput {
+        tenant_id: &tenant_id,
+        tenant_email: user_context.email.as_str(),
+        issue_number: issue.issue_number,
+        content: &issue.content,
+        scheduled_at: None,
+        template_id: issue.template_id.as_deref(),
+        content_type: &normalize_content_type(issue.content_type.as_deref()),
+        subject: &issue.subject,
+    })
     .await?;
 
     response::format_response(
@@ -1902,9 +1902,11 @@ async fn handle_create_issue(event: Request) -> Result<Response<Body>, AppError>
         issue_number,
         &body,
         normalized_scheduled_at.clone(),
-        ab_test,
-        local_send,
-        content_assembly,
+        SendConfig {
+            ab_test,
+            local_send,
+            content_assembly,
+        },
         overwrite_draft,
     )
     .await?;
@@ -1920,16 +1922,16 @@ async fn handle_create_issue(event: Request) -> Result<Response<Body>, AppError>
     }
 
     if action == CreateIssueAction::Schedule {
-        start_issue_schedule(
-            &tenant_id,
-            user_context.email.as_str(),
+        start_issue_schedule(IssueScheduleInput {
+            tenant_id: &tenant_id,
+            tenant_email: user_context.email.as_str(),
             issue_number,
-            &body.content,
-            normalized_scheduled_at.as_deref(),
-            body.template_id.as_deref(),
-            &normalize_content_type(body.content_type.as_deref()),
-            &body.subject,
-        )
+            content: &body.content,
+            scheduled_at: normalized_scheduled_at.as_deref(),
+            template_id: body.template_id.as_deref(),
+            content_type: &normalize_content_type(body.content_type.as_deref()),
+            subject: &body.subject,
+        })
         .await?;
     } else if let Some(ttl_seconds) = body.ttl_seconds {
         schedule_draft_deletion(&tenant_id, issue_number, ttl_seconds).await?;
@@ -2051,12 +2053,14 @@ async fn handle_update_issue(
         &tenant_id,
         &issue_id,
         &body,
-        ab_test,
-        clear_ab_test,
-        local_send,
-        clear_local_send,
-        content_assembly,
-        clear_content_assembly,
+        SendConfigUpdate {
+            ab_test,
+            clear_ab_test,
+            local_send,
+            clear_local_send,
+            content_assembly,
+            clear_content_assembly,
+        },
     )
     .await?;
 
@@ -3629,16 +3633,33 @@ async fn save_idempotency_record(
     }
 }
 
-async fn start_issue_schedule(
-    tenant_id: &str,
-    tenant_email: &str,
+/// Everything the stage-issue state machine needs in its execution input.
+/// Grouped rather than passed positionally because several fields are bare
+/// `&str` — named struct fields make a transposed pair a compile error instead
+/// of an issue published under the wrong tenant.
+struct IssueScheduleInput<'a> {
+    tenant_id: &'a str,
+    tenant_email: &'a str,
     issue_number: i32,
-    content: &str,
-    scheduled_at: Option<&str>,
-    template_id: Option<&str>,
-    content_type: &str,
-    subject: &str,
-) -> Result<(), AppError> {
+    content: &'a str,
+    scheduled_at: Option<&'a str>,
+    template_id: Option<&'a str>,
+    content_type: &'a str,
+    subject: &'a str,
+}
+
+async fn start_issue_schedule(input: IssueScheduleInput<'_>) -> Result<(), AppError> {
+    let IssueScheduleInput {
+        tenant_id,
+        tenant_email,
+        issue_number,
+        content,
+        scheduled_at,
+        template_id,
+        content_type,
+        subject,
+    } = input;
+
     let sfn_client = aws_clients::get_sfn_client().await;
     let state_machine_arn = std::env::var("STATE_MACHINE_ARN")
         .map_err(|_| AppError::InternalError("STATE_MACHINE_ARN not set".to_string()))?;
@@ -3819,16 +3840,30 @@ async fn get_next_issue_number(tenant_id: &str) -> Result<i32, AppError> {
     Ok(max_issue_number + 1)
 }
 
+/// The per-issue send configuration. These three always travel together — the
+/// API extracts, validates and stores them as a set — so they are passed as
+/// one.
+#[derive(Default)]
+struct SendConfig {
+    ab_test: Option<serde_json::Value>,
+    local_send: Option<serde_json::Value>,
+    content_assembly: Option<serde_json::Value>,
+}
+
 async fn create_issue_record(
     tenant_id: &str,
     issue_number: i32,
     body: &CreateIssueRequest,
     scheduled_at: Option<String>,
-    ab_test: Option<serde_json::Value>,
-    local_send: Option<serde_json::Value>,
-    content_assembly: Option<serde_json::Value>,
+    send_config: SendConfig,
     overwrite_draft: bool,
 ) -> Result<CreateIssueResponse, AppError> {
+    let SendConfig {
+        ab_test,
+        local_send,
+        content_assembly,
+    } = send_config;
+
     let ddb_client = aws_clients::get_dynamodb_client().await;
     let table_name = std::env::var("TABLE_NAME")
         .map_err(|_| AppError::InternalError("TABLE_NAME not set".to_string()))?;
@@ -3938,17 +3973,34 @@ async fn create_issue_record(
     })
 }
 
-async fn update_issue_record(
-    tenant_id: &str,
-    issue_id: &str,
-    body: &UpdateIssueRequest,
+/// The same three configs on update, where each can also be explicitly
+/// cleared — a distinct case from "not mentioned in this request", which
+/// leaves the stored value alone.
+#[derive(Default)]
+struct SendConfigUpdate {
     ab_test: Option<serde_json::Value>,
     clear_ab_test: bool,
     local_send: Option<serde_json::Value>,
     clear_local_send: bool,
     content_assembly: Option<serde_json::Value>,
     clear_content_assembly: bool,
+}
+
+async fn update_issue_record(
+    tenant_id: &str,
+    issue_id: &str,
+    body: &UpdateIssueRequest,
+    send_config: SendConfigUpdate,
 ) -> Result<GetIssueResponse, AppError> {
+    let SendConfigUpdate {
+        ab_test,
+        clear_ab_test,
+        local_send,
+        clear_local_send,
+        content_assembly,
+        clear_content_assembly,
+    } = send_config;
+
     let ddb_client = aws_clients::get_dynamodb_client().await;
     let table_name = std::env::var("TABLE_NAME")
         .map_err(|_| AppError::InternalError("TABLE_NAME not set".to_string()))?;

--- a/functions/src/api/controllers/issues.rs
+++ b/functions/src/api/controllers/issues.rs
@@ -1822,7 +1822,7 @@ async fn handle_create_issue(event: Request) -> Result<Response<Body>, AppError>
                 &body,
                 existing.issue_number,
                 action,
-                normalized_scheduled_at.as_deref(),
+                body.scheduled_at.as_deref(),
                 raw_ab_test.as_ref(),
                 raw_local_send.as_ref(),
                 raw_content_assembly.as_ref(),
@@ -1890,7 +1890,7 @@ async fn handle_create_issue(event: Request) -> Result<Response<Body>, AppError>
             &body,
             issue_number,
             action,
-            normalized_scheduled_at.as_deref(),
+            body.scheduled_at.as_deref(),
             raw_ab_test.as_ref(),
             raw_local_send.as_ref(),
             raw_content_assembly.as_ref(),
@@ -3417,15 +3417,19 @@ fn resolve_scheduled_at(
 
 /// Hashes everything that determines what a create request does, so a reused
 /// Idempotency-Key with any behavioral change is rejected instead of replayed.
-/// The send-config values (`abTest`, `localSend`, `contentAssembly`) are the
-/// raw caller-supplied objects, not the normalized forms: normalization
-/// injects server-generated values (e.g. the A/B `testId`), which would make
-/// byte-identical replays hash differently.
+///
+/// Every value here is the raw caller-supplied one, never the normalized form.
+/// Normalization folds in things the caller didn't send: server-generated
+/// values (the A/B `testId`), the current time (a `scheduledAt` that has since
+/// passed), and tenant settings (a date-only `scheduledAt` resolves against
+/// the tenant's timezone and send time). Hashing any of those would make a
+/// byte-identical replay look like a different request — so changing the
+/// tenant's timezone would turn a CI re-run of the same commit into a 409.
 fn compute_idempotency_hash(
     body: &CreateIssueRequest,
     issue_number: i32,
     action: CreateIssueAction,
-    scheduled_at: Option<&str>,
+    raw_scheduled_at: Option<&str>,
     ab_test: Option<&serde_json::Value>,
     local_send: Option<&serde_json::Value>,
     content_assembly: Option<&serde_json::Value>,
@@ -3438,7 +3442,7 @@ fn compute_idempotency_hash(
             CreateIssueAction::Draft => "draft",
             CreateIssueAction::Schedule => "schedule",
         },
-        "scheduledAt": scheduled_at,
+        "scheduledAt": raw_scheduled_at,
         "metadata": body.metadata.clone(),
         "templateId": body.template_id.clone(),
         "contentType": normalize_content_type(body.content_type.as_deref()),
@@ -5807,6 +5811,65 @@ Thanks!"#;
         );
 
         assert_eq!(first, second);
+    }
+
+    #[test]
+    fn test_compute_idempotency_hash_survives_a_tenant_settings_change() {
+        // The hash covers the caller's date-only value, not the instant it
+        // resolves to. A tenant editing their timezone or send time between a
+        // request and its retry must not turn a byte-identical replay into a
+        // 409 — which is exactly what hashing the resolved instant would do.
+        let request = create_request("# Test Content", None, None);
+
+        let before = compute_idempotency_hash(
+            &request,
+            7,
+            CreateIssueAction::Schedule,
+            Some("2026-08-01"),
+            None,
+            None,
+            None,
+        );
+        let after = compute_idempotency_hash(
+            &request,
+            7,
+            CreateIssueAction::Schedule,
+            Some("2026-08-01"),
+            None,
+            None,
+            None,
+        );
+
+        assert_eq!(before, after);
+
+        // Sanity check that the field still participates at all: a different
+        // date is still a different request.
+        let other_date = compute_idempotency_hash(
+            &request,
+            7,
+            CreateIssueAction::Schedule,
+            Some("2026-08-02"),
+            None,
+            None,
+            None,
+        );
+        assert_ne!(before, other_date);
+    }
+
+    #[test]
+    fn test_resolve_scheduled_at_varies_with_settings_the_hash_ignores() {
+        // The other half of the guarantee above: the same date-only value
+        // genuinely does resolve to different instants under different
+        // settings, so hashing the resolved form would have been unstable.
+        let date = format!("{}-08-01", future_year());
+
+        let chicago =
+            resolve_scheduled_at(Some(&date), &tenant_settings("America/Chicago", "09:00"))
+                .unwrap();
+        let tokyo =
+            resolve_scheduled_at(Some(&date), &tenant_settings("Asia/Tokyo", "09:00")).unwrap();
+
+        assert_ne!(chicago, tokyo);
     }
 
     #[test]

--- a/functions/src/api/controllers/mod.rs
+++ b/functions/src/api/controllers/mod.rs
@@ -8,6 +8,7 @@ pub mod profile;
 pub mod reports;
 pub mod segments;
 pub mod senders;
+pub mod settings;
 pub mod snippets;
 pub mod sponsors;
 pub mod subscribers;

--- a/functions/src/api/controllers/settings.rs
+++ b/functions/src/api/controllers/settings.rs
@@ -114,9 +114,22 @@ struct SettingsResponse {
     /// The system defaults, so the dashboard can mark which effective values
     /// are inherited rather than chosen.
     defaults: TenantSettings,
+    /// Which settings the tenant has explicitly chosen. `settings` alone can't
+    /// answer that — a stored `UTC` and an unset timezone look identical — and
+    /// the dashboard needs the difference to offer a better suggestion than the
+    /// system default (e.g. the viewer's own timezone).
+    configured: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     updated_at: Option<String>,
 }
+
+/// Every setting name this endpoint recognizes, in display order.
+const SETTING_NAMES: [&str; 4] = [
+    "timezone",
+    "defaultSendTime",
+    "subjectTemplate",
+    "issueUrlPattern",
+];
 
 /// One update to one settings attribute. `None` is an explicit reset back to
 /// the system default (`"timezone": null` in the request body).
@@ -506,8 +519,30 @@ fn build_response(
     SettingsResponse {
         settings: settings_from_item(item.as_ref()),
         defaults: TenantSettings::default(),
+        configured: configured_settings(item.as_ref()),
         updated_at,
     }
+}
+
+/// The settings actually present on the record, so a value the tenant chose is
+/// distinguishable from one that happens to equal the system default.
+fn configured_settings(
+    item: Option<&std::collections::HashMap<String, AttributeValue>>,
+) -> Vec<String> {
+    let Some(item) = item else {
+        return Vec::new();
+    };
+
+    SETTING_NAMES
+        .iter()
+        .filter(|name| {
+            item.get(**name)
+                .and_then(|value| value.as_s().ok())
+                .map(|value| !value.trim().is_empty())
+                .unwrap_or(false)
+        })
+        .map(|name| name.to_string())
+        .collect()
 }
 
 /// Applies the changes with a single UpdateItem so settings the request didn't
@@ -911,5 +946,39 @@ mod tests {
         let response = build_response(None);
         assert!(response.updated_at.is_none());
         assert_eq!(response.settings, TenantSettings::default());
+        assert!(response.configured.is_empty());
+    }
+
+    #[test]
+    fn configured_lists_only_the_settings_the_tenant_chose() {
+        let mut item = std::collections::HashMap::new();
+        item.insert(
+            "defaultSendTime".to_string(),
+            AttributeValue::S("07:30".to_string()),
+        );
+        // A blank attribute is not a choice.
+        item.insert("timezone".to_string(), AttributeValue::S("".to_string()));
+        item.insert(
+            "updatedAt".to_string(),
+            AttributeValue::S("2026-07-25T00:00:00Z".to_string()),
+        );
+
+        let response = build_response(Some(item));
+
+        // The tenant saved a send time but never picked a zone, even though
+        // the effective timezone reads as the system default either way.
+        assert_eq!(response.configured, vec!["defaultSendTime".to_string()]);
+        assert_eq!(response.settings.timezone, DEFAULT_TIMEZONE);
+    }
+
+    #[test]
+    fn configured_reports_a_timezone_that_matches_the_system_default() {
+        // Explicitly choosing UTC is a choice, and must not be reported as an
+        // unset value the dashboard is free to replace with a suggestion.
+        let mut item = std::collections::HashMap::new();
+        item.insert("timezone".to_string(), AttributeValue::S("UTC".to_string()));
+
+        let response = build_response(Some(item));
+        assert_eq!(response.configured, vec!["timezone".to_string()]);
     }
 }

--- a/functions/src/api/controllers/settings.rs
+++ b/functions/src/api/controllers/settings.rs
@@ -1,12 +1,22 @@
 //! Tenant-level settings: the defaults the platform falls back to when a
 //! request doesn't spell a value out.
 //!
-//! Two settings live here today:
+//! The settings that live here today:
 //!
 //! - `timezone` — the tenant's wall-clock zone. It is what the dashboard
 //!   formats dates in, and the zone a date-only send is read against.
 //! - `defaultSendTime` — the time of day (in `timezone`) a send lands on when
 //!   the caller supplied a date but no time.
+//! - `subjectTemplate` — how an email subject is built when the request that
+//!   staged the issue didn't supply one (the markdown/GitHub path never does).
+//! - `issueUrlPattern` — where an issue lives on the tenant's own site, used
+//!   for the "view online" link in the email.
+//!
+//! The first two have system defaults; the last two do not. An unset
+//! `subjectTemplate` means "use the issue title", and an unset
+//! `issueUrlPattern` means "there is no public URL, omit the link" — for both,
+//! guessing a value would put the wrong words or the wrong domain in front of
+//! somebody's subscribers.
 //!
 //! Both are stored on a single `pk = {tenantId}`, `sk = "settings"` record.
 //! An absent record — or an absent attribute on it — means "use the system
@@ -36,6 +46,20 @@ pub(crate) const DEFAULT_TIMEZONE: &str = "UTC";
 /// midnight that a small zone mistake doesn't move the send to another day.
 pub(crate) const DEFAULT_SEND_TIME: &str = "09:00";
 
+/// Subject lines are capped by the create API at 200 characters; the template
+/// gets headroom for the tokens it expands.
+const SUBJECT_TEMPLATE_MAX_LEN: usize = 300;
+
+const URL_PATTERN_MAX_LEN: usize = 500;
+
+/// Tokens `subjectTemplate` may reference. Validated on write so a typo is
+/// caught in the settings form rather than shipping literally in a subject
+/// line. Kept in step with `buildSubject` in `functions/utils/tenant-settings.mjs`.
+const SUBJECT_TOKENS: [&str; 3] = ["title", "number", "date"];
+
+/// Tokens `issueUrlPattern` may reference.
+const URL_TOKENS: [&str; 1] = ["number"];
+
 // ── Data types ─────────────────────────────────────────────────────────
 
 /// The effective settings for a tenant: stored values where present, system
@@ -45,6 +69,14 @@ pub(crate) const DEFAULT_SEND_TIME: &str = "09:00";
 pub(crate) struct TenantSettings {
     pub timezone: String,
     pub default_send_time: String,
+    /// Absent when the tenant hasn't chosen one — there is no sensible system
+    /// default for somebody else's subject line.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subject_template: Option<String>,
+    /// Absent when the tenant hasn't chosen one, in which case the email omits
+    /// its "view online" link rather than pointing at the wrong site.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub issue_url_pattern: Option<String>,
 }
 
 impl Default for TenantSettings {
@@ -52,6 +84,8 @@ impl Default for TenantSettings {
         Self {
             timezone: DEFAULT_TIMEZONE.to_string(),
             default_send_time: DEFAULT_SEND_TIME.to_string(),
+            subject_template: None,
+            issue_url_pattern: None,
         }
     }
 }
@@ -169,6 +203,24 @@ fn extract_changes(body: &Value) -> Result<Vec<SettingChange>, AppError> {
         });
     }
 
+    if let Some(value) = map.get("subjectTemplate") {
+        changes.push(SettingChange {
+            attribute: "subjectTemplate",
+            value: optional_string("subjectTemplate", value)?
+                .map(|template| validate_subject_template(&template))
+                .transpose()?,
+        });
+    }
+
+    if let Some(value) = map.get("issueUrlPattern") {
+        changes.push(SettingChange {
+            attribute: "issueUrlPattern",
+            value: optional_string("issueUrlPattern", value)?
+                .map(|pattern| validate_issue_url_pattern(&pattern))
+                .transpose()?,
+        });
+    }
+
     Ok(changes)
 }
 
@@ -227,6 +279,97 @@ fn parse_send_time(value: &str) -> Result<NaiveTime, AppError> {
     let minutes: u32 = minutes.parse().map_err(|_| invalid())?;
 
     NaiveTime::from_hms_opt(hours, minutes, 0).ok_or_else(invalid)
+}
+
+/// Validates a subject template. The hard rule is no CR/LF: a subject line is
+/// an email header, and a newline in one is header injection. Everything else
+/// is a guard against a template that would obviously misbehave at send time.
+fn validate_subject_template(value: &str) -> Result<String, AppError> {
+    if value.len() > SUBJECT_TEMPLATE_MAX_LEN {
+        return Err(AppError::BadRequest(format!(
+            "subjectTemplate must be {} characters or fewer",
+            SUBJECT_TEMPLATE_MAX_LEN
+        )));
+    }
+
+    if value.chars().any(|c| c.is_control()) {
+        return Err(AppError::BadRequest(
+            "subjectTemplate must not contain line breaks or control characters".to_string(),
+        ));
+    }
+
+    validate_tokens("subjectTemplate", value, &SUBJECT_TOKENS)?;
+
+    Ok(value.to_string())
+}
+
+/// Validates the public issue URL pattern. It ends up as an `href` in every
+/// subscriber's inbox, so it must be an absolute http(s) URL, and it must vary
+/// per issue or every issue would link to the same page.
+fn validate_issue_url_pattern(value: &str) -> Result<String, AppError> {
+    if value.len() > URL_PATTERN_MAX_LEN {
+        return Err(AppError::BadRequest(format!(
+            "issueUrlPattern must be {} characters or fewer",
+            URL_PATTERN_MAX_LEN
+        )));
+    }
+
+    if !value.starts_with("https://") && !value.starts_with("http://") {
+        return Err(AppError::BadRequest(
+            "issueUrlPattern must be an absolute http:// or https:// URL".to_string(),
+        ));
+    }
+
+    if value.chars().any(|c| c.is_control() || c.is_whitespace()) {
+        return Err(AppError::BadRequest(
+            "issueUrlPattern must not contain whitespace or control characters".to_string(),
+        ));
+    }
+
+    validate_tokens("issueUrlPattern", value, &URL_TOKENS)?;
+
+    if !value.contains("{{number}}") {
+        return Err(AppError::BadRequest(
+            "issueUrlPattern must include {{number}} so each issue links to its own page"
+                .to_string(),
+        ));
+    }
+
+    Ok(value.to_string())
+}
+
+/// Rejects `{{token}}` placeholders the renderer doesn't know about. An
+/// unknown token would otherwise reach subscribers verbatim, braces and all.
+fn validate_tokens(field: &str, value: &str, allowed: &[&str]) -> Result<(), AppError> {
+    let mut rest = value;
+
+    while let Some(start) = rest.find("{{") {
+        let after = &rest[start + 2..];
+        let Some(end) = after.find("}}") else {
+            return Err(AppError::BadRequest(format!(
+                "{} has an unclosed {{{{ placeholder",
+                field
+            )));
+        };
+
+        let token = after[..end].trim();
+        if !allowed.contains(&token) {
+            return Err(AppError::BadRequest(format!(
+                "{} does not support the placeholder {{{{{}}}}} — available: {}",
+                field,
+                token,
+                allowed
+                    .iter()
+                    .map(|t| format!("{{{{{}}}}}", t))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )));
+        }
+
+        rest = &after[end + 2..];
+    }
+
+    Ok(())
 }
 
 // ── Date-only resolution ───────────────────────────────────────────────
@@ -346,6 +489,8 @@ fn settings_from_item(
     TenantSettings {
         timezone: read("timezone").unwrap_or(defaults.timezone),
         default_send_time: read("defaultSendTime").unwrap_or(defaults.default_send_time),
+        subject_template: read("subjectTemplate"),
+        issue_url_pattern: read("issueUrlPattern"),
     }
 }
 
@@ -436,6 +581,7 @@ mod tests {
         TenantSettings {
             timezone: timezone.to_string(),
             default_send_time: send_time.to_string(),
+            ..Default::default()
         }
     }
 
@@ -519,6 +665,123 @@ mod tests {
         // The handler turns this into a 400 rather than a no-op write.
         let changes = extract_changes(&json!({ "somethingElse": "x" })).unwrap();
         assert!(changes.is_empty());
+    }
+
+    #[test]
+    fn validate_subject_template_accepts_supported_tokens() {
+        assert_eq!(
+            validate_subject_template("{{title}} | Weekly #{{number}}").unwrap(),
+            "{{title}} | Weekly #{{number}}"
+        );
+        assert_eq!(
+            validate_subject_template("{{ title }} — {{ date }}").unwrap(),
+            "{{ title }} — {{ date }}"
+        );
+        // A template with no tokens at all is a fixed subject line, which is
+        // odd but not wrong.
+        assert_eq!(
+            validate_subject_template("This week's issue").unwrap(),
+            "This week's issue"
+        );
+    }
+
+    #[test]
+    fn validate_subject_template_rejects_header_injection() {
+        // A newline in a subject is a second email header. This is the one
+        // rule here that is a security boundary, not a nicety.
+        assert!(validate_subject_template("Hi\r\nBcc: someone@example.com").is_err());
+        assert!(validate_subject_template("Hi\nX-Spoof: yes").is_err());
+        assert!(validate_subject_template("Hi\u{0}there").is_err());
+    }
+
+    #[test]
+    fn validate_subject_template_rejects_unknown_and_unclosed_tokens() {
+        // {{brand}} would otherwise reach subscribers with the braces intact.
+        assert!(validate_subject_template("{{title}} from {{brand}}").is_err());
+        assert!(validate_subject_template("{{title").is_err());
+    }
+
+    #[test]
+    fn validate_subject_template_rejects_overlong_values() {
+        assert!(validate_subject_template(&"x".repeat(SUBJECT_TEMPLATE_MAX_LEN + 1)).is_err());
+    }
+
+    #[test]
+    fn validate_issue_url_pattern_accepts_an_absolute_per_issue_url() {
+        assert_eq!(
+            validate_issue_url_pattern("https://example.com/newsletter/{{number}}").unwrap(),
+            "https://example.com/newsletter/{{number}}"
+        );
+        assert_eq!(
+            validate_issue_url_pattern("http://localhost:3000/issues/{{number}}").unwrap(),
+            "http://localhost:3000/issues/{{number}}"
+        );
+    }
+
+    #[test]
+    fn validate_issue_url_pattern_requires_an_absolute_http_url() {
+        // This value becomes an href in every subscriber's inbox, so a
+        // relative path or a javascript: scheme is not acceptable.
+        assert!(validate_issue_url_pattern("/newsletter/{{number}}").is_err());
+        assert!(validate_issue_url_pattern("example.com/{{number}}").is_err());
+        assert!(validate_issue_url_pattern("javascript:alert(1){{number}}").is_err());
+    }
+
+    #[test]
+    fn validate_issue_url_pattern_requires_the_number_token() {
+        // Without it every issue would link to the same page.
+        assert!(validate_issue_url_pattern("https://example.com/newsletter").is_err());
+    }
+
+    #[test]
+    fn validate_issue_url_pattern_rejects_whitespace_and_unknown_tokens() {
+        assert!(validate_issue_url_pattern("https://example.com/a b/{{number}}").is_err());
+        assert!(validate_issue_url_pattern("https://example.com/{{slug}}/{{number}}").is_err());
+    }
+
+    #[test]
+    fn extract_changes_covers_every_recognized_setting() {
+        let changes = extract_changes(&json!({
+            "timezone": "UTC",
+            "defaultSendTime": "09:00",
+            "subjectTemplate": "{{title}}",
+            "issueUrlPattern": "https://example.com/n/{{number}}"
+        }))
+        .unwrap();
+
+        assert_eq!(changes.len(), 4);
+    }
+
+    #[test]
+    fn settings_from_item_reads_the_optional_settings() {
+        let mut item = std::collections::HashMap::new();
+        item.insert(
+            "subjectTemplate".to_string(),
+            AttributeValue::S("{{title}} #{{number}}".to_string()),
+        );
+        item.insert(
+            "issueUrlPattern".to_string(),
+            AttributeValue::S("https://example.com/n/{{number}}".to_string()),
+        );
+
+        let resolved = settings_from_item(Some(&item));
+        assert_eq!(
+            resolved.subject_template.as_deref(),
+            Some("{{title}} #{{number}}")
+        );
+        assert_eq!(
+            resolved.issue_url_pattern.as_deref(),
+            Some("https://example.com/n/{{number}}")
+        );
+    }
+
+    #[test]
+    fn optional_settings_have_no_system_default() {
+        // Unlike timezone and send time, these two stay None: guessing a
+        // subject line or a domain would be worse than omitting them.
+        let defaults = TenantSettings::default();
+        assert!(defaults.subject_template.is_none());
+        assert!(defaults.issue_url_pattern.is_none());
     }
 
     #[test]

--- a/functions/src/api/controllers/settings.rs
+++ b/functions/src/api/controllers/settings.rs
@@ -1,0 +1,652 @@
+//! Tenant-level settings: the defaults the platform falls back to when a
+//! request doesn't spell a value out.
+//!
+//! Two settings live here today:
+//!
+//! - `timezone` — the tenant's wall-clock zone. It is what the dashboard
+//!   formats dates in, and the zone a date-only send is read against.
+//! - `defaultSendTime` — the time of day (in `timezone`) a send lands on when
+//!   the caller supplied a date but no time.
+//!
+//! Both are stored on a single `pk = {tenantId}`, `sk = "settings"` record.
+//! An absent record — or an absent attribute on it — means "use the system
+//! default", so a tenant that never opens the settings page still gets
+//! well-defined behavior ([`TenantSettings::default`]).
+
+use aws_sdk_dynamodb::types::AttributeValue;
+use chrono::{DateTime, LocalResult, NaiveDate, NaiveTime, TimeZone, Utc};
+use chrono_tz::Tz;
+use lambda_http::{Body, Error, Request, Response};
+use newsletter::admin::{auth, aws_clients, error::AppError, response};
+use serde::Serialize;
+use serde_json::Value;
+use std::env;
+
+// ── Constants ──────────────────────────────────────────────────────────
+
+const SETTINGS_SK: &str = "settings";
+
+/// Used for both display formatting and date-only send resolution until the
+/// tenant picks a zone. UTC keeps the pre-settings behavior (bare ISO strings
+/// were already read as UTC) intact for tenants that never configure one.
+pub(crate) const DEFAULT_TIMEZONE: &str = "UTC";
+
+/// Where a date-only send lands when the tenant hasn't chosen a time. Morning
+/// local time is the common newsletter slot, and it is far enough from
+/// midnight that a small zone mistake doesn't move the send to another day.
+pub(crate) const DEFAULT_SEND_TIME: &str = "09:00";
+
+// ── Data types ─────────────────────────────────────────────────────────
+
+/// The effective settings for a tenant: stored values where present, system
+/// defaults everywhere else. Callers never have to deal with `None`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TenantSettings {
+    pub timezone: String,
+    pub default_send_time: String,
+}
+
+impl Default for TenantSettings {
+    fn default() -> Self {
+        Self {
+            timezone: DEFAULT_TIMEZONE.to_string(),
+            default_send_time: DEFAULT_SEND_TIME.to_string(),
+        }
+    }
+}
+
+impl TenantSettings {
+    /// The tenant's zone, falling back to UTC if a stored value is somehow
+    /// unparseable. Resolution must not fail on data that was already
+    /// validated on the way in.
+    pub(crate) fn timezone(&self) -> Tz {
+        self.timezone.parse().unwrap_or(chrono_tz::UTC)
+    }
+
+    /// The tenant's default send time, falling back to the system default for
+    /// the same reason as [`Self::timezone`].
+    pub(crate) fn send_time(&self) -> NaiveTime {
+        parse_send_time(&self.default_send_time)
+            .unwrap_or_else(|_| parse_send_time(DEFAULT_SEND_TIME).expect("valid default"))
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SettingsResponse {
+    /// Effective settings — what the platform will actually use.
+    settings: TenantSettings,
+    /// The system defaults, so the dashboard can mark which effective values
+    /// are inherited rather than chosen.
+    defaults: TenantSettings,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    updated_at: Option<String>,
+}
+
+/// One update to one settings attribute. `None` is an explicit reset back to
+/// the system default (`"timezone": null` in the request body).
+struct SettingChange {
+    attribute: &'static str,
+    value: Option<String>,
+}
+
+// ── Handlers ───────────────────────────────────────────────────────────
+
+pub async fn get_settings(event: Request) -> Result<Response<Body>, Error> {
+    match handle_get_settings(event).await {
+        Ok(response) => Ok(response),
+        Err(e) => Ok(response::format_error_response(&e)),
+    }
+}
+
+async fn handle_get_settings(event: Request) -> Result<Response<Body>, AppError> {
+    let tenant_id = require_tenant(&event)?;
+    let record = get_settings_item(&tenant_id).await?;
+
+    response::format_response(200, build_response(record))
+}
+
+pub async fn update_settings(event: Request) -> Result<Response<Body>, Error> {
+    match handle_update_settings(event).await {
+        Ok(response) => Ok(response),
+        Err(e) => Ok(response::format_error_response(&e)),
+    }
+}
+
+async fn handle_update_settings(event: Request) -> Result<Response<Body>, AppError> {
+    let tenant_id = require_tenant(&event)?;
+
+    let body: Value = if event.body().is_empty() {
+        Value::Object(Default::default())
+    } else {
+        serde_json::from_slice(event.body())
+            .map_err(|e| AppError::BadRequest(format!("Invalid JSON: {}", e)))?
+    };
+
+    let changes = extract_changes(&body)?;
+    if changes.is_empty() {
+        return Err(AppError::BadRequest(
+            "At least one setting must be provided".to_string(),
+        ));
+    }
+
+    let updated_at = Utc::now().to_rfc3339();
+    write_settings(&tenant_id, &changes, &updated_at).await?;
+
+    let record = get_settings_item(&tenant_id).await?;
+    response::format_response(200, build_response(record))
+}
+
+// ── Validation ─────────────────────────────────────────────────────────
+
+/// Pulls the recognized settings out of a request body. A key that is present
+/// with a `null` value is a reset; a key that is absent is left alone.
+fn extract_changes(body: &Value) -> Result<Vec<SettingChange>, AppError> {
+    let Value::Object(map) = body else {
+        return Err(AppError::BadRequest(
+            "Request body must be a JSON object".to_string(),
+        ));
+    };
+
+    let mut changes = Vec::new();
+
+    if let Some(value) = map.get("timezone") {
+        changes.push(SettingChange {
+            attribute: "timezone",
+            value: optional_string("timezone", value)?
+                .map(|tz| validate_timezone(&tz))
+                .transpose()?,
+        });
+    }
+
+    if let Some(value) = map.get("defaultSendTime") {
+        changes.push(SettingChange {
+            attribute: "defaultSendTime",
+            value: optional_string("defaultSendTime", value)?
+                .map(|time| validate_send_time(&time))
+                .transpose()?,
+        });
+    }
+
+    Ok(changes)
+}
+
+/// Accepts a string, `null`, or an empty string. The latter two both mean
+/// "clear this setting" — an empty select in the dashboard shouldn't be stored
+/// as an empty timezone.
+fn optional_string(field: &str, value: &Value) -> Result<Option<String>, AppError> {
+    match value {
+        Value::Null => Ok(None),
+        Value::String(s) if s.trim().is_empty() => Ok(None),
+        Value::String(s) => Ok(Some(s.trim().to_string())),
+        _ => Err(AppError::BadRequest(format!(
+            "{} must be a string or null",
+            field
+        ))),
+    }
+}
+
+/// Validates an IANA zone name against the bundled tz database and returns it
+/// in its canonical form, so `utc` and `UTC` don't produce two spellings of
+/// the same zone in storage.
+fn validate_timezone(value: &str) -> Result<String, AppError> {
+    let tz: Tz = value.parse().map_err(|_| {
+        AppError::BadRequest(format!(
+            "timezone must be a valid IANA timezone name (e.g. America/Chicago), got '{}'",
+            value
+        ))
+    })?;
+
+    Ok(tz.name().to_string())
+}
+
+/// Validates a 24-hour `HH:MM` time of day and returns it zero-padded, so
+/// `9:05` and `09:05` don't produce two spellings of the same time.
+fn validate_send_time(value: &str) -> Result<String, AppError> {
+    let time = parse_send_time(value)?;
+    Ok(time.format("%H:%M").to_string())
+}
+
+fn parse_send_time(value: &str) -> Result<NaiveTime, AppError> {
+    let invalid = || {
+        AppError::BadRequest(format!(
+            "defaultSendTime must be a 24-hour HH:MM time, got '{}'",
+            value
+        ))
+    };
+
+    let (hours, minutes) = value.split_once(':').ok_or_else(invalid)?;
+    // `%H:%M` alone would accept "9:5"; requiring digit-only components of the
+    // right length keeps the stored form unambiguous.
+    if hours.len() > 2 || hours.is_empty() || minutes.len() != 2 {
+        return Err(invalid());
+    }
+
+    let hours: u32 = hours.parse().map_err(|_| invalid())?;
+    let minutes: u32 = minutes.parse().map_err(|_| invalid())?;
+
+    NaiveTime::from_hms_opt(hours, minutes, 0).ok_or_else(invalid)
+}
+
+// ── Date-only resolution ───────────────────────────────────────────────
+
+/// True when a schedule value carries a date but no time (`YYYY-MM-DD`) and so
+/// needs the tenant's default send time to become an instant.
+pub(crate) fn is_date_only(value: &str) -> bool {
+    NaiveDate::parse_from_str(value, "%Y-%m-%d").is_ok()
+}
+
+/// Turns a bare `YYYY-MM-DD` into an instant: the tenant's default send time
+/// on that date, read as a wall-clock time in the tenant's timezone.
+///
+/// Daylight-saving transitions make that wall-clock time either ambiguous
+/// (it happens twice) or nonexistent (it is skipped). Both are resolved
+/// forward — the earlier of two candidates, or the first valid minute after a
+/// gap — so a scheduled send always lands on the requested day and never
+/// before the time the tenant asked for.
+pub(crate) fn resolve_date_only(
+    value: &str,
+    settings: &TenantSettings,
+) -> Result<DateTime<Utc>, AppError> {
+    let date = NaiveDate::parse_from_str(value, "%Y-%m-%d")
+        .map_err(|_| AppError::BadRequest(format!("'{}' is not a valid date", value)))?;
+
+    let tz = settings.timezone();
+    let naive = date.and_time(settings.send_time());
+
+    let local = match tz.from_local_datetime(&naive) {
+        LocalResult::Single(dt) => dt,
+        LocalResult::Ambiguous(earlier, _) => earlier,
+        LocalResult::None => {
+            // Spring-forward gap: walk forward a minute at a time to the first
+            // wall-clock time that exists. Gaps are at most a couple of hours.
+            let mut candidate = naive;
+            loop {
+                candidate += chrono::Duration::minutes(1);
+                if candidate.date() != naive.date() {
+                    return Err(AppError::InternalError(format!(
+                        "Could not resolve {} in timezone {}",
+                        naive,
+                        tz.name()
+                    )));
+                }
+                if let Some(resolved) = tz.from_local_datetime(&candidate).earliest() {
+                    break resolved;
+                }
+            }
+        }
+    };
+
+    Ok(local.with_timezone(&Utc))
+}
+
+// ── Persistence ────────────────────────────────────────────────────────
+
+fn require_tenant(event: &Request) -> Result<String, AppError> {
+    let user_context = auth::get_user_context(event)?;
+    user_context
+        .tenant_id
+        .ok_or_else(|| AppError::Unauthorized("Tenant access required".to_string()))
+}
+
+fn table_name() -> Result<String, AppError> {
+    env::var("TABLE_NAME")
+        .map_err(|_| AppError::InternalError("TABLE_NAME not configured".to_string()))
+}
+
+/// Reads the raw settings record. `None` means the tenant has never saved
+/// settings, which is not an error — it just means every value is inherited.
+async fn get_settings_item(
+    tenant_id: &str,
+) -> Result<Option<std::collections::HashMap<String, AttributeValue>>, AppError> {
+    let client = aws_clients::get_dynamodb_client().await;
+
+    let result = client
+        .get_item()
+        .table_name(table_name()?)
+        .key("pk", AttributeValue::S(tenant_id.to_string()))
+        .key("sk", AttributeValue::S(SETTINGS_SK.to_string()))
+        .send()
+        .await
+        .map_err(|e| AppError::AwsError(format!("Failed to load settings: {}", e)))?;
+
+    Ok(result.item)
+}
+
+/// The canonical settings read used by anything that needs a tenant default
+/// (see [`super::issues`]). Never fails the caller: a settings read that errors
+/// falls back to the system defaults rather than blocking the operation the
+/// tenant actually asked for.
+pub(crate) async fn get_tenant_settings(tenant_id: &str) -> TenantSettings {
+    match get_settings_item(tenant_id).await {
+        Ok(item) => settings_from_item(item.as_ref()),
+        Err(e) => {
+            tracing::warn!(error = %e, tenant_id = %tenant_id, "Falling back to default settings");
+            TenantSettings::default()
+        }
+    }
+}
+
+fn settings_from_item(
+    item: Option<&std::collections::HashMap<String, AttributeValue>>,
+) -> TenantSettings {
+    let defaults = TenantSettings::default();
+    let Some(item) = item else {
+        return defaults;
+    };
+
+    let read = |key: &str| {
+        item.get(key)
+            .and_then(|value| value.as_s().ok())
+            .map(|value| value.to_string())
+            .filter(|value| !value.trim().is_empty())
+    };
+
+    TenantSettings {
+        timezone: read("timezone").unwrap_or(defaults.timezone),
+        default_send_time: read("defaultSendTime").unwrap_or(defaults.default_send_time),
+    }
+}
+
+fn build_response(
+    item: Option<std::collections::HashMap<String, AttributeValue>>,
+) -> SettingsResponse {
+    let updated_at = item.as_ref().and_then(|item| {
+        item.get("updatedAt")
+            .and_then(|value| value.as_s().ok())
+            .map(|value| value.to_string())
+    });
+
+    SettingsResponse {
+        settings: settings_from_item(item.as_ref()),
+        defaults: TenantSettings::default(),
+        updated_at,
+    }
+}
+
+/// Applies the changes with a single UpdateItem so settings the request didn't
+/// mention are left untouched, and a reset removes the attribute entirely
+/// (rather than storing the system default, which would freeze the tenant on
+/// today's default if it ever changes).
+async fn write_settings(
+    tenant_id: &str,
+    changes: &[SettingChange],
+    updated_at: &str,
+) -> Result<(), AppError> {
+    let client = aws_clients::get_dynamodb_client().await;
+
+    let mut sets = vec!["#updatedAt = :updatedAt".to_string()];
+    let mut removes = Vec::new();
+    let mut names = vec![("#updatedAt".to_string(), "updatedAt".to_string())];
+    let mut values = vec![(
+        ":updatedAt".to_string(),
+        AttributeValue::S(updated_at.to_string()),
+    )];
+
+    for change in changes {
+        let placeholder = format!("#{}", change.attribute);
+        names.push((placeholder.clone(), change.attribute.to_string()));
+
+        match &change.value {
+            Some(value) => {
+                let value_placeholder = format!(":{}", change.attribute);
+                sets.push(format!("{} = {}", placeholder, value_placeholder));
+                values.push((value_placeholder, AttributeValue::S(value.clone())));
+            }
+            None => removes.push(placeholder),
+        }
+    }
+
+    let mut expression = format!("SET {}", sets.join(", "));
+    if !removes.is_empty() {
+        expression.push_str(&format!(" REMOVE {}", removes.join(", ")));
+    }
+
+    let mut request = client
+        .update_item()
+        .table_name(table_name()?)
+        .key("pk", AttributeValue::S(tenant_id.to_string()))
+        .key("sk", AttributeValue::S(SETTINGS_SK.to_string()))
+        .update_expression(expression);
+
+    for (placeholder, name) in names {
+        request = request.expression_attribute_names(placeholder, name);
+    }
+    for (placeholder, value) in values {
+        request = request.expression_attribute_values(placeholder, value);
+    }
+
+    request
+        .send()
+        .await
+        .map_err(|e| AppError::AwsError(format!("Failed to save settings: {}", e)))?;
+
+    Ok(())
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn settings(timezone: &str, send_time: &str) -> TenantSettings {
+        TenantSettings {
+            timezone: timezone.to_string(),
+            default_send_time: send_time.to_string(),
+        }
+    }
+
+    #[test]
+    fn defaults_are_utc_at_nine() {
+        let defaults = TenantSettings::default();
+        assert_eq!(defaults.timezone, "UTC");
+        assert_eq!(defaults.default_send_time, "09:00");
+    }
+
+    #[test]
+    fn validate_timezone_accepts_iana_names() {
+        assert_eq!(
+            validate_timezone("America/Chicago").unwrap(),
+            "America/Chicago"
+        );
+        assert_eq!(validate_timezone("UTC").unwrap(), "UTC");
+    }
+
+    #[test]
+    fn validate_timezone_rejects_offsets_and_abbreviations() {
+        // Offsets drift with DST and abbreviations are ambiguous, so neither is
+        // a usable basis for "9am local time on this date".
+        assert!(validate_timezone("-05:00").is_err());
+        assert!(validate_timezone("CST").is_err());
+        assert!(validate_timezone("Not/AZone").is_err());
+    }
+
+    #[test]
+    fn validate_send_time_zero_pads() {
+        assert_eq!(validate_send_time("9:05").unwrap(), "09:05");
+        assert_eq!(validate_send_time("09:05").unwrap(), "09:05");
+        assert_eq!(validate_send_time("23:59").unwrap(), "23:59");
+        assert_eq!(validate_send_time("00:00").unwrap(), "00:00");
+    }
+
+    #[test]
+    fn validate_send_time_rejects_malformed_values() {
+        assert!(validate_send_time("24:00").is_err());
+        assert!(validate_send_time("09:60").is_err());
+        assert!(validate_send_time("9").is_err());
+        assert!(validate_send_time("9:5").is_err());
+        assert!(validate_send_time("09:00:00").is_err());
+        assert!(validate_send_time("9am").is_err());
+    }
+
+    #[test]
+    fn extract_changes_ignores_absent_keys() {
+        let changes = extract_changes(&json!({ "timezone": "UTC" })).unwrap();
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].attribute, "timezone");
+        assert_eq!(changes[0].value.as_deref(), Some("UTC"));
+    }
+
+    #[test]
+    fn extract_changes_treats_null_and_empty_as_reset() {
+        for body in [
+            json!({ "timezone": null }),
+            json!({ "timezone": "" }),
+            json!({ "timezone": "   " }),
+        ] {
+            let changes = extract_changes(&body).unwrap();
+            assert_eq!(changes.len(), 1);
+            assert!(
+                changes[0].value.is_none(),
+                "{} should clear the value",
+                body
+            );
+        }
+    }
+
+    #[test]
+    fn extract_changes_rejects_non_string_values() {
+        assert!(extract_changes(&json!({ "timezone": 5 })).is_err());
+        assert!(extract_changes(&json!({ "defaultSendTime": true })).is_err());
+        assert!(extract_changes(&json!(["timezone"])).is_err());
+    }
+
+    #[test]
+    fn extract_changes_returns_empty_for_unknown_keys_only() {
+        // The handler turns this into a 400 rather than a no-op write.
+        let changes = extract_changes(&json!({ "somethingElse": "x" })).unwrap();
+        assert!(changes.is_empty());
+    }
+
+    #[test]
+    fn is_date_only_matches_bare_dates_only() {
+        assert!(is_date_only("2026-08-01"));
+        assert!(!is_date_only("2026-08-01T09:00:00Z"));
+        assert!(!is_date_only("2026-08-01T09:00:00-05:00"));
+        assert!(!is_date_only("now"));
+        assert!(!is_date_only("08/01/2026"));
+    }
+
+    #[test]
+    fn resolve_date_only_uses_tenant_time_and_zone() {
+        // 09:00 in Chicago on a summer date is CDT (UTC-5) → 14:00Z.
+        let resolved = resolve_date_only("2026-08-01", &settings("America/Chicago", "09:00"))
+            .unwrap()
+            .to_rfc3339();
+        assert_eq!(resolved, "2026-08-01T14:00:00+00:00");
+    }
+
+    #[test]
+    fn resolve_date_only_follows_daylight_saving() {
+        // The same wall-clock time in winter is CST (UTC-6) → 15:00Z. A fixed
+        // offset would have silently sent an hour off for half the year.
+        let resolved = resolve_date_only("2026-01-15", &settings("America/Chicago", "09:00"))
+            .unwrap()
+            .to_rfc3339();
+        assert_eq!(resolved, "2026-01-15T15:00:00+00:00");
+    }
+
+    #[test]
+    fn resolve_date_only_defaults_to_utc_at_nine() {
+        let resolved = resolve_date_only("2026-08-01", &TenantSettings::default())
+            .unwrap()
+            .to_rfc3339();
+        assert_eq!(resolved, "2026-08-01T09:00:00+00:00");
+    }
+
+    #[test]
+    fn resolve_date_only_skips_a_daylight_saving_gap() {
+        // US spring forward 2026 is March 8: 02:00–02:59 local never happens.
+        // The send must still land on March 8, at the first minute that exists.
+        let resolved =
+            resolve_date_only("2026-03-08", &settings("America/Chicago", "02:30")).unwrap();
+        assert_eq!(resolved.to_rfc3339(), "2026-03-08T08:00:00+00:00");
+
+        let local = resolved.with_timezone(&"America/Chicago".parse::<Tz>().unwrap());
+        assert_eq!(local.format("%Y-%m-%d").to_string(), "2026-03-08");
+    }
+
+    #[test]
+    fn resolve_date_only_picks_the_earlier_of_an_ambiguous_hour() {
+        // US fall back 2026 is November 1: 01:30 local happens twice (CDT then
+        // CST). The earlier occurrence keeps the send closest to the requested
+        // wall-clock moment.
+        let resolved = resolve_date_only("2026-11-01", &settings("America/Chicago", "01:30"))
+            .unwrap()
+            .to_rfc3339();
+        assert_eq!(resolved, "2026-11-01T06:30:00+00:00");
+    }
+
+    #[test]
+    fn resolve_date_only_rejects_invalid_dates() {
+        assert!(resolve_date_only("2026-02-30", &TenantSettings::default()).is_err());
+        assert!(resolve_date_only("nonsense", &TenantSettings::default()).is_err());
+    }
+
+    #[test]
+    fn settings_accessors_fall_back_on_unparseable_stored_values() {
+        // Stored values are validated on write, so this only guards against
+        // hand-edited records — resolution should degrade, not fail.
+        let broken = settings("Not/AZone", "nope");
+        assert_eq!(broken.timezone(), chrono_tz::UTC);
+        assert_eq!(
+            broken.send_time(),
+            NaiveTime::from_hms_opt(9, 0, 0).unwrap()
+        );
+    }
+
+    #[test]
+    fn settings_from_item_fills_gaps_with_defaults() {
+        let mut item = std::collections::HashMap::new();
+        item.insert(
+            "timezone".to_string(),
+            AttributeValue::S("Europe/London".to_string()),
+        );
+
+        let resolved = settings_from_item(Some(&item));
+        assert_eq!(resolved.timezone, "Europe/London");
+        assert_eq!(resolved.default_send_time, DEFAULT_SEND_TIME);
+    }
+
+    #[test]
+    fn settings_from_item_ignores_blank_attributes() {
+        let mut item = std::collections::HashMap::new();
+        item.insert("timezone".to_string(), AttributeValue::S("".to_string()));
+
+        assert_eq!(settings_from_item(Some(&item)), TenantSettings::default());
+    }
+
+    #[test]
+    fn settings_from_item_defaults_when_no_record_exists() {
+        assert_eq!(settings_from_item(None), TenantSettings::default());
+    }
+
+    #[test]
+    fn build_response_reports_defaults_alongside_effective_values() {
+        let mut item = std::collections::HashMap::new();
+        item.insert(
+            "timezone".to_string(),
+            AttributeValue::S("Asia/Tokyo".to_string()),
+        );
+        item.insert(
+            "updatedAt".to_string(),
+            AttributeValue::S("2026-07-25T00:00:00Z".to_string()),
+        );
+
+        let response = build_response(Some(item));
+        assert_eq!(response.settings.timezone, "Asia/Tokyo");
+        assert_eq!(response.settings.default_send_time, DEFAULT_SEND_TIME);
+        assert_eq!(response.defaults, TenantSettings::default());
+        assert_eq!(response.updated_at.as_deref(), Some("2026-07-25T00:00:00Z"));
+    }
+
+    #[test]
+    fn build_response_omits_updated_at_when_never_saved() {
+        let response = build_response(None);
+        assert!(response.updated_at.is_none());
+        assert_eq!(response.settings, TenantSettings::default());
+    }
+}

--- a/functions/src/api/router.rs
+++ b/functions/src/api/router.rs
@@ -2,8 +2,8 @@ use lambda_http::{http::Method, Body, Error, Request, Response};
 use serde_json::json;
 
 use crate::controllers::{
-    api_keys, brand, churn, domain, issues, pricing, profile, reports, segments, senders, snippets,
-    sponsors, subscribers, templates,
+    api_keys, brand, churn, domain, issues, pricing, profile, reports, segments, senders, settings,
+    snippets, sponsors, subscribers, templates,
 };
 
 pub async fn route_request(event: Request) -> Result<Response<Body>, Error> {
@@ -31,6 +31,10 @@ pub async fn route_request(event: Request) -> Result<Response<Body>, Error> {
             let user_id = extract_path_param(path, "/profile/");
             profile::get_user_profile(event, user_id).await
         }
+
+        // Settings endpoints (tenant-wide defaults)
+        (&Method::GET, "/settings") => settings::get_settings(event).await,
+        (&Method::PUT, "/settings") => settings::update_settings(event).await,
 
         // Brand endpoints
         (&Method::GET, "/brand/check") => brand::check_brand_id(event).await,
@@ -383,6 +387,8 @@ fn is_valid_api_path(path: &str) -> bool {
     // Profile paths
     path == "/me"
         || path.starts_with("/profile/")
+        // Settings paths
+        || path == "/settings"
         // Brand paths
         || path == "/brand"
         || path == "/brand/check"
@@ -627,6 +633,14 @@ mod tests {
         assert!(is_valid_api_path("/brand/check"));
         assert!(is_valid_api_path("/brand/validate"));
         assert!(is_valid_api_path("/brand/logo"));
+    }
+
+    #[test]
+    fn test_is_valid_api_path_settings() {
+        // GET and PUT both live on the bare /settings path; anything deeper is
+        // not a settings route.
+        assert!(is_valid_api_path("/settings"));
+        assert!(!is_valid_api_path("/settings/timezone"));
     }
 
     #[test]

--- a/functions/utils/tenant-settings.mjs
+++ b/functions/utils/tenant-settings.mjs
@@ -1,0 +1,259 @@
+/**
+ * Reads the tenant-wide defaults written by the admin API's `/settings`
+ * endpoint (`functions/src/api/controllers/settings.rs`) and applies them to
+ * the publish pipeline.
+ *
+ * These are the values the platform falls back to when a request doesn't spell
+ * something out: which timezone a bare date is read against, what time of day
+ * such a send lands on, how a subject line is built, and where an issue lives
+ * on the tenant's site.
+ *
+ * Every read here is fail-open. A settings lookup that errors — or a tenant id
+ * that was never threaded through — degrades to the documented defaults rather
+ * than failing a publish that was otherwise ready to go.
+ */
+
+import { DynamoDBClient, GetItemCommand } from '@aws-sdk/client-dynamodb';
+import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
+
+const ddb = new DynamoDBClient();
+
+/** Keep in step with `DEFAULT_TIMEZONE` in `settings.rs`. */
+export const DEFAULT_TIMEZONE = 'UTC';
+
+/** Keep in step with `DEFAULT_SEND_TIME` in `settings.rs`. */
+export const DEFAULT_SEND_TIME = '09:00';
+
+/** A bare calendar date, with no time of day attached. */
+const DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+const SEND_TIME_PATTERN = /^([01]?\d|2[0-3]):([0-5]\d)$/;
+
+/**
+ * The effective settings when the tenant has saved nothing (or the read
+ * failed). `subjectTemplate` and `issueUrlPattern` have no system default:
+ * absent means "the caller decides", not "use this".
+ */
+export const DEFAULT_SETTINGS = Object.freeze({
+  timezone: DEFAULT_TIMEZONE,
+  defaultSendTime: DEFAULT_SEND_TIME,
+  subjectTemplate: null,
+  issueUrlPattern: null
+});
+
+/**
+ * Loads a tenant's effective settings. Returns {@link DEFAULT_SETTINGS} for an
+ * unknown tenant, a missing record, or any failure — publishing must not break
+ * because a preferences lookup did.
+ *
+ * @param {string} [tenantId]
+ * @returns {Promise<typeof DEFAULT_SETTINGS>}
+ */
+export const getTenantSettings = async (tenantId) => {
+  if (!tenantId) {
+    return DEFAULT_SETTINGS;
+  }
+
+  try {
+    const result = await ddb.send(new GetItemCommand({
+      TableName: process.env.TABLE_NAME,
+      Key: marshall({ pk: tenantId, sk: 'settings' })
+    }));
+
+    if (!result.Item) {
+      return DEFAULT_SETTINGS;
+    }
+
+    const item = unmarshall(result.Item);
+    return {
+      timezone: nonEmpty(item.timezone) ?? DEFAULT_SETTINGS.timezone,
+      defaultSendTime: nonEmpty(item.defaultSendTime) ?? DEFAULT_SETTINGS.defaultSendTime,
+      subjectTemplate: nonEmpty(item.subjectTemplate) ?? null,
+      issueUrlPattern: nonEmpty(item.issueUrlPattern) ?? null
+    };
+  } catch (err) {
+    console.error('Failed to load tenant settings, using defaults', { tenantId, error: err.message });
+    return DEFAULT_SETTINGS;
+  }
+};
+
+const nonEmpty = (value) => {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+};
+
+/**
+ * True when a value names a day but no time of day, and therefore needs the
+ * tenant's default send time to become an instant. Accepts the `YYYY-MM-DD`
+ * string form and a `Date` that is exactly UTC midnight — which is what a YAML
+ * parser produces from a bare frontmatter `date:`.
+ */
+export const isDateOnly = (value) => {
+  if (value instanceof Date) {
+    return !Number.isNaN(value.getTime()) && value.toISOString().endsWith('T00:00:00.000Z');
+  }
+  return typeof value === 'string' && DATE_ONLY_PATTERN.test(value.trim());
+};
+
+/** The `YYYY-MM-DD` day a date-only value refers to. */
+const dayOf = (value) => {
+  if (value instanceof Date) {
+    return value.toISOString().slice(0, 10);
+  }
+  return String(value).trim().slice(0, 10);
+};
+
+/**
+ * The offset of `timeZone` at a given instant, in milliseconds east of UTC.
+ * Derived by reading the zone's own wall clock at that instant and comparing
+ * it back — the only DST-correct way to get an offset out of `Intl`.
+ */
+const timeZoneOffsetMs = (instantMs, timeZone) => {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hourCycle: 'h23'
+  }).formatToParts(new Date(instantMs));
+
+  const read = (type) => Number(parts.find((part) => part.type === type)?.value ?? '0');
+
+  const wallClockAsUtc = Date.UTC(
+    read('year'),
+    read('month') - 1,
+    read('day'),
+    read('hour'),
+    read('minute'),
+    read('second')
+  );
+
+  return wallClockAsUtc - instantMs;
+};
+
+/**
+ * Reads `YYYY-MM-DDTHH:mm` as a wall-clock time in `timeZone` and returns the
+ * instant it names.
+ *
+ * The offset is applied twice on purpose: the first pass uses the offset at
+ * the wall-clock time treated as UTC, which is wrong by up to an hour near a
+ * DST boundary, and re-reading the offset at that estimate lands on the right
+ * instant. Mirrors `resolve_date_only` in `settings.rs` and
+ * `fromDatetimeLocalInTimeZone` in the dashboard.
+ */
+const wallClockToInstant = (wallClock, timeZone) => {
+  const asUtc = Date.parse(`${wallClock}:00Z`);
+  if (Number.isNaN(asUtc)) return null;
+
+  let offset;
+  try {
+    offset = timeZoneOffsetMs(asUtc, timeZone);
+    const firstPass = asUtc - offset;
+    offset = timeZoneOffsetMs(firstPass, timeZone);
+  } catch (err) {
+    console.error('Unknown timezone, falling back to UTC', { timeZone, error: err.message });
+    return new Date(asUtc);
+  }
+
+  return new Date(asUtc - offset);
+};
+
+/**
+ * Resolves a send date into the instant it should actually go out at.
+ *
+ * A date-only value is anchored to the tenant's default send time, read as
+ * wall-clock time in the tenant's timezone. A value that already carries a
+ * time of day is respected as given — settings fill in what the caller left
+ * out, they don't override what the caller said.
+ *
+ * @param {string|Date} value
+ * @param {typeof DEFAULT_SETTINGS} settings
+ * @returns {Date|null} null when the value isn't a usable date
+ */
+export const resolveSendInstant = (value, settings = DEFAULT_SETTINGS) => {
+  if (value === null || value === undefined || value === '') return null;
+
+  if (!isDateOnly(value)) {
+    const parsed = value instanceof Date ? value : new Date(value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  }
+
+  const day = dayOf(value);
+  const sendTime = SEND_TIME_PATTERN.test(settings.defaultSendTime ?? '')
+    ? padSendTime(settings.defaultSendTime)
+    : DEFAULT_SEND_TIME;
+
+  const resolved = wallClockToInstant(`${day}T${sendTime}`, settings.timezone || DEFAULT_TIMEZONE);
+  if (resolved && !Number.isNaN(resolved.getTime())) {
+    return resolved;
+  }
+
+  // A wall-clock time that doesn't exist (a spring-forward gap) or an
+  // unparseable day: fall back to the day at the send time in UTC rather than
+  // dropping the schedule entirely.
+  const fallback = new Date(`${day}T${sendTime}:00Z`);
+  return Number.isNaN(fallback.getTime()) ? null : fallback;
+};
+
+/** `9:05` → `09:05`. */
+const padSendTime = (value) => {
+  const match = SEND_TIME_PATTERN.exec(value.trim());
+  if (!match) return value;
+  return `${match[1].padStart(2, '0')}:${match[2]}`;
+};
+
+/**
+ * Substitutes `{{token}}` placeholders. Deliberately not Handlebars: these
+ * templates produce an email subject and a URL, where the only thing wanted is
+ * literal substitution, and where helpers/partials would be a needless way to
+ * fail at send time.
+ *
+ * Unknown tokens are left untouched so a typo is visible rather than silently
+ * blanking part of the subject. Whitespace inside the braces is tolerated.
+ */
+export const renderTokens = (template, tokens) => {
+  if (typeof template !== 'string') return '';
+
+  return template.replace(/\{\{\s*([a-zA-Z][a-zA-Z0-9_]*)\s*\}\}/g, (match, name) => {
+    const value = tokens[name];
+    return value === undefined || value === null ? match : String(value);
+  });
+};
+
+/**
+ * Builds an issue's email subject.
+ *
+ * Precedence follows the whole point of these settings — anything the request
+ * supplied wins, and the tenant's template only fills a gap:
+ *   1. the subject the caller sent
+ *   2. the tenant's `subjectTemplate`
+ *   3. the issue title, or a generic fallback
+ */
+export const buildSubject = (settings, { callerSubject, title, number, date } = {}) => {
+  const supplied = nonEmpty(callerSubject);
+  if (supplied) return supplied;
+
+  const template = nonEmpty(settings?.subjectTemplate);
+  if (template) {
+    const rendered = nonEmpty(renderTokens(template, { title, number, date }));
+    if (rendered) return rendered;
+  }
+
+  return nonEmpty(title) ?? `Newsletter Issue #${number}`;
+};
+
+/**
+ * Builds the public URL for an issue from the tenant's `issueUrlPattern`.
+ * Returns null when no pattern is configured — callers omit the field rather
+ * than emitting a link to somebody else's site.
+ */
+export const buildIssueUrl = (settings, { number } = {}) => {
+  const pattern = nonEmpty(settings?.issueUrlPattern);
+  if (!pattern) return null;
+
+  return nonEmpty(renderTokens(pattern, { number }));
+};

--- a/functions/utils/tenant-settings.mjs
+++ b/functions/utils/tenant-settings.mjs
@@ -135,6 +135,9 @@ const timeZoneOffsetMs = (instantMs, timeZone) => {
   return wallClockAsUtc - instantMs;
 };
 
+/** Longest spring-forward gap we'll search past. Real gaps are 30–120 minutes. */
+const GAP_SEARCH_LIMIT_MINUTES = 180;
+
 /**
  * Reads `YYYY-MM-DDTHH:mm` as a wall-clock time in `timeZone` and returns the
  * instant it names.
@@ -142,25 +145,57 @@ const timeZoneOffsetMs = (instantMs, timeZone) => {
  * The offset is applied twice on purpose: the first pass uses the offset at
  * the wall-clock time treated as UTC, which is wrong by up to an hour near a
  * DST boundary, and re-reading the offset at that estimate lands on the right
- * instant. Mirrors `resolve_date_only` in `settings.rs` and
- * `fromDatetimeLocalInTimeZone` in the dashboard.
+ * instant.
+ *
+ * A wall-clock time inside a spring-forward gap never happens, and no offset
+ * makes it happen — the two-pass result lands *before* the requested time,
+ * which would send an issue an hour early. Those resolve forward to the first
+ * minute that does exist, matching `resolve_date_only` in `settings.rs` and
+ * `fromDatetimeLocalInTimeZone` in the dashboard. All three have to agree, or
+ * the settings preview would contradict the send.
  */
 const wallClockToInstant = (wallClock, timeZone) => {
   const asUtc = Date.parse(`${wallClock}:00Z`);
   if (Number.isNaN(asUtc)) return null;
 
-  let offset;
   try {
-    offset = timeZoneOffsetMs(asUtc, timeZone);
-    const firstPass = asUtc - offset;
-    offset = timeZoneOffsetMs(firstPass, timeZone);
+    return new Date(resolveWallClock(asUtc, timeZone));
   } catch (err) {
     console.error('Unknown timezone, falling back to UTC', { timeZone, error: err.message });
     return new Date(asUtc);
   }
-
-  return new Date(asUtc - offset);
 };
+
+/**
+ * The instant a wall-clock time names, where the wall clock is expressed as
+ * though it were UTC.
+ */
+const resolveWallClock = (asUtc, timeZone) => {
+  const firstPass = asUtc - timeZoneOffsetMs(asUtc, timeZone);
+  const instant = asUtc - timeZoneOffsetMs(firstPass, timeZone);
+
+  // Round-trip check: if reading the instant back in the zone doesn't give the
+  // wall clock we asked for, that wall clock doesn't exist on that day.
+  if (wallClockOf(instant, timeZone) === asUtc) {
+    return instant;
+  }
+
+  for (let minutes = 1; minutes <= GAP_SEARCH_LIMIT_MINUTES; minutes += 1) {
+    const candidate = asUtc + minutes * 60_000;
+    const firstPassCandidate = candidate - timeZoneOffsetMs(candidate, timeZone);
+    const resolved = candidate - timeZoneOffsetMs(firstPassCandidate, timeZone);
+    if (wallClockOf(resolved, timeZone) === candidate) {
+      return resolved;
+    }
+  }
+
+  // No valid time found (unreachable for real zones) — the two-pass estimate is
+  // still a real instant, so prefer it over failing the publish outright.
+  return instant;
+};
+
+/** The zone's wall clock at `instant`, as though that wall clock were UTC. */
+const wallClockOf = (instant, timeZone) => instant + timeZoneOffsetMs(instant, timeZone);
 
 /**
  * Resolves a send date into the instant it should actually go out at.
@@ -192,9 +227,9 @@ export const resolveSendInstant = (value, settings = DEFAULT_SETTINGS) => {
     return resolved;
   }
 
-  // A wall-clock time that doesn't exist (a spring-forward gap) or an
-  // unparseable day: fall back to the day at the send time in UTC rather than
-  // dropping the schedule entirely.
+  // An unparseable day: fall back to the send time in UTC rather than dropping
+  // the schedule entirely. (Spring-forward gaps are handled above, in
+  // `resolveWallClock`.)
   const fallback = new Date(`${day}T${sendTime}:00Z`);
   return Number.isNaN(fallback.getTime()) ? null : fallback;
 };

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3028,6 +3028,22 @@ components:
             a request supplies a date without a time.
           example: "09:00"
           default: "09:00"
+        subjectTemplate:
+          type: string
+          description: >-
+            How an email subject is built when the request that staged the
+            issue didn't supply one — which is always the case on the
+            markdown/GitHub path. Supports the placeholders `{{title}}`,
+            `{{number}}` and `{{date}}`. Absent means "use the issue title";
+            there is no system default. A supplied `subject` always wins.
+          example: "{{title}} | Picks of the Week #{{number}}"
+        issueUrlPattern:
+          type: string
+          description: >-
+            Absolute URL where an issue lives on the tenant's own site, used
+            for the "view online" link. Must be http(s) and must include the
+            `{{number}}` placeholder. Absent means the link is omitted.
+          example: "https://example.com/newsletter/{{number}}"
 
     SettingsResponse:
       type: object
@@ -3063,6 +3079,21 @@ components:
           pattern: "^([01]?[0-9]|2[0-3]):[0-5][0-9]$"
           description: 24-hour HH:MM time of day, or null to reset to the system default.
           example: "09:00"
+        subjectTemplate:
+          type: string
+          nullable: true
+          description: >-
+            Subject format using `{{title}}`, `{{number}}` and `{{date}}`, or
+            null to clear it (subjects then fall back to the issue title).
+            Rejected if it contains line breaks or an unsupported placeholder.
+          example: "{{title}} | Picks of the Week #{{number}}"
+        issueUrlPattern:
+          type: string
+          nullable: true
+          description: >-
+            Absolute http(s) URL containing `{{number}}`, or null to clear it
+            (the "view online" link is then omitted from the email).
+          example: "https://example.com/newsletter/{{number}}"
 
     SenderEmail:
       type: object
@@ -3873,7 +3904,8 @@ components:
           type: string
           description: >-
             IANA timezone (e.g. "America/New_York") whose wall clock defines
-            the target send time. Required when enabled is true.
+            the target send time. Optional: when omitted or blank it falls back
+            to the tenant's `timezone` setting (see GET /settings).
         mode:
           type: string
           enum:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -21,6 +21,7 @@ info:
 tags:
   - name: API Keys
   - name: Profile
+  - name: Settings
   - name: Senders
   - name: Issues
   - name: Reports
@@ -299,6 +300,57 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/UnknownError"
+
+  /settings:
+    get:
+      summary: Get tenant settings
+      description: >-
+        Returns the tenant-wide defaults the platform falls back to when a
+        request doesn't specify a value. `settings` holds the effective values
+        (stored where set, system defaults everywhere else) and `defaults`
+        holds the system defaults, so a client can tell which effective values
+        are inherited rather than chosen.
+      tags:
+        - Settings
+      responses:
+        "200":
+          description: The tenant's effective settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SettingsResponse"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/UnknownError"
+    put:
+      summary: Update tenant settings
+      description: >-
+        Updates one or more tenant settings. Settings the request doesn't
+        mention are left unchanged; a setting sent as `null` (or an empty
+        string) is reset to the system default. At least one recognized
+        setting must be provided.
+      tags:
+        - Settings
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateSettingsRequest"
+      responses:
+        "200":
+          description: The tenant's settings after the update
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SettingsResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "500":
           $ref: "#/components/responses/UnknownError"
 
@@ -2955,6 +3007,63 @@ components:
                 example: An unexpected error occurred.
 
   schemas:
+    TenantSettings:
+      type: object
+      required:
+        - timezone
+        - defaultSendTime
+      properties:
+        timezone:
+          type: string
+          description: >-
+            IANA timezone name. Used to format dates in the dashboard and as
+            the zone a date-only send is read against.
+          example: America/Chicago
+          default: UTC
+        defaultSendTime:
+          type: string
+          pattern: "^([01][0-9]|2[0-3]):[0-5][0-9]$"
+          description: >-
+            24-hour HH:MM time of day, in `timezone`, that a send lands on when
+            a request supplies a date without a time.
+          example: "09:00"
+          default: "09:00"
+
+    SettingsResponse:
+      type: object
+      required:
+        - settings
+        - defaults
+      properties:
+        settings:
+          allOf:
+            - $ref: "#/components/schemas/TenantSettings"
+          description: The effective settings — what the platform will use.
+        defaults:
+          allOf:
+            - $ref: "#/components/schemas/TenantSettings"
+          description: The system defaults applied wherever the tenant has set nothing.
+        updatedAt:
+          type: string
+          format: date-time
+          description: When settings were last saved. Absent if they never have been.
+
+    UpdateSettingsRequest:
+      type: object
+      minProperties: 1
+      properties:
+        timezone:
+          type: string
+          nullable: true
+          description: IANA timezone name, or null to reset to the system default.
+          example: America/Chicago
+        defaultSendTime:
+          type: string
+          nullable: true
+          pattern: "^([01]?[0-9]|2[0-3]):[0-5][0-9]$"
+          description: 24-hour HH:MM time of day, or null to reset to the system default.
+          example: "09:00"
+
     SenderEmail:
       type: object
       required:
@@ -3551,7 +3660,14 @@ components:
             the content must be a JSON object.
         scheduledAt:
           type: string
-          description: When to schedule the issue for publishing (RFC3339 or "now")
+          description: >-
+            When to schedule the issue for publishing. Accepts an RFC3339
+            timestamp, "now", or a date-only "YYYY-MM-DD" value. A date-only
+            value has no time of day, so it is anchored to the tenant's
+            defaultSendTime read as wall-clock time in the tenant's timezone
+            (see GET /settings). A resolved time that has already passed sends
+            immediately.
+          example: "2026-08-01"
         action:
           type: string
           enum: [draft, schedule]
@@ -3716,8 +3832,10 @@ components:
             content must be a JSON object.
         scheduledAt:
           type: string
-          format: date-time
-          description: When to schedule the issue for publishing
+          description: >-
+            When to schedule the issue for publishing. Accepts an RFC3339
+            timestamp or a date-only "YYYY-MM-DD" value, which is anchored to
+            the tenant's defaultSendTime and timezone (see GET /settings).
         metadata:
           type: object
           description: Optional metadata for the issue

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3059,6 +3059,16 @@ components:
           allOf:
             - $ref: "#/components/schemas/TenantSettings"
           description: The system defaults applied wherever the tenant has set nothing.
+        configured:
+          type: array
+          items:
+            type: string
+            enum: [timezone, defaultSendTime, subjectTemplate, issueUrlPattern]
+          description: >-
+            Which settings the tenant has explicitly chosen. `settings` alone
+            cannot answer that — a stored "UTC" and an unset timezone look the
+            same — so clients that want to suggest a better value than the
+            system default (the viewer's own timezone, say) should check here.
         updatedAt:
           type: string
           format: date-time

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint:all": "npm run lint && npm run lint:ui",
     "coverage": "c8 npm test",
     "test:rust": "cargo test --workspace",
-    "lint:rust": "cargo clippy --workspace --all-targets",
+    "lint:rust": "cargo clippy --workspace --all-targets --all-features -- -D warnings",
     "lint:rust:fix": "cargo clippy --workspace --all-targets --fix --allow-dirty --allow-staged",
     "fmt:rust": "cargo fmt --all -- --check",
     "fmt:rust:fix": "cargo fmt --all"

--- a/state-machines/stage-issue.asl.json
+++ b/state-machines/stage-issue.asl.json
@@ -238,7 +238,8 @@
             "fileName.$": "$$.Execution.Input.fileName",
             "isPreview.$": "$$.Execution.Input.isPreview",
             "issueId.$": "$$.Execution.Input.issueId",
-            "tenantId.$": "$$.Execution.Input.tenant.id"
+            "tenantId.$": "$$.Execution.Input.tenant.id",
+            "subject.$": "$$.Execution.Input.subject"
           }
         },
               "Retry": [

--- a/templates/newsletter.hbs
+++ b/templates/newsletter.hbs
@@ -215,8 +215,8 @@
                                   <tr>
                                     <td height="100%" valign="top" role="module-content">
                                       <div style="font-family: inherit;padding-bottom:8px;">
-                                        <span>{{ metadata.date }} - </span>
-                                        <span> <a href="{{ metadata.url }}"> View online version</a></span>
+                                        <span>{{ metadata.date }}{{#if metadata.url}} - {{/if}}</span>
+                                        {{#if metadata.url}}<span> <a href="{{ metadata.url }}"> View online version</a></span>{{/if}}
                                       </div>
                                     </td>
                                   </tr>


### PR DESCRIPTION
Adds a Settings section covering the defaults the platform falls back to
when an API request doesn't spell a value out.

Backend:
- new `settings` controller with GET/PUT /settings, storing `timezone`
  and `defaultSendTime` on a `pk={tenantId}, sk=settings` record. An
  absent record or attribute means "system default" (UTC / 09:00), so a
  tenant that never opens the page still has defined behavior.
- `scheduledAt` on issue create/update now accepts a date-only
  `YYYY-MM-DD` value and anchors it to the tenant's default send time,
  read as wall-clock time in the tenant's timezone. DST-ambiguous and
  nonexistent wall-clock times both resolve forward, so a send always
  lands on the requested day.
- adds chrono-tz for a real, historically correct tz database; a fixed
  offset would send an hour off for half the year.

Dashboard:
- Settings page (timezone + default send time) with a live preview of
  where a date-only send would land, in both the tenant zone and UTC.
- SettingsProvider loads the settings once per session; useTenantDateFormat
  gives every surface the same wall clock. Issue list, card, and detail
  now format in the newsletter's zone rather than the viewer's.
- the issue form's schedule and A/B send-time fields now read and write
  wall-clock times in the newsletter's timezone, matching what the API
  does with a date-only value.

The read path degrades to the defaults outside a provider — formatting a
date is not a good enough reason to crash a page — while the write path
still requires one.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Y7XFATKc9mBMkBGp9ysZJV