### PR TITLE
fix(issues): correct the draft preview, and finish the timezone work

### DIFF
--- a/dashboard-ui/src/components/billing/BillingAlerts.tsx
+++ b/dashboard-ui/src/components/billing/BillingAlerts.tsx
@@ -9,6 +9,8 @@ import {
 } from 'lucide-react';
 import { Card, CardContent, Button } from '@/components/ui';
 import type { BillingAlertsProps, BillingAlert } from '@/types';
+import { formatInTimeZone } from '@/utils/dateFormatting';
+import { useTenantDateFormat } from '@/contexts/SettingsContext';
 
 interface AlertItemProps {
   alert: BillingAlert;
@@ -50,13 +52,16 @@ function AlertItem({ alert, onDismiss, onAction }: AlertItemProps) {
     }
   };
 
+  // Dates render in the newsletter's timezone, not the viewer's.
+  const { timeZone } = useTenantDateFormat();
+
   const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString('en-US', {
+    return formatInTimeZone(dateString, timeZone, {
       month: 'short',
       day: 'numeric',
       hour: '2-digit',
       minute: '2-digit'
-    });
+    }, 'en-US');
   };
 
   return (

--- a/dashboard-ui/src/components/billing/BillingManagement.tsx
+++ b/dashboard-ui/src/components/billing/BillingManagement.tsx
@@ -11,6 +11,8 @@ import {
 import { Card, CardContent, CardHeader, CardTitle, Button } from '@/components/ui';
 import { billingService } from '@/services';
 import type { Subscription, BillingInfo } from '@/types';
+import { formatInTimeZone } from '@/utils/dateFormatting';
+import { useTenantDateFormat } from '@/contexts/SettingsContext';
 
 interface BillingManagementProps {
   subscription: Subscription | null;
@@ -76,6 +78,8 @@ export function BillingManagement({
   onError,
   onSuccess: _onSuccess
 }: BillingManagementProps) {
+  // Dates render in the newsletter's timezone, not the viewer's.
+  const { timeZone } = useTenantDateFormat();
   const [actionLoading, setActionLoading] = useState<string | null>(null);
 
   const handleCustomerPortal = async (action: string) => {
@@ -159,7 +163,7 @@ export function BillingManagement({
                 <div>
                   <p className="text-sm font-medium text-primary-900">Active Subscription</p>
                   <p className="text-sm text-primary-700">
-                    {subscription.plan.name} plan &bull; Next billing: {new Date(subscription.currentPeriodEnd).toLocaleDateString()}
+                    {subscription.plan.name} plan &bull; Next billing: {formatInTimeZone(subscription.currentPeriodEnd, timeZone, {})}
                   </p>
                 </div>
               </div>

--- a/dashboard-ui/src/components/billing/SubscriptionStatusCard.tsx
+++ b/dashboard-ui/src/components/billing/SubscriptionStatusCard.tsx
@@ -18,6 +18,8 @@ import type {
   BillingInfo,
   SubscriptionCardProps
 } from '@/types';
+import { formatInTimeZone } from '@/utils/dateFormatting';
+import { useTenantDateFormat } from '@/contexts/SettingsContext';
 
 interface SubscriptionStatusCardProps extends SubscriptionCardProps {
   subscription: Subscription | null;
@@ -71,12 +73,15 @@ export function SubscriptionStatusCard({
     }
   };
 
+  // Dates render in the newsletter's timezone, not the viewer's.
+  const { timeZone } = useTenantDateFormat();
+
   const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString('en-US', {
+    return formatInTimeZone(dateString, timeZone, {
       year: 'numeric',
       month: 'long',
       day: 'numeric'
-    });
+    }, 'en-US');
   };
 
   if (loading) {

--- a/dashboard-ui/src/components/billing/UsageDisplay.tsx
+++ b/dashboard-ui/src/components/billing/UsageDisplay.tsx
@@ -7,6 +7,8 @@ import {
   formatUsage
 } from '@/constants';
 import type { UsageDisplayProps } from '@/types';
+import { formatInTimeZone } from '@/utils/dateFormatting';
+import { useTenantDateFormat } from '@/contexts/SettingsContext';
 
 interface UsageProgressBarProps {
   current: number;
@@ -17,6 +19,8 @@ interface UsageProgressBarProps {
 }
 
 function UsageProgressBar({ current, limit, label, icon, resetDate }: UsageProgressBarProps) {
+  // Dates render in the newsletter's timezone, not the viewer's.
+  const { timeZone } = useTenantDateFormat();
   const percentage = calculateUsagePercentage(current, limit);
   const status = getUsageStatus(percentage);
 
@@ -59,10 +63,10 @@ function UsageProgressBar({ current, limit, label, icon, resetDate }: UsageProgr
 
       {resetDate && (
         <p className="text-xs text-muted-foreground">
-          Resets on {new Date(resetDate).toLocaleDateString('en-US', {
+          Resets on {formatInTimeZone(resetDate, timeZone, {
             month: 'short',
             day: 'numeric'
-          })}
+          }, 'en-US')}
         </p>
       )}
 

--- a/dashboard-ui/src/components/issues/AbTestHistory.tsx
+++ b/dashboard-ui/src/components/issues/AbTestHistory.tsx
@@ -12,6 +12,7 @@ import {
 } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '../ui/Card';
 import { formatDate } from '../../utils/issueDetailUtils';
+import { useTenantDateFormat } from '@/contexts/SettingsContext';
 import { cn } from '../../utils/cn';
 import type {
   AbHistoryResponse,
@@ -68,7 +69,10 @@ interface VariantRateProps {
   isWinner: boolean;
 }
 
-const VariantRate: React.FC<VariantRateProps> = ({ variant, dimension, isWinner }) => (
+const VariantRate: React.FC<VariantRateProps> = ({ variant, dimension, isWinner }) => {
+  const { timeZone } = useTenantDateFormat();
+
+  return (
   <div
     className={cn(
       'rounded-md border p-2 text-xs',
@@ -87,7 +91,7 @@ const VariantRate: React.FC<VariantRateProps> = ({ variant, dimension, isWinner 
       {dimension === 'subject'
         ? variant.subject || 'No subject'
         : variant.sendAt
-          ? formatDate(variant.sendAt)
+          ? formatDate(variant.sendAt, true, timeZone)
           : 'No send time'}
     </p>
     <div className="flex items-center gap-3 text-foreground">
@@ -95,13 +99,15 @@ const VariantRate: React.FC<VariantRateProps> = ({ variant, dimension, isWinner 
       <span>Click {formatRate(variant.clickRate)}</span>
     </div>
   </div>
-);
+  );
+};
 
 interface TestRowProps {
   test: AbHistoryTest;
 }
 
 const TestRow: React.FC<TestRowProps> = ({ test }) => {
+  const { timeZone } = useTenantDateFormat();
   const winnerId = test.winnerVariantId ?? null;
   return (
     <li className="rounded-lg border border-border p-4" aria-label={`Issue #${test.issueNumber} A/B test`}>
@@ -117,7 +123,7 @@ const TestRow: React.FC<TestRowProps> = ({ test }) => {
             {dimensionLabel(test.dimension)}
           </span>
           {test.decidedAt && (
-            <span className="text-xs text-muted-foreground">{formatDate(test.decidedAt, false)}</span>
+            <span className="text-xs text-muted-foreground">{formatDate(test.decidedAt, false, timeZone)}</span>
           )}
         </div>
         <div className="flex items-center gap-2 flex-wrap">

--- a/dashboard-ui/src/components/issues/AbTestResults.tsx
+++ b/dashboard-ui/src/components/issues/AbTestResults.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import { FlaskConical, Trophy, Mail, Clock, CheckCircle2, MinusCircle, Loader2, AlertTriangle } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '../ui/Card';
 import { formatDate } from '../../utils/issueDetailUtils';
+import { useTenantDateFormat } from '@/contexts/SettingsContext';
 import { cn } from '../../utils/cn';
 import type { AbTest, VariantStats, VariantId, AbTestVariant } from '../../types/issues';
 
@@ -10,6 +11,14 @@ export interface AbTestResultsProps {
   abTest: AbTest;
   /** Per-variant engagement counters returned alongside the issue. */
   variantStats?: VariantStats[];
+  /**
+   * Whether the issue has started sending. A test only exists once a sample has
+   * gone out — before that this is a saved configuration, and saying anything
+   * about results (or spinning a progress indicator) is a claim about a test
+   * that hasn't run. Defaults to true so existing published-issue callers are
+   * unaffected.
+   */
+  hasStarted?: boolean;
 }
 
 const VARIANT_LABELS: Record<VariantId, string> = {
@@ -52,6 +61,8 @@ interface VariantCardProps {
   stats?: VariantStats;
   isWinner: boolean;
   winMetric: NonNullable<AbTest['winMetric']>;
+  /** False while the issue is unsent, when there is nothing to measure. */
+  hasStarted: boolean;
 }
 
 const VariantCard: React.FC<VariantCardProps> = ({
@@ -61,7 +72,11 @@ const VariantCard: React.FC<VariantCardProps> = ({
   stats,
   isWinner,
   winMetric,
+  hasStarted,
 }) => {
+  // A variant's send time is a wall clock in the newsletter's zone, not the
+  // viewer's.
+  const { timeZone } = useTenantDateFormat();
   const deliveries = stats?.deliveries ?? 0;
   const opens = stats?.opens ?? 0;
   const clicks = stats?.clicks ?? 0;
@@ -74,7 +89,7 @@ const VariantCard: React.FC<VariantCardProps> = ({
           ? 'border-success-400 bg-success-50 dark:border-success-500 dark:bg-success-900/20'
           : 'border-border bg-muted/40'
       )}
-      aria-label={`${VARIANT_LABELS[variantId]} results`}
+      aria-label={`${VARIANT_LABELS[variantId]}${hasStarted ? ' results' : ''}`}
     >
       <div className="flex items-start justify-between gap-2 mb-3">
         <span className="text-sm font-semibold text-foreground">{VARIANT_LABELS[variantId]}</span>
@@ -94,32 +109,48 @@ const VariantCard: React.FC<VariantCardProps> = ({
         ) : (
           <span className="inline-flex items-center gap-1">
             <Clock className="w-3.5 h-3.5" aria-hidden="true" />
-            {variant?.sendAt ? formatDate(variant.sendAt) : 'No send time set'}
+            {variant?.sendAt ? formatDate(variant.sendAt, true, timeZone) : 'No send time set'}
           </span>
         )}
       </div>
 
-      <dl className="grid grid-cols-2 gap-3">
-        <div className={cn('rounded-md p-2', winMetric === 'openRate' && 'ring-1 ring-primary-300 dark:ring-primary-700')}>
-          <dt className="text-xs text-muted-foreground font-medium">Open rate</dt>
-          <dd className="text-lg sm:text-xl font-bold text-foreground">{formatPercent(opens, deliveries)}</dd>
-          <dd className="text-xs text-muted-foreground">{opens} / {deliveries} delivered</dd>
-        </div>
-        <div className={cn('rounded-md p-2', winMetric === 'clickRate' && 'ring-1 ring-primary-300 dark:ring-primary-700')}>
-          <dt className="text-xs text-muted-foreground font-medium">Click rate</dt>
-          <dd className="text-lg sm:text-xl font-bold text-foreground">{formatPercent(clicks, deliveries)}</dd>
-          <dd className="text-xs text-muted-foreground">{clicks} / {deliveries} delivered</dd>
-        </div>
-      </dl>
+      {hasStarted ? (
+        <dl className="grid grid-cols-2 gap-3">
+          <div className={cn('rounded-md p-2', winMetric === 'openRate' && 'ring-1 ring-primary-300 dark:ring-primary-700')}>
+            <dt className="text-xs text-muted-foreground font-medium">Open rate</dt>
+            <dd className="text-lg sm:text-xl font-bold text-foreground">{formatPercent(opens, deliveries)}</dd>
+            <dd className="text-xs text-muted-foreground">{opens} / {deliveries} delivered</dd>
+          </div>
+          <div className={cn('rounded-md p-2', winMetric === 'clickRate' && 'ring-1 ring-primary-300 dark:ring-primary-700')}>
+            <dt className="text-xs text-muted-foreground font-medium">Click rate</dt>
+            <dd className="text-lg sm:text-xl font-bold text-foreground">{formatPercent(clicks, deliveries)}</dd>
+            <dd className="text-xs text-muted-foreground">{clicks} / {deliveries} delivered</dd>
+          </div>
+        </dl>
+      ) : (
+        // Rendering "—" and "0 / 0 delivered" here would read as a measurement
+        // that came back empty, rather than one that hasn't happened.
+        <p className="text-xs text-muted-foreground">
+          Will be measured on {winMetric === 'openRate' ? 'open rate' : 'click rate'} once sent.
+        </p>
+      )}
     </div>
   );
 };
 
 VariantCard.displayName = 'VariantCard';
 
+/** Shown in place of a lifecycle status while the issue is still unsent. */
+const NOT_STARTED_CONFIG = {
+  label: 'Not started',
+  className:
+    'bg-gray-100 text-gray-800 border-gray-300 dark:bg-gray-700 dark:text-gray-100 dark:border-gray-500',
+};
+
 export const AbTestResults: React.FC<AbTestResultsProps> = ({
   abTest,
   variantStats,
+  hasStarted = true,
 }) => {
   const status = abTest.status ?? 'pending';
   const winMetric = abTest.winMetric ?? 'openRate';
@@ -138,10 +169,11 @@ export const AbTestResults: React.FC<AbTestResultsProps> = ({
     return map;
   }, [abTest.variants]);
 
-  const isDecided = status === 'sent' || status === 'inconclusive' || status === 'evaluating';
+  const isDecided =
+    hasStarted && (status === 'sent' || status === 'inconclusive' || status === 'evaluating');
 
   const dimensionLabel = abTest.dimension === 'subject' ? 'Subject line' : 'Send time';
-  const statusConfig = STATUS_CONFIG[status];
+  const statusConfig = hasStarted ? STATUS_CONFIG[status] : NOT_STARTED_CONFIG;
 
   return (
     <Card>
@@ -149,7 +181,7 @@ export const AbTestResults: React.FC<AbTestResultsProps> = ({
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
           <CardTitle className="flex items-center gap-2">
             <FlaskConical className="w-5 h-5" aria-hidden="true" />
-            A/B Test Results
+            {hasStarted ? 'A/B Test Results' : 'A/B Test'}
           </CardTitle>
           <div className="flex items-center gap-2">
             <span className="inline-flex items-center gap-1 text-xs sm:text-sm text-muted-foreground font-medium">
@@ -177,7 +209,7 @@ export const AbTestResults: React.FC<AbTestResultsProps> = ({
         <div
           className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4"
           role="region"
-          aria-label="A/B test variant results"
+          aria-label={hasStarted ? 'A/B test variant results' : 'A/B test variants'}
         >
           <VariantCard
             variantId="a"
@@ -186,6 +218,7 @@ export const AbTestResults: React.FC<AbTestResultsProps> = ({
             stats={statsById.get('a')}
             isWinner={winnerVariantId === 'a'}
             winMetric={winMetric}
+            hasStarted={hasStarted}
           />
           <VariantCard
             variantId="b"
@@ -194,6 +227,7 @@ export const AbTestResults: React.FC<AbTestResultsProps> = ({
             stats={statsById.get('b')}
             isWinner={winnerVariantId === 'b'}
             winMetric={winMetric}
+            hasStarted={hasStarted}
           />
         </div>
 
@@ -203,7 +237,20 @@ export const AbTestResults: React.FC<AbTestResultsProps> = ({
           role="status"
           aria-live="polite"
         >
-          {!isDecided ? (
+          {!hasStarted ? (
+            <div className="flex items-start gap-2">
+              <FlaskConical className="w-4 h-4 mt-0.5 text-muted-foreground" aria-hidden="true" />
+              <div>
+                <p className="text-sm font-medium text-foreground">
+                  Configured — the test starts when this issue sends
+                </p>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  Each variant goes to part of the audience, and the winner is sent to the rest.
+                  No results exist yet.
+                </p>
+              </div>
+            </div>
+          ) : !isDecided ? (
             <div className="flex items-start gap-2">
               <Loader2 className="w-4 h-4 mt-0.5 text-blue-600 dark:text-blue-400 animate-spin" aria-hidden="true" />
               <div>
@@ -262,8 +309,8 @@ export const AbTestResults: React.FC<AbTestResultsProps> = ({
           <div className="flex items-start gap-2 rounded-lg border border-amber-300 bg-amber-50 dark:border-amber-500/50 dark:bg-amber-900/20 p-3 mb-4">
             <AlertTriangle className="w-4 h-4 mt-0.5 text-amber-600 dark:text-amber-400 flex-shrink-0" aria-hidden="true" />
             <p className="text-xs text-amber-800 dark:text-amber-200">
-              This test is decided on open rate. Apple Mail Privacy Protection can inflate open rates, so
-              click rate may be a more reliable signal.
+              This test {hasStarted ? 'is' : 'will be'} decided on open rate. Apple Mail Privacy
+              Protection can inflate open rates, so click rate may be a more reliable signal.
             </p>
           </div>
         )}

--- a/dashboard-ui/src/components/issues/ComplaintDetailsTable.tsx
+++ b/dashboard-ui/src/components/issues/ComplaintDetailsTable.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useMemo } from 'react';
 import { InfoTooltip } from '../ui/InfoTooltip';
 import { ComplaintDetail } from '../../types/issues';
+import { formatInTimeZone } from '@/utils/dateFormatting';
+import { useTenantDateFormat } from '@/contexts/SettingsContext';
 
 export interface ComplaintDetailsTableProps {
   complaints: ComplaintDetail[];
@@ -17,6 +19,8 @@ const SortIcon: React.FC<{ field: SortField; sortField: SortField; sortDirection
 };
 
 export const ComplaintDetailsTable: React.FC<ComplaintDetailsTableProps> = ({ complaints }) => {
+  // Dates render in the newsletter's timezone, not the viewer's.
+  const { timeZone } = useTenantDateFormat();
   const [sortField, setSortField] = useState<SortField>('timestamp');
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
   const [filterType, setFilterType] = useState<string>('all');
@@ -53,14 +57,13 @@ export const ComplaintDetailsTable: React.FC<ComplaintDetailsTableProps> = ({ co
   }, [complaints, sortField, sortDirection, filterType]);
 
   const formatTimestamp = (timestamp: string) => {
-    const date = new Date(timestamp);
-    return date.toLocaleString('en-US', {
+    return formatInTimeZone(timestamp, timeZone, {
       month: 'short',
       day: 'numeric',
       year: 'numeric',
       hour: '2-digit',
       minute: '2-digit',
-    });
+    }, 'en-US');
   };
 
   if (complaints.length === 0) {

--- a/dashboard-ui/src/components/issues/IssueStatusBadge.tsx
+++ b/dashboard-ui/src/components/issues/IssueStatusBadge.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { AlertTriangle, CheckCircle2, Clock, PencilLine, Send } from 'lucide-react';
 import { cn } from '../../utils/cn';
 import type { IssueStatus } from '../../types/issues';
 
@@ -8,38 +9,68 @@ import type { IssueStatus } from '../../types/issues';
 export interface IssueStatusBadgeProps {
   /** The current status of the issue */
   status: IssueStatus;
+  /**
+   * `sm` (default) is the inline pill used in lists. `lg` is for a page header,
+   * where the status has to be readable at a glance rather than found — a
+   * draft that looks like a published issue is how an unsent issue gets
+   * mistaken for a sent one.
+   */
+  size?: 'sm' | 'lg';
   /** Optional additional CSS classes to apply */
   className?: string;
 }
 
-const statusConfig: Record<IssueStatus, { label: string; className: string }> = {
+type StatusConfig = {
+  label: string;
+  className: string;
+  icon: React.ComponentType<{ className?: string }>;
+};
+
+const statusConfig: Record<IssueStatus, StatusConfig> = {
   draft: {
     label: 'Draft',
-    className: 'bg-gray-100 text-gray-800 border-gray-300 dark:bg-gray-700 dark:text-gray-100 dark:border-gray-500'
+    // Amber rather than grey: a draft is a state that needs action, and grey
+    // reads as "nothing to see here" next to the other statuses.
+    className: 'bg-amber-100 text-amber-900 border-amber-400 dark:bg-amber-800/60 dark:text-amber-50 dark:border-amber-400',
+    icon: PencilLine
   },
   scheduled: {
     label: 'Scheduled',
-    className: 'bg-blue-100 text-blue-800 border-blue-300 dark:bg-blue-800/60 dark:text-blue-100 dark:border-blue-400'
+    className: 'bg-blue-100 text-blue-800 border-blue-300 dark:bg-blue-800/60 dark:text-blue-100 dark:border-blue-400',
+    icon: Clock
   },
   'in progress': {
     label: 'In Progress',
-    className: 'bg-yellow-100 text-yellow-800 border-yellow-300 dark:bg-yellow-800/60 dark:text-yellow-100 dark:border-yellow-400'
+    className: 'bg-yellow-100 text-yellow-800 border-yellow-300 dark:bg-yellow-800/60 dark:text-yellow-100 dark:border-yellow-400',
+    icon: Send
   },
   published: {
     label: 'Published',
-    className: 'bg-green-100 text-green-800 border-green-300 dark:bg-green-800/60 dark:text-green-100 dark:border-green-400'
+    className: 'bg-green-100 text-green-800 border-green-300 dark:bg-green-800/60 dark:text-green-100 dark:border-green-400',
+    icon: CheckCircle2
   },
   failed: {
     label: 'Failed',
-    className: 'bg-red-100 text-red-800 border-red-300 dark:bg-red-800/60 dark:text-red-100 dark:border-red-400'
+    className: 'bg-red-100 text-red-800 border-red-300 dark:bg-red-800/60 dark:text-red-100 dark:border-red-400',
+    icon: AlertTriangle
   }
 };
+
+const SIZE_CLASSES = {
+  sm: 'px-2.5 py-0.5 text-xs gap-1',
+  lg: 'px-3 py-1 text-sm gap-1.5 shadow-sm'
+} as const;
+
+const ICON_CLASSES = {
+  sm: 'w-3 h-3',
+  lg: 'w-4 h-4'
+} as const;
 
 /**
  * Badge component that displays the status of an issue with appropriate styling
  * Supports draft, scheduled, published, and failed statuses with color-coded indicators
  */
-export const IssueStatusBadge: React.FC<IssueStatusBadgeProps> = React.memo(({ status, className }) => {
+export const IssueStatusBadge: React.FC<IssueStatusBadgeProps> = React.memo(({ status, size = 'sm', className }) => {
   const config = statusConfig[status];
 
   // Defensive check: if status is invalid, use a default config
@@ -48,7 +79,8 @@ export const IssueStatusBadge: React.FC<IssueStatusBadgeProps> = React.memo(({ s
     return (
       <span
         className={cn(
-          'inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium border',
+          'inline-flex items-center rounded-full font-medium border',
+          SIZE_CLASSES[size],
           'bg-gray-100 text-gray-800 border-gray-300 dark:bg-gray-700 dark:text-gray-100 dark:border-gray-500',
           className
         )}
@@ -60,16 +92,21 @@ export const IssueStatusBadge: React.FC<IssueStatusBadgeProps> = React.memo(({ s
     );
   }
 
+  const Icon = config.icon;
+
   return (
     <span
       className={cn(
-        'inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium border',
+        'inline-flex items-center rounded-full border',
+        size === 'lg' ? 'font-semibold' : 'font-medium',
+        SIZE_CLASSES[size],
         config.className,
         className
       )}
       role="status"
       aria-label={`Issue status: ${config.label}`}
     >
+      <Icon className={ICON_CLASSES[size]} aria-hidden="true" />
       {config.label}
     </span>
   );

--- a/dashboard-ui/src/components/issues/__tests__/AbTestResults.test.tsx
+++ b/dashboard-ui/src/components/issues/__tests__/AbTestResults.test.tsx
@@ -106,4 +106,54 @@ describe('AbTestResults', () => {
     render(<AbTestResults abTest={abTest} variantStats={baseStats} />);
     expect(screen.getByText('Send time')).toBeInTheDocument();
   });
+
+  describe('before the issue has sent', () => {
+    it('does not claim a test is running', async () => {
+      // A draft's saved config used to render "Test in progress — awaiting
+      // results" next to a spinner, describing a test that had not started.
+      render(<AbTestResults abTest={subjectTest({ status: undefined })} hasStarted={false} />);
+
+      expect(screen.queryByText(/test in progress/i)).not.toBeInTheDocument();
+      expect(
+        screen.getByText(/the test starts when this issue sends/i)
+      ).toBeInTheDocument();
+    });
+
+    it('reports the status as not started', () => {
+      render(<AbTestResults abTest={subjectTest({ status: undefined })} hasStarted={false} />);
+
+      expect(screen.getByLabelText(/A\/B test status: Not started/i)).toBeInTheDocument();
+    });
+
+    it('is titled as a configuration, not results', () => {
+      render(<AbTestResults abTest={subjectTest({ status: undefined })} hasStarted={false} />);
+
+      expect(screen.getByText('A/B Test')).toBeInTheDocument();
+      expect(screen.queryByText('A/B Test Results')).not.toBeInTheDocument();
+    });
+
+    it('shows no engagement metrics', () => {
+      // Rendering "—" and "0 / 0 delivered" reads as a measurement that came
+      // back empty rather than one that hasn't happened.
+      render(<AbTestResults abTest={subjectTest({ status: undefined })} hasStarted={false} />);
+
+      expect(screen.queryByText(/delivered/)).not.toBeInTheDocument();
+      expect(screen.getAllByText(/will be measured on open rate once sent/i)).toHaveLength(2);
+    });
+
+    it('still shows what each variant is configured to send', () => {
+      render(<AbTestResults abTest={subjectTest({ status: undefined })} hasStarted={false} />);
+
+      expect(screen.getByText('Variant A (Control)')).toBeInTheDocument();
+      expect(screen.getByText('Variant B (Challenger)')).toBeInTheDocument();
+    });
+
+    it('goes back to reporting results once the issue sends', () => {
+      // The same config, after the send has started, is a live test again.
+      render(<AbTestResults abTest={subjectTest({ status: 'testing' })} variantStats={baseStats} />);
+
+      expect(screen.getByText('A/B Test Results')).toBeInTheDocument();
+      expect(screen.getByText(/test in progress/i)).toBeInTheDocument();
+    });
+  });
 });

--- a/dashboard-ui/src/components/issues/__tests__/IssueStatusBadge.test.tsx
+++ b/dashboard-ui/src/components/issues/__tests__/IssueStatusBadge.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { IssueStatusBadge } from '../IssueStatusBadge';
+import type { IssueStatus } from '../../../types/issues';
+
+const ALL_STATUSES: IssueStatus[] = ['draft', 'scheduled', 'in progress', 'published', 'failed'];
+
+describe('IssueStatusBadge', () => {
+  it('labels every status', () => {
+    for (const status of ALL_STATUSES) {
+      const { unmount } = render(<IssueStatusBadge status={status} />);
+      expect(screen.getByRole('status')).toBeInTheDocument();
+      unmount();
+    }
+  });
+
+  it('exposes the status to assistive tech', () => {
+    render(<IssueStatusBadge status="draft" />);
+
+    expect(screen.getByLabelText('Issue status: Draft')).toBeInTheDocument();
+  });
+
+  it('gives draft a distinct treatment from published', () => {
+    // The complaint that prompted this: a draft was easy to mistake for a sent
+    // issue, because grey reads as "nothing to see here".
+    const { container: draft } = render(<IssueStatusBadge status="draft" />);
+    const draftClass = draft.querySelector('[role="status"]')!.className;
+
+    const { container: published } = render(<IssueStatusBadge status="published" />);
+    const publishedClass = published.querySelector('[role="status"]')!.className;
+
+    expect(draftClass).not.toBe(publishedClass);
+    expect(draftClass).toContain('amber');
+  });
+
+  it('renders larger and heavier at lg, for page headers', () => {
+    const { container: small } = render(<IssueStatusBadge status="draft" />);
+    const { container: large } = render(<IssueStatusBadge status="draft" size="lg" />);
+
+    expect(small.querySelector('[role="status"]')!.className).toContain('text-xs');
+
+    const largeClass = large.querySelector('[role="status"]')!.className;
+    expect(largeClass).toContain('text-sm');
+    expect(largeClass).toContain('font-semibold');
+  });
+
+  it('carries an icon so the status reads without parsing the text', () => {
+    const { container } = render(<IssueStatusBadge status="draft" />);
+
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('falls back readably for an unrecognized status', () => {
+    render(<IssueStatusBadge status={'nonsense' as IssueStatus} />);
+
+    expect(screen.getByText('nonsense')).toBeInTheDocument();
+  });
+});

--- a/dashboard-ui/src/components/senders/SenderEmailList.tsx
+++ b/dashboard-ui/src/components/senders/SenderEmailList.tsx
@@ -22,6 +22,8 @@ import {
 } from '@heroicons/react/24/outline';
 import { StarIcon as StarIconSolid } from '@heroicons/react/24/solid';
 import { cn } from '@/utils/cn';
+import { formatInTimeZone } from '@/utils/dateFormatting';
+import { useTenantDateFormat } from '@/contexts/SettingsContext';
 
 interface SenderEmailListProps {
   senders: SenderEmail[];
@@ -38,6 +40,8 @@ export const SenderEmailList: React.FC<SenderEmailListProps> = ({
   onSenderUpdated,
   isLoading = false,
 }) => {
+  // Dates render in the newsletter's timezone, not the viewer's.
+  const { timeZone } = useTenantDateFormat();
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [updatingId, setUpdatingId] = useState<string | null>(null);
   const [refreshingId, setRefreshingId] = useState<string | null>(null);
@@ -408,7 +412,7 @@ export const SenderEmailList: React.FC<SenderEmailListProps> = ({
                   )}
 
                   <div className="flex items-center space-x-1">
-                    <span>Added {new Date(sender.createdAt).toLocaleDateString()}</span>
+                    <span>Added {formatInTimeZone(sender.createdAt, timeZone, {})}</span>
                   </div>
                 </div>
               </div>

--- a/dashboard-ui/src/components/subscribers/SubscriberProfileModal.tsx
+++ b/dashboard-ui/src/components/subscribers/SubscriberProfileModal.tsx
@@ -9,6 +9,8 @@ import {
 import { getEngagementStatus } from '@/utils/engagement';
 import { subscriberService } from '@/services/subscriberService';
 import type { SubscriberListItem, SubscriberDetail, ActivityEntry } from '@/types';
+import { useTenantDateFormat } from '@/contexts/SettingsContext';
+import { formatInTimeZone } from '@/utils/dateFormatting';
 
 interface SubscriberProfileModalProps {
   subscriber: SubscriberListItem | null;
@@ -16,12 +18,12 @@ interface SubscriberProfileModalProps {
   onClose: () => void;
 }
 
-const formatDate = (dateString: string) =>
-  new Date(dateString).toLocaleDateString('en-US', {
+const formatDate = (dateString: string, timeZone?: string) =>
+  formatInTimeZone(dateString, timeZone, {
     year: 'numeric',
     month: 'short',
     day: 'numeric',
-  });
+  }, 'en-US');
 
 /** Shorten a URL to host + path for compact display; full URL goes in a title. */
 const shortenUrl = (url?: string): string => {
@@ -38,7 +40,7 @@ const shortenUrl = (url?: string): string => {
 };
 
 /** A short relative timestamp ("just now", "5h ago", "3d ago") with a date fallback. */
-const formatRelative = (iso: string): string => {
+const formatRelative = (iso: string, timeZone?: string): string => {
   const then = new Date(iso).getTime();
   if (Number.isNaN(then)) return '';
   const diffMs = Date.now() - then;
@@ -48,7 +50,7 @@ const formatRelative = (iso: string): string => {
   if (diffMs < day) return `${Math.floor(diffMs / hour)}h ago`;
   const days = Math.floor(diffMs / day);
   if (days < 30) return `${days}d ago`;
-  return formatDate(iso);
+  return formatDate(iso, timeZone);
 };
 
 const activityLabel = (entry: ActivityEntry): React.ReactNode => {
@@ -75,6 +77,8 @@ export const SubscriberProfileModal: React.FC<SubscriberProfileModalProps> = ({
   latestIssueNumber,
   onClose,
 }) => {
+  // Dates render in the newsletter's timezone, not the viewer's.
+  const { timeZone } = useTenantDateFormat();
   const [detail, setDetail] = useState<SubscriberDetail | null>(null);
   const [activityLoading, setActivityLoading] = useState(false);
   const email = subscriber?.email;
@@ -149,7 +153,7 @@ export const SubscriberProfileModal: React.FC<SubscriberProfileModalProps> = ({
             )}
           </div>
           <div className="text-xs text-muted-foreground mt-2 space-y-0.5">
-            {subscriber.addedAt && <p>Subscribed {formatDate(subscriber.addedAt)}</p>}
+            {subscriber.addedAt && <p>Subscribed {formatDate(subscriber.addedAt, timeZone)}</p>}
             {subscriber.timeZone && (
               <p title="Detected from engagement activity across 3 consecutive issues">
                 Local timezone: {subscriber.timeZone} (auto-detected)
@@ -219,7 +223,7 @@ export const SubscriberProfileModal: React.FC<SubscriberProfileModalProps> = ({
                   )}
                   <span className="min-w-0 truncate">{activityLabel(entry)}</span>
                   <span className="ml-auto text-xs text-muted-foreground whitespace-nowrap">
-                    {formatRelative(entry.ts)}
+                    {formatRelative(entry.ts, timeZone)}
                   </span>
                 </li>
               ))}

--- a/dashboard-ui/src/pages/api-keys/components/ApiKeyCard.tsx
+++ b/dashboard-ui/src/pages/api-keys/components/ApiKeyCard.tsx
@@ -10,6 +10,8 @@ import {
   NoSymbolIcon,
   ClockIcon,
 } from '@heroicons/react/24/outline';
+import { formatInTimeZone } from '@/utils/dateFormatting';
+import { useTenantDateFormat } from '@/contexts/SettingsContext';
 
 interface ApiKeyCardProps {
   apiKey: Omit<ApiKey, 'keyValue'>;
@@ -22,17 +24,19 @@ export const ApiKeyCard: React.FC<ApiKeyCardProps> = ({
   onRevoke,
   onDelete,
 }) => {
+  // Dates render in the newsletter's timezone, not the viewer's.
+  const { timeZone } = useTenantDateFormat();
   const isExpired = apiKeyService.isApiKeyExpired(apiKey);
   const isActive = apiKeyService.isApiKeyActive(apiKey);
 
   const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString('en-US', {
+    return formatInTimeZone(dateString, timeZone, {
       year: 'numeric',
       month: 'short',
       day: 'numeric',
       hour: '2-digit',
       minute: '2-digit',
-    });
+    }, 'en-US');
   };
 
   const getStatusBadge = () => {

--- a/dashboard-ui/src/pages/api-keys/components/ApiKeyCreatedModal.tsx
+++ b/dashboard-ui/src/pages/api-keys/components/ApiKeyCreatedModal.tsx
@@ -15,6 +15,8 @@ import {
   ClipboardDocumentIcon,
   ExclamationTriangleIcon,
 } from '@heroicons/react/24/outline';
+import { formatInTimeZone } from '@/utils/dateFormatting';
+import { useTenantDateFormat } from '@/contexts/SettingsContext';
 
 interface ApiKeyCreatedModalProps {
   isOpen: boolean;
@@ -27,6 +29,8 @@ export const ApiKeyCreatedModal: React.FC<ApiKeyCreatedModalProps> = ({
   onClose,
   apiKey,
 }) => {
+  // Dates render in the newsletter's timezone, not the viewer's.
+  const { timeZone } = useTenantDateFormat();
   const [isCopied, setIsCopied] = useState(false);
   const { addToast } = useToast();
 
@@ -139,13 +143,13 @@ export const ApiKeyCreatedModal: React.FC<ApiKeyCreatedModalProps> = ({
                   Created
                 </div>
                 <p className="text-foreground">
-                  {new Date(apiKey.createdAt).toLocaleDateString('en-US', {
+                  {formatInTimeZone(apiKey.createdAt, timeZone, {
                     year: 'numeric',
                     month: 'long',
                     day: 'numeric',
                     hour: '2-digit',
                     minute: '2-digit',
-                  })}
+                  }, 'en-US')}
                 </p>
               </div>
 
@@ -155,13 +159,13 @@ export const ApiKeyCreatedModal: React.FC<ApiKeyCreatedModalProps> = ({
                 </div>
                 <p className="text-foreground">
                   {apiKey.expiresAt
-                    ? new Date(apiKey.expiresAt).toLocaleDateString('en-US', {
+                    ? formatInTimeZone(apiKey.expiresAt, timeZone, {
                       year: 'numeric',
                       month: 'long',
                       day: 'numeric',
                       hour: '2-digit',
                       minute: '2-digit',
-                    })
+                    }, 'en-US')
                     : 'Never'
                   }
                 </p>

--- a/dashboard-ui/src/pages/api-keys/components/DeleteConfirmModal.tsx
+++ b/dashboard-ui/src/pages/api-keys/components/DeleteConfirmModal.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { ConfirmationDialog, confirmationPresets } from '@/components/ui/ConfirmationDialog';
 import type { ApiKey } from '@/types';
+import { formatInTimeZone } from '@/utils/dateFormatting';
+import { useTenantDateFormat } from '@/contexts/SettingsContext';
 
 interface DeleteConfirmModalProps {
   isOpen: boolean;
@@ -17,6 +19,8 @@ export const DeleteConfirmModal: React.FC<DeleteConfirmModalProps> = ({
   apiKey,
   isRevoke,
 }) => {
+  // Dates render in the newsletter's timezone, not the viewer's.
+  const { timeZone } = useTenantDateFormat();
   const confirmationProps = isRevoke
     ? confirmationPresets.revokeApiKey(apiKey.name)
     : confirmationPresets.deleteApiKey(apiKey.name);
@@ -25,9 +29,9 @@ export const DeleteConfirmModal: React.FC<DeleteConfirmModalProps> = ({
   const enhancedDetails = [
     { label: 'Name', value: apiKey.name },
     ...(apiKey.description ? [{ label: 'Description', value: apiKey.description }] : []),
-    { label: 'Created', value: new Date(apiKey.createdAt).toLocaleDateString() },
+    { label: 'Created', value: formatInTimeZone(apiKey.createdAt, timeZone, {}) },
     { label: 'Usage Count', value: `${apiKey.usageCount} request${apiKey.usageCount !== 1 ? 's' : ''}` },
-    ...(apiKey.lastUsed ? [{ label: 'Last Used', value: new Date(apiKey.lastUsed).toLocaleDateString() }] : [])
+    ...(apiKey.lastUsed ? [{ label: 'Last Used', value: formatInTimeZone(apiKey.lastUsed, timeZone, {}) }] : [])
   ];
 
   return (

--- a/dashboard-ui/src/pages/issues/IssueDetailPage.tsx
+++ b/dashboard-ui/src/pages/issues/IssueDetailPage.tsx
@@ -1,10 +1,11 @@
 import React, { useState, useEffect, useMemo, useCallback, lazy, Suspense, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { ArrowLeft, Pencil, Trash, RefreshCw, AlertCircle, TrendingUp, Users, Shield, FileText, CheckCircle, Flame, Hash, CalendarDays, Clock, Send } from 'lucide-react';
+import { ArrowLeft, Pencil, PencilLine, Trash, RefreshCw, AlertCircle, TrendingUp, Users, Shield, FileText, CheckCircle, Flame, Hash, CalendarDays, Clock, Send } from 'lucide-react';
 import { PageHero, PageHeroTitle, PageHeroChips, PageHeroChip, SegmentedControl } from '@readysetcloud/ui';
 import { Card, CardContent, CardHeader, CardTitle } from '../../components/ui/Card';
 import { Button } from '../../components/ui/Button';
 import { useToast } from '../../components/ui/Toast';
+import { cn } from '../../utils/cn';
 import { IssueStatusBadge } from '../../components/issues/IssueStatusBadge';
 import { MarkdownPreview } from '../../components/issues/MarkdownPreview';
 import { DeleteIssueDialog } from '../../components/issues/DeleteIssueDialog';
@@ -513,6 +514,15 @@ export const IssueDetailPage: React.FC = () => {
 
   const isDraft = useMemo(() => issue?.status === 'draft', [issue?.status]);
   const isPublished = useMemo(() => issue?.status === 'published', [issue?.status]);
+  /**
+   * Whether the issue has reached the point where things actually happen —
+   * mail goes out, an A/B sample is measured. A draft or a scheduled issue
+   * hasn't sent anything yet, so panels must not report on it as if it had.
+   */
+  const hasStartedSending = useMemo(
+    () => issue?.status === 'in progress' || issue?.status === 'published' || issue?.status === 'failed',
+    [issue?.status]
+  );
   const canMarkAsPublished = useMemo(() => issue?.status === 'in progress' || issue?.status === 'failed', [issue?.status]);
 
   // The content heatmap overlays click data on the rendered markdown, so it only
@@ -748,7 +758,7 @@ export const IssueDetailPage: React.FC = () => {
               <div className="flex-1 min-w-0">
                 <div className="flex items-center gap-3 mb-3 flex-wrap">
                   <PageHeroTitle className="break-words">{issue.subject}</PageHeroTitle>
-                  <IssueStatusBadge status={issue.status} />
+                  <IssueStatusBadge status={issue.status} size="lg" />
                 </div>
                 <PageHeroChips>
                   <PageHeroChip icon={<Hash className="w-3.5 h-3.5" />}>
@@ -915,6 +925,40 @@ export const IssueDetailPage: React.FC = () => {
           </div>
         )}
 
+        {/* Unsent-state notice. The badge alone sits inline with the title and is
+            easy to read past; this states plainly that nothing has gone out,
+            which is the thing that matters when previewing a draft. */}
+        {!hasStartedSending && (
+          <Card
+            className={cn(
+              'shadow-sm mb-4 sm:mb-6 border-l-4',
+              isDraft ? 'border-l-amber-500' : 'border-l-blue-500'
+            )}
+          >
+            <CardContent className="p-3 sm:p-4">
+              <div className="flex items-start gap-3">
+                {isDraft ? (
+                  <PencilLine className="h-5 w-5 text-amber-600 dark:text-amber-400 shrink-0 mt-0.5" aria-hidden="true" />
+                ) : (
+                  <Clock className="h-5 w-5 text-blue-600 dark:text-blue-400 shrink-0 mt-0.5" aria-hidden="true" />
+                )}
+                <div>
+                  <p className="text-sm font-semibold text-foreground">
+                    {isDraft ? 'This is a draft — it has not been sent' : 'Scheduled — it has not been sent yet'}
+                  </p>
+                  <p className="text-sm text-muted-foreground mt-0.5">
+                    {isDraft
+                      ? 'Everything below is a preview. No subscriber has received this issue, and there are no results to report.'
+                      : issue.scheduledAt
+                        ? `Everything below is a preview until it sends on ${formatDate(issue.scheduledAt)}.`
+                        : 'Everything below is a preview until it sends.'}
+                  </p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
         {/* A/B Test Results Panel - Show whenever the issue has a managed A/B test */}
         {issue.abTest && (
           <div className="mb-4 sm:mb-6">
@@ -923,6 +967,7 @@ export const IssueDetailPage: React.FC = () => {
                 <AbTestResults
                   abTest={issue.abTest}
                   variantStats={issue.variantStats}
+                  hasStarted={hasStartedSending}
                 />
               </AsyncErrorBoundary>
             </FadeIn>

--- a/dashboard-ui/src/pages/reports/ReportDetailPage.tsx
+++ b/dashboard-ui/src/pages/reports/ReportDetailPage.tsx
@@ -22,7 +22,7 @@ import { cn } from '@/utils/cn';
 import { reportsService } from '@/services/reportsService';
 import type { MonthlyReport, ReportInsightSeverity } from '@/types/reports';
 import { useTenantDateFormat } from '@/contexts/SettingsContext';
-import { formatInTimeZone } from '@/utils/dateFormatting';
+import { formatCalendarDate, formatInTimeZone } from '@/utils/dateFormatting';
 
 const formatPercent = (value: number): string => `${value.toFixed(1)}%`;
 const formatNumber = (value: number): string => value.toLocaleString('en-US');
@@ -31,6 +31,18 @@ const formatSignedNumber = (value: number): string =>
 
 const formatDate = (dateString: string, timeZone?: string): string =>
   formatInTimeZone(dateString, timeZone, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  }, 'en-US');
+
+/**
+ * The reporting window is built from UTC month boundaries, so its ends name
+ * calendar days rather than instants. Shifting them into the tenant's zone
+ * would report July as running from June 30.
+ */
+const formatPeriodDate = (dateString: string): string =>
+  formatCalendarDate(dateString, {
     year: 'numeric',
     month: 'short',
     day: 'numeric',
@@ -260,7 +272,7 @@ export const ReportDetailPage: React.FC = () => {
             {report.monthLabel} Report
           </h1>
           <p className="text-sm text-muted-foreground mt-1">
-            {formatDate(report.periodStart, timeZone)} – {formatDate(report.periodEnd, timeZone)} · Generated{' '}
+            {formatPeriodDate(report.periodStart)} – {formatPeriodDate(report.periodEnd)} · Generated{' '}
             {formatDate(report.generatedAt, timeZone)}
           </p>
         </div>

--- a/dashboard-ui/src/pages/reports/ReportDetailPage.tsx
+++ b/dashboard-ui/src/pages/reports/ReportDetailPage.tsx
@@ -21,18 +21,20 @@ import { useToast } from '@/components/ui/Toast';
 import { cn } from '@/utils/cn';
 import { reportsService } from '@/services/reportsService';
 import type { MonthlyReport, ReportInsightSeverity } from '@/types/reports';
+import { useTenantDateFormat } from '@/contexts/SettingsContext';
+import { formatInTimeZone } from '@/utils/dateFormatting';
 
 const formatPercent = (value: number): string => `${value.toFixed(1)}%`;
 const formatNumber = (value: number): string => value.toLocaleString('en-US');
 const formatSignedNumber = (value: number): string =>
   `${value > 0 ? '+' : ''}${value.toLocaleString('en-US')}`;
 
-const formatDate = (dateString: string): string =>
-  new Date(dateString).toLocaleDateString('en-US', {
+const formatDate = (dateString: string, timeZone?: string): string =>
+  formatInTimeZone(dateString, timeZone, {
     year: 'numeric',
     month: 'short',
     day: 'numeric',
-  });
+  }, 'en-US');
 
 /**
  * Severity styling mirrors the issues analytics `InsightsHeroSection` palette:
@@ -111,6 +113,8 @@ const Section: React.FC<SectionProps> = ({ title, icon, children }) => (
 );
 
 export const ReportDetailPage: React.FC = () => {
+  // Dates render in the newsletter's timezone, not the viewer's.
+  const { timeZone } = useTenantDateFormat();
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const { addToast } = useToast();
@@ -256,8 +260,8 @@ export const ReportDetailPage: React.FC = () => {
             {report.monthLabel} Report
           </h1>
           <p className="text-sm text-muted-foreground mt-1">
-            {formatDate(report.periodStart)} – {formatDate(report.periodEnd)} · Generated{' '}
-            {formatDate(report.generatedAt)}
+            {formatDate(report.periodStart, timeZone)} – {formatDate(report.periodEnd, timeZone)} · Generated{' '}
+            {formatDate(report.generatedAt, timeZone)}
           </p>
         </div>
 
@@ -471,7 +475,7 @@ export const ReportDetailPage: React.FC = () => {
                         >
                           <div className="text-sm font-medium text-foreground">{issue.subject}</div>
                           <div className="text-xs text-muted-foreground mt-0.5">
-                            #{issue.issueNumber} · {formatDate(issue.publishedAt)}
+                            #{issue.issueNumber} · {formatDate(issue.publishedAt, timeZone)}
                           </div>
                         </button>
                       </td>

--- a/dashboard-ui/src/pages/segments/SegmentDetailPage.tsx
+++ b/dashboard-ui/src/pages/segments/SegmentDetailPage.tsx
@@ -7,8 +7,12 @@ import { Card, CardContent } from '@/components/ui/Card';
 import { segmentService } from '@/services/segmentService';
 import type { Segment, SegmentMember } from '@/services/segmentService';
 import { getSortedInterestProfile, RECENCY_STYLES } from './interestProfileUtils';
+import { useTenantDateFormat } from '@/contexts/SettingsContext';
+import { formatInTimeZone } from '@/utils/dateFormatting';
 
 export const SegmentDetailPage: React.FC = () => {
+  // Dates render in the newsletter's timezone, not the viewer's.
+  const { timeZone } = useTenantDateFormat();
   const { segmentId } = useParams<{ segmentId: string }>();
   const navigate = useNavigate();
   const { addToast } = useToast();
@@ -240,7 +244,8 @@ export const SegmentDetailPage: React.FC = () => {
   const editDescError = editDescription.length > 500 ? 'Description must not exceed 500 characters' : null;
   const canSaveEdit = editName.trim().length >= 1 && !editNameError && !editDescError && !saving;
 
-  const formatDate = (d: string) => new Date(d).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+  const formatDate = (d: string) =>
+    formatInTimeZone(d, timeZone, { year: 'numeric', month: 'short', day: 'numeric' }, 'en-US');
 
   // --- Render: Loading ---
   if (loading) {

--- a/dashboard-ui/src/pages/segments/SegmentListPage.tsx
+++ b/dashboard-ui/src/pages/segments/SegmentListPage.tsx
@@ -6,8 +6,12 @@ import { useToast } from '@/components/ui/Toast';
 import { Card, CardContent } from '@/components/ui/Card';
 import { segmentService } from '@/services/segmentService';
 import type { Segment } from '@/services/segmentService';
+import { useTenantDateFormat } from '@/contexts/SettingsContext';
+import { formatInTimeZone } from '@/utils/dateFormatting';
 
 export const SegmentListPage: React.FC = () => {
+  // Dates render in the newsletter's timezone, not the viewer's.
+  const { timeZone } = useTenantDateFormat();
   const navigate = useNavigate();
   const { addToast } = useToast();
 
@@ -109,7 +113,7 @@ export const SegmentListPage: React.FC = () => {
   }, [segmentToDelete, segments, addToast]);
 
   const formatDate = (dateString: string) =>
-    new Date(dateString).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+    formatInTimeZone(dateString, timeZone, { year: 'numeric', month: 'short', day: 'numeric' }, 'en-US');
 
   const manualSegments = useMemo(() => segments.filter(s => !s.autoManaged), [segments]);
   const autoSegments = useMemo(() => segments.filter(s => s.autoManaged), [segments]);

--- a/dashboard-ui/src/pages/snippets/SnippetsListPage.tsx
+++ b/dashboard-ui/src/pages/snippets/SnippetsListPage.tsx
@@ -14,8 +14,12 @@ import {
   PencilSquareIcon,
   TrashIcon,
 } from '@heroicons/react/24/outline';
+import { formatInTimeZone } from '@/utils/dateFormatting';
+import { useTenantDateFormat } from '@/contexts/SettingsContext';
 
 export function SnippetsListPage() {
+  // Dates render in the newsletter's timezone, not the viewer's.
+  const { timeZone } = useTenantDateFormat();
   const navigate = useNavigate();
   const { addToast } = useToast();
   const { showConfirmation, ConfirmationDialog } = useConfirmationDialog();
@@ -125,7 +129,7 @@ export function SnippetsListPage() {
                         <p className="text-sm text-muted-foreground truncate mt-0.5">{snippet.description}</p>
                       )}
                       <p className="text-xs text-muted-foreground mt-1">
-                        Updated {new Date(snippet.updatedAt).toLocaleDateString()} · v{snippet.version}
+                        Updated {formatInTimeZone(snippet.updatedAt, timeZone, {})} · v{snippet.version}
                       </p>
                     </div>
                   </button>

--- a/dashboard-ui/src/pages/sponsors/SponsorDetailPage.tsx
+++ b/dashboard-ui/src/pages/sponsors/SponsorDetailPage.tsx
@@ -30,7 +30,7 @@ import type {
   CreateSponsorshipRequest,
   UpdateSponsorshipRequest,
 } from '../../services/sponsorService';
-import { formatInTimeZone } from '@/utils/dateFormatting';
+import { formatCalendarDate, formatInTimeZone } from '@/utils/dateFormatting';
 import { useTenantDateFormat } from '@/contexts/SettingsContext';
 
 // --- Helpers ---
@@ -38,6 +38,18 @@ import { useTenantDateFormat } from '@/contexts/SettingsContext';
 const formatDate = (dateString?: string, timeZone?: string) => {
   if (!dateString) return '—';
   return formatInTimeZone(dateString, timeZone, {
+    year: 'numeric', month: 'short', day: 'numeric',
+  }, 'en-US');
+};
+
+/**
+ * Sponsorship dates are entered in a `type="date"` field and stored verbatim,
+ * so they name a day, not an instant. Rendering them in the tenant's zone
+ * would move them a day earlier anywhere west of UTC.
+ */
+const formatSponsorshipDate = (dateString?: string) => {
+  if (!dateString) return '—';
+  return formatCalendarDate(dateString, {
     year: 'numeric', month: 'short', day: 'numeric',
   }, 'en-US');
 };
@@ -710,7 +722,7 @@ export const SponsorDetailPage: React.FC = () => {
           <Card>
             <CardContent className="text-center py-4">
               <p className="text-xs text-muted-foreground">Last Sponsored</p>
-              <p className="text-xl font-bold text-foreground">{formatDate(sponsor.lastSponsoredDate, timeZone)}</p>
+              <p className="text-xl font-bold text-foreground">{formatSponsorshipDate(sponsor.lastSponsoredDate)}</p>
             </CardContent>
           </Card>
         </div>
@@ -789,7 +801,7 @@ export const SponsorDetailPage: React.FC = () => {
                         <td className="px-4 py-3 text-sm text-foreground max-w-[200px] truncate" title={entry.issueTitle}>
                           {entry.issueTitle || entry.issueId}
                         </td>
-                        <td className="px-4 py-3 text-sm text-muted-foreground whitespace-nowrap">{formatDate(entry.sponsorshipDate, timeZone)}</td>
+                        <td className="px-4 py-3 text-sm text-muted-foreground whitespace-nowrap">{formatSponsorshipDate(entry.sponsorshipDate)}</td>
                         <td className="px-4 py-3 text-sm text-foreground whitespace-nowrap">{formatCurrency(entry.amountCharged)}</td>
                         <td className="px-4 py-3">
                           <span className={`inline-flex px-2 py-0.5 rounded text-xs font-medium ${statusColor(entry.status)}`}>

--- a/dashboard-ui/src/pages/sponsors/SponsorDetailPage.tsx
+++ b/dashboard-ui/src/pages/sponsors/SponsorDetailPage.tsx
@@ -30,22 +30,24 @@ import type {
   CreateSponsorshipRequest,
   UpdateSponsorshipRequest,
 } from '../../services/sponsorService';
+import { formatInTimeZone } from '@/utils/dateFormatting';
+import { useTenantDateFormat } from '@/contexts/SettingsContext';
 
 // --- Helpers ---
 
-const formatDate = (dateString?: string) => {
+const formatDate = (dateString?: string, timeZone?: string) => {
   if (!dateString) return '—';
-  return new Date(dateString).toLocaleDateString('en-US', {
+  return formatInTimeZone(dateString, timeZone, {
     year: 'numeric', month: 'short', day: 'numeric',
-  });
+  }, 'en-US');
 };
 
-const formatDateTime = (dateString?: string) => {
+const formatDateTime = (dateString?: string, timeZone?: string) => {
   if (!dateString) return '—';
-  return new Date(dateString).toLocaleString('en-US', {
+  return formatInTimeZone(dateString, timeZone, {
     year: 'numeric', month: 'short', day: 'numeric',
     hour: '2-digit', minute: '2-digit',
-  });
+  }, 'en-US');
 };
 
 const formatCurrency = (amount: number) =>
@@ -55,10 +57,10 @@ const formatCurrency = (amount: number) =>
 // --- Sub-components ---
 
 /** Archived status badge */
-const ArchivedBadge: React.FC<{ archivedAt?: string }> = ({ archivedAt }) => (
+const ArchivedBadge: React.FC<{ archivedAt?: string; timeZone?: string }> = ({ archivedAt, timeZone }) => (
   <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-warning-100 text-warning-800 dark:bg-warning-900/30 dark:text-warning-300">
     <Archive className="w-3 h-3" />
-    Archived{archivedAt ? ` on ${formatDate(archivedAt)}` : ''}
+    Archived{archivedAt ? ` on ${formatDate(archivedAt, timeZone)}` : ''}
   </span>
 );
 
@@ -131,6 +133,8 @@ const EditableField: React.FC<{
 // --- Main Component ---
 
 export const SponsorDetailPage: React.FC = () => {
+  // Dates render in the newsletter's timezone, not the viewer's.
+  const { timeZone } = useTenantDateFormat();
   const { sponsorId } = useParams<{ sponsorId: string }>();
   const navigate = useNavigate();
   const { addToast } = useToast();
@@ -566,7 +570,7 @@ export const SponsorDetailPage: React.FC = () => {
           <div>
             <div className="flex items-center gap-3 mb-1">
               <h1 className="text-2xl sm:text-3xl font-bold text-foreground">{sponsor.sponsorName}</h1>
-              {sponsor.status === 'archived' && <ArchivedBadge archivedAt={sponsor.archivedAt} />}
+              {sponsor.status === 'archived' && <ArchivedBadge archivedAt={sponsor.archivedAt} timeZone={timeZone} />}
             </div>
             {sponsor.shortDescription && (
               <p className="text-sm text-muted-foreground">{sponsor.shortDescription}</p>
@@ -574,7 +578,7 @@ export const SponsorDetailPage: React.FC = () => {
             {sponsor.lastOutreachAt && (
               <p className="text-xs text-muted-foreground mt-1">
                 <Clock className="w-3 h-3 inline mr-1" />
-                Last outreach: {formatDateTime(sponsor.lastOutreachAt)}
+                Last outreach: {formatDateTime(sponsor.lastOutreachAt, timeZone)}
               </p>
             )}
           </div>
@@ -679,11 +683,11 @@ export const SponsorDetailPage: React.FC = () => {
               </div>
               <div>
                 <p className="text-xs text-muted-foreground">Created</p>
-                <p className="text-sm font-medium text-foreground">{formatDate(sponsor.createdAt)}</p>
+                <p className="text-sm font-medium text-foreground">{formatDate(sponsor.createdAt, timeZone)}</p>
               </div>
               <div>
                 <p className="text-xs text-muted-foreground">Updated</p>
-                <p className="text-sm font-medium text-foreground">{formatDate(sponsor.updatedAt)}</p>
+                <p className="text-sm font-medium text-foreground">{formatDate(sponsor.updatedAt, timeZone)}</p>
               </div>
             </div>
           </CardContent>
@@ -706,7 +710,7 @@ export const SponsorDetailPage: React.FC = () => {
           <Card>
             <CardContent className="text-center py-4">
               <p className="text-xs text-muted-foreground">Last Sponsored</p>
-              <p className="text-xl font-bold text-foreground">{formatDate(sponsor.lastSponsoredDate)}</p>
+              <p className="text-xl font-bold text-foreground">{formatDate(sponsor.lastSponsoredDate, timeZone)}</p>
             </CardContent>
           </Card>
         </div>
@@ -785,7 +789,7 @@ export const SponsorDetailPage: React.FC = () => {
                         <td className="px-4 py-3 text-sm text-foreground max-w-[200px] truncate" title={entry.issueTitle}>
                           {entry.issueTitle || entry.issueId}
                         </td>
-                        <td className="px-4 py-3 text-sm text-muted-foreground whitespace-nowrap">{formatDate(entry.sponsorshipDate)}</td>
+                        <td className="px-4 py-3 text-sm text-muted-foreground whitespace-nowrap">{formatDate(entry.sponsorshipDate, timeZone)}</td>
                         <td className="px-4 py-3 text-sm text-foreground whitespace-nowrap">{formatCurrency(entry.amountCharged)}</td>
                         <td className="px-4 py-3">
                           <span className={`inline-flex px-2 py-0.5 rounded text-xs font-medium ${statusColor(entry.status)}`}>
@@ -862,7 +866,7 @@ export const SponsorDetailPage: React.FC = () => {
               <CardTitle>Outreach</CardTitle>
               {sponsor.lastOutreachAt && (
                 <span className="text-xs text-muted-foreground">
-                  Last: {formatDateTime(sponsor.lastOutreachAt)}
+                  Last: {formatDateTime(sponsor.lastOutreachAt, timeZone)}
                 </span>
               )}
             </div>
@@ -873,7 +877,7 @@ export const SponsorDetailPage: React.FC = () => {
               <div className="mb-4">
                 <div className="flex items-center gap-2 mb-2">
                   <p className="text-xs text-muted-foreground">
-                    Generated {formatDateTime(latestOutreach.generatedAt)}
+                    Generated {formatDateTime(latestOutreach.generatedAt, timeZone)}
                   </p>
                   {latestOutreach.isFallback && (
                     <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-warning-100 text-warning-800 dark:bg-warning-900/30 dark:text-warning-300">
@@ -917,7 +921,7 @@ export const SponsorDetailPage: React.FC = () => {
                       <div key={email.generatedAt} className="p-3 rounded-md border border-border bg-muted/10">
                         <div className="flex items-center justify-between mb-1">
                           <div className="flex items-center gap-2">
-                            <p className="text-xs text-muted-foreground">{formatDateTime(email.generatedAt)}</p>
+                            <p className="text-xs text-muted-foreground">{formatDateTime(email.generatedAt, timeZone)}</p>
                             {email.isFallback && (
                               <span className="text-xs text-warning-600">Fallback</span>
                             )}

--- a/dashboard-ui/src/pages/sponsors/SponsorDirectoryPage.tsx
+++ b/dashboard-ui/src/pages/sponsors/SponsorDirectoryPage.tsx
@@ -12,7 +12,7 @@ import {
   filterSponsors,
 } from '../../services/sponsorService';
 import type { SponsorRecord, CreateSponsorRequest } from '../../services/sponsorService';
-import { formatInTimeZone } from '@/utils/dateFormatting';
+import { formatCalendarDate, formatInTimeZone } from '@/utils/dateFormatting';
 import { useTenantDateFormat } from '@/contexts/SettingsContext';
 
 export const SponsorDirectoryPage: React.FC = () => {
@@ -370,7 +370,7 @@ export const SponsorDirectoryPage: React.FC = () => {
                         {formatCurrency(sponsor.totalRevenue)}
                       </td>
                       <td className="px-6 py-4 text-sm text-muted-foreground hidden lg:table-cell">
-                        {formatDate(sponsor.lastSponsoredDate)}
+                        {formatCalendarDate(sponsor.lastSponsoredDate, { year: 'numeric', month: 'short', day: 'numeric' }, 'en-US')}
                       </td>
                       <td className="px-6 py-4 text-sm text-muted-foreground hidden xl:table-cell">
                         {formatDate(sponsor.lastOutreachAt)}

--- a/dashboard-ui/src/pages/sponsors/SponsorDirectoryPage.tsx
+++ b/dashboard-ui/src/pages/sponsors/SponsorDirectoryPage.tsx
@@ -12,8 +12,12 @@ import {
   filterSponsors,
 } from '../../services/sponsorService';
 import type { SponsorRecord, CreateSponsorRequest } from '../../services/sponsorService';
+import { formatInTimeZone } from '@/utils/dateFormatting';
+import { useTenantDateFormat } from '@/contexts/SettingsContext';
 
 export const SponsorDirectoryPage: React.FC = () => {
+  // Dates render in the newsletter's timezone, not the viewer's.
+  const { timeZone } = useTenantDateFormat();
   const navigate = useNavigate();
   const { addToast } = useToast();
 
@@ -69,11 +73,11 @@ export const SponsorDirectoryPage: React.FC = () => {
 
   const formatDate = (dateString?: string) => {
     if (!dateString) return '—';
-    return new Date(dateString).toLocaleDateString('en-US', {
+    return formatInTimeZone(dateString, timeZone, {
       year: 'numeric',
       month: 'short',
       day: 'numeric',
-    });
+    }, 'en-US');
   };
 
   const formatCurrency = (amount: number) =>

--- a/dashboard-ui/src/pages/subscribers/SubscribersPage.tsx
+++ b/dashboard-ui/src/pages/subscribers/SubscribersPage.tsx
@@ -19,13 +19,15 @@ import { segmentService } from '@/services/segmentService';
 import { useMediaQuery } from '@/hooks/useMediaQuery';
 import type { Segment } from '@/services/segmentService';
 import type { SubscriberTrendsResponse, SubscriberListItem } from '@/types';
+import { useTenantDateFormat } from '@/contexts/SettingsContext';
+import { formatInTimeZone } from '@/utils/dateFormatting';
 
-const formatDate = (dateString: string) =>
-  new Date(dateString).toLocaleDateString('en-US', {
+const formatDate = (dateString: string, timeZone?: string) =>
+  formatInTimeZone(dateString, timeZone, {
     year: 'numeric',
     month: 'short',
     day: 'numeric',
-  });
+  }, 'en-US');
 
 /** Skeleton for the subscriber count metric card (Row 1) */
 const MetricSkeleton: React.FC = () => (
@@ -88,6 +90,8 @@ const SectionError: React.FC<{ message: string; onRetry: () => void }> = ({ mess
 );
 
 export const SubscribersPage: React.FC = () => {
+  // Dates render in the newsletter's timezone, not the viewer's.
+  const { timeZone } = useTenantDateFormat();
   const navigate = useNavigate();
   const { addToast } = useToast();
   // Below Tailwind's `sm` breakpoint we swap the multi-column table for a
@@ -297,7 +301,7 @@ export const SubscribersPage: React.FC = () => {
                 >
                   {label.text}
                 </span>
-                <span>{sub.addedAt ? formatDate(sub.addedAt) : '—'}</span>
+                <span>{sub.addedAt ? formatDate(sub.addedAt, timeZone) : '—'}</span>
               </div>
             </div>
           );
@@ -332,7 +336,7 @@ export const SubscribersPage: React.FC = () => {
         ),
       },
     ],
-    [sortDirection, toggleSortDirection, SortIcon, getEngagementLabel, renderBotBadge, handleUnsubscribe]
+    [sortDirection, toggleSortDirection, SortIcon, getEngagementLabel, renderBotBadge, handleUnsubscribe, timeZone]
   );
 
   const subscriberColumns: VirtualTableColumn<SubscriberListItem>[] = useMemo(
@@ -402,7 +406,7 @@ export const SubscribersPage: React.FC = () => {
         ),
         render: (sub) => (
           <span className="text-muted-foreground">
-            {sub.addedAt ? formatDate(sub.addedAt) : '—'}
+            {sub.addedAt ? formatDate(sub.addedAt, timeZone) : '—'}
           </span>
         ),
       },
@@ -433,7 +437,7 @@ export const SubscribersPage: React.FC = () => {
         ),
       },
     ],
-    [sortDirection, toggleSortDirection, SortIcon, getEngagementLabel, renderBotBadge, handleUnsubscribe]
+    [sortDirection, toggleSortDirection, SortIcon, getEngagementLabel, renderBotBadge, handleUnsubscribe, timeZone]
   );
 
   const segmentColumns: DataListColumn<Segment>[] = useMemo(
@@ -470,12 +474,12 @@ export const SubscribersPage: React.FC = () => {
         headerClassName: 'hidden md:table-cell',
         render: (segment) => (
           <span className="text-muted-foreground">
-            {formatDate(segment.createdAt)}
+            {formatDate(segment.createdAt, timeZone)}
           </span>
         ),
       },
     ],
-    []
+    [timeZone]
   );
 
   const handleSegmentClick = useCallback(

--- a/dashboard-ui/src/pages/templates/TemplatesListPage.tsx
+++ b/dashboard-ui/src/pages/templates/TemplatesListPage.tsx
@@ -14,8 +14,12 @@ import {
   PencilSquareIcon,
   TrashIcon,
 } from '@heroicons/react/24/outline';
+import { formatInTimeZone } from '@/utils/dateFormatting';
+import { useTenantDateFormat } from '@/contexts/SettingsContext';
 
 export function TemplatesListPage() {
+  // Dates render in the newsletter's timezone, not the viewer's.
+  const { timeZone } = useTenantDateFormat();
   const navigate = useNavigate();
   const { addToast } = useToast();
   const { showConfirmation, ConfirmationDialog } = useConfirmationDialog();
@@ -130,7 +134,7 @@ export function TemplatesListPage() {
                         <p className="text-sm text-muted-foreground truncate mt-0.5">{template.description}</p>
                       )}
                       <p className="text-xs text-muted-foreground mt-1">
-                        Updated {new Date(template.updatedAt).toLocaleDateString()} · v{template.version}
+                        Updated {formatInTimeZone(template.updatedAt, timeZone, {})} · v{template.version}
                       </p>
                     </div>
                   </button>

--- a/dashboard-ui/src/utils/__tests__/dateFormatting.test.ts
+++ b/dashboard-ui/src/utils/__tests__/dateFormatting.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   combineDateAndTimeInTimeZone,
+  formatCalendarDate,
   formatDateInTimeZone,
   formatDateTimeInTimeZone,
   formatTimeInTimeZone,
@@ -160,6 +161,35 @@ describe('dateFormatting', () => {
     it('returns an empty string when either half is missing', () => {
       expect(combineDateAndTimeInTimeZone('', '09:00', 'UTC')).toBe('');
       expect(combineDateAndTimeInTimeZone('2026-08-01', '', 'UTC')).toBe('');
+    });
+  });
+
+  describe('formatCalendarDate', () => {
+    const OPTIONS = { year: 'numeric', month: 'short', day: 'numeric' } as const;
+
+    it('keeps the day a bare YYYY-MM-DD names', () => {
+      // The bug this exists for: `2026-01-15` parses as midnight UTC, so
+      // formatting it in a zone west of UTC renders January 14 — moving a
+      // sponsorship a day earlier than the one that was entered.
+      expect(formatCalendarDate('2026-01-15', OPTIONS, 'en-US')).toBe('Jan 15, 2026');
+    });
+
+    it('keeps a UTC-midnight boundary on its own day', () => {
+      // Reporting periods are built from UTC month edges; in Chicago this
+      // instant is 6pm on June 30.
+      expect(formatCalendarDate('2026-07-01T00:00:00.000Z', OPTIONS, 'en-US')).toBe('Jul 1, 2026');
+    });
+
+    it('differs from zoned formatting exactly where it should', () => {
+      // Same input, the two helpers, one calendar day apart — this is what
+      // makes the distinction worth having.
+      expect(formatDateInTimeZone('2026-01-15', 'America/Chicago')).toBe('Jan 14, 2026');
+      expect(formatCalendarDate('2026-01-15', OPTIONS, 'en-US')).toBe('Jan 15, 2026');
+    });
+
+    it('formats empty and unparseable values as an empty string', () => {
+      expect(formatCalendarDate('', OPTIONS)).toBe('');
+      expect(formatCalendarDate('not a date', OPTIONS)).toBe('');
     });
   });
 });

--- a/dashboard-ui/src/utils/__tests__/issueDetailUtils.test.ts
+++ b/dashboard-ui/src/utils/__tests__/issueDetailUtils.test.ts
@@ -12,6 +12,7 @@ import {
   saveScrollPosition,
   loadScrollPosition,
   clearScrollPosition,
+  formatDate,
 } from '../issueDetailUtils';
 
 describe('User Preferences', () => {
@@ -205,5 +206,36 @@ describe('Scroll Position', () => {
       const loaded = loadScrollPosition('issue-123');
       expect(loaded).toBeNull();
     });
+  });
+});
+
+describe('formatDate', () => {
+  // 14:00Z is 9am in Chicago during daylight saving, and still Jul 31 there
+  // when it is already Aug 1 in UTC.
+  const instant = '2026-08-01T14:00:00Z';
+
+  it('formats in the timezone it is given', () => {
+    expect(formatDate(instant, false, 'America/Chicago')).toBe('Aug 1, 2026');
+    expect(formatDate(instant, true, 'America/Chicago')).toContain('09:00');
+    expect(formatDate(instant, true, 'UTC')).toContain('02:00');
+  });
+
+  it('can put an instant on a different calendar day per zone', () => {
+    const lateEvening = '2026-08-01T04:00:00Z';
+
+    expect(formatDate(lateEvening, false, 'UTC')).toBe('Aug 1, 2026');
+    expect(formatDate(lateEvening, false, 'America/Chicago')).toBe('Jul 31, 2026');
+  });
+
+  it('falls back to the browser zone when no timezone is supplied', () => {
+    // Callers without tenant context keep the old behavior rather than
+    // silently formatting against UTC.
+    expect(formatDate(instant, false)).toBe(
+      new Date(instant).toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      })
+    );
   });
 });

--- a/dashboard-ui/src/utils/dateFormatting.ts
+++ b/dashboard-ui/src/utils/dateFormatting.ts
@@ -267,6 +267,26 @@ export function combineDateAndTimeInTimeZone(
   return fromDatetimeLocalInTimeZone(`${date}T${time}`, timeZone);
 }
 
+/**
+ * Formats a *calendar date* — a value that names a day rather than an instant.
+ *
+ * These come from `<input type="date">` fields (stored verbatim as
+ * `YYYY-MM-DD`) and from period boundaries built at UTC midnight. They are not
+ * moments in time, so shifting them into any zone is wrong: `2026-01-15` read
+ * in a zone west of UTC renders as January 14, moving a sponsorship or a
+ * reporting period a day earlier than the one that was entered.
+ *
+ * Formatting in UTC is what keeps the day intact, because that is the zone a
+ * bare `YYYY-MM-DD` parses into.
+ */
+export function formatCalendarDate(
+  value: DateInput,
+  options: Intl.DateTimeFormatOptions,
+  locale?: string
+): string {
+  return formatInTimeZone(value, 'UTC', options, locale);
+}
+
 /** The browser's own timezone, used to seed a tenant that hasn't picked one. */
 export function getBrowserTimeZone(): string {
   try {

--- a/dashboard-ui/src/utils/issueDetailUtils.ts
+++ b/dashboard-ui/src/utils/issueDetailUtils.ts
@@ -4,6 +4,7 @@
 
 import type { IssueMetrics } from '../types/issues';
 import { STORAGE_KEYS } from '@/constants/brand';
+import { formatInTimeZone } from './dateFormatting';
 
 /**
  * Comparison result for metrics
@@ -52,26 +53,35 @@ export function calculateComparison(
 }
 
 /**
- * Format a date string
+ * Format a date string.
+ *
+ * `timeZone` should be the newsletter's zone (components get it from
+ * `useTenantDateFormat`). It falls back to the viewer's browser zone when
+ * omitted, which is only correct for callers with no tenant context.
  */
-export function formatDate(dateString: string, includeTime: boolean = true): string {
-  const date = new Date(dateString);
-
-  if (includeTime) {
-    return date.toLocaleDateString('en-US', {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-    });
-  }
-
-  return date.toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-  });
+export function formatDate(
+  dateString: string,
+  includeTime: boolean = true,
+  timeZone?: string
+): string {
+  return formatInTimeZone(
+    dateString,
+    timeZone,
+    includeTime
+      ? {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+      }
+      : {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      },
+    'en-US'
+  );
 }
 
 /**


### PR DESCRIPTION
Three things, the first two reported from previewing a draft issue.

## The A/B panel claimed a test was running before anything had sent

A draft with a saved A/B config rendered **"Test in progress — awaiting results"** under an animated spinner, with rate cards showing `—` and `0 / 0 delivered`. Nothing had been sent — that panel was describing a test that had not started.

`AbTestResults` now takes an explicit `hasStarted`, driven by the issue's own status (`in progress` / `published` / `failed`). Before the send it presents as configuration:

| | Before send | After send |
|---|---|---|
| Title | A/B Test | A/B Test Results |
| Badge | Not started | Testing / Evaluating / Sent … |
| Summary | Configured — the test starts when this issue sends | Test in progress — awaiting results |
| Metrics | "Will be measured on open rate once sent" | Live open/click rates |

Rendering `—` and `0 / 0 delivered` reads as a measurement that came back empty rather than one that hasn't happened, so the metrics are replaced rather than zeroed. Once the issue sends, the panel behaves exactly as before.

## The status was easy to miss

Draft was a small **grey** pill inline with the title, which reads as "nothing to see here" next to the other statuses.

- Every status now carries an icon, and draft is **amber** rather than grey.
- The issue-detail header renders the badge at `lg` — larger, semibold.
- Below the header, any unsent issue gets a notice stating plainly that nothing has gone out and everything below is a preview. Scheduled issues get the equivalent with their send date.

Worth a second opinion: amber puts draft close in hue to the yellow "In Progress" badge. Icons and labels distinguish them and they rarely co-occur outside the list view, but happy to take draft in a different direction.

## Finished the deferred timezone work

23 date/time call sites across billing, subscribers, sponsors, segments, api-keys, senders, templates, snippets, reports and the shared `issueDetailUtils.formatDate` now render in the newsletter's timezone rather than the viewer's browser zone.

Each site keeps its existing format options — this changes *which* clock the dates are read against and nothing about how they look.

Two corrections to earlier estimates:

- The "~79 remaining" figure counted every `toLocale*` call, most of which are number formatting (`subscribers.toLocaleString('en-US')`). Only dates were ever timezone-dependent; the real number was ~22.
- The original survey missed four sites using `toLocaleString` with date options rather than `toLocaleDateString`, including a sponsor date-time helper. Found by re-scanning and included here.

## Testing

15 new tests. The four A/B pre-send tests were verified to fail against the unfixed component, so they discriminate rather than just documenting current behavior. Both A/B states were also rendered and screenshotted to confirm they read correctly.

Full sweep on the CI commands: Vitest 1062 (95 files), root JS 1133 (91 suites), Rust 536, plus `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo fmt --check`, both lint configs, type-check and the production build — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7XFATKc9mBMkBGp9ysZJV)_