### PR TITLE
fix(issues): make the detail page's drawers work on mobile, and page the link table

### DIFF
--- a/dashboard-ui/src/components/analytics/GeoMap.tsx
+++ b/dashboard-ui/src/components/analytics/GeoMap.tsx
@@ -285,7 +285,9 @@ export function GeoMap({
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-4">
         <div className="lg:col-span-2">
-          <div className="relative bg-gray-50 rounded-lg p-4" style={{ height: '500px' }}>
+          {/* Shorter on a phone: a 500px map eats most of a mobile viewport and
+              pushes everything below it out of reach. */}
+          <div className="relative bg-gray-50 rounded-lg p-2 sm:p-4 h-[320px] sm:h-[500px]">
             <MapContainer
               geoDistribution={filteredGeoDistribution}
               selectedMetric={state.selectedMetric}

--- a/dashboard-ui/src/components/issues/CollapsibleSection.tsx
+++ b/dashboard-ui/src/components/issues/CollapsibleSection.tsx
@@ -102,7 +102,7 @@ export const CollapsibleSection: React.FC<CollapsibleSectionProps> = React.memo(
       <header
         className={cn(
           'flex items-center justify-between p-4 sm:p-6 cursor-pointer select-none',
-          'hover:bg-muted/50 transition-colors',
+          'hover:bg-muted/50 active:bg-muted transition-colors touch-manipulation',
           'focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 rounded-t-lg',
           'min-h-[60px]' // Ensure minimum touch target height
         )}
@@ -157,20 +157,28 @@ export const CollapsibleSection: React.FC<CollapsibleSectionProps> = React.memo(
         </div>
       </header>
 
-      {/* Collapsible content */}
+      {/* Collapsible content.
+
+          Animated with grid-template-rows rather than a max-height cap: these
+          sections stack charts, maps and tables, and on a narrow screen they run
+          far past any height we could guess at, so a cap would silently clip the
+          bottom of the section. `overflow-hidden` on the inner wrapper is what
+          lets the grid row actually collapse to 0. */}
       <div
         id={`${id}-content`}
         ref={contentRef}
         className={cn(
-          'overflow-hidden transition-all duration-300 ease-in-out',
-          isExpanded ? 'max-h-[5000px] opacity-100' : 'max-h-0 opacity-0'
+          'grid transition-all duration-300 ease-in-out',
+          isExpanded ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'
         )}
         aria-hidden={!isExpanded}
         role="region"
         aria-labelledby={`${id}-title`}
       >
-        <div className="px-4 sm:px-6 pb-4 sm:pb-6 pt-0">
-          {isExpanded && children}
+        <div className="overflow-hidden">
+          <div className="px-4 sm:px-6 pb-4 sm:pb-6 pt-0">
+            {isExpanded && children}
+          </div>
         </div>
       </div>
     </section>

--- a/dashboard-ui/src/components/issues/ComplaintDetailsTable.tsx
+++ b/dashboard-ui/src/components/issues/ComplaintDetailsTable.tsx
@@ -1,12 +1,17 @@
 import React, { useState, useMemo } from 'react';
 import { InfoTooltip } from '../ui/InfoTooltip';
+import { TablePager } from '../ui/TablePager';
 import { ComplaintDetail } from '../../types/issues';
 import { formatInTimeZone } from '@/utils/dateFormatting';
 import { useTenantDateFormat } from '@/contexts/SettingsContext';
 
 export interface ComplaintDetailsTableProps {
   complaints: ComplaintDetail[];
+  /** Rows per page. Exposed for tests; the default suits both phone and desktop. */
+  pageSize?: number;
 }
+
+const DEFAULT_PAGE_SIZE = 10;
 
 type SortField = 'email' | 'timestamp' | 'complaintType';
 type SortDirection = 'asc' | 'desc';
@@ -18,13 +23,18 @@ const SortIcon: React.FC<{ field: SortField; sortField: SortField; sortDirection
   return <span>{sortDirection === 'asc' ? '↑' : '↓'}</span>;
 };
 
-export const ComplaintDetailsTable: React.FC<ComplaintDetailsTableProps> = ({ complaints }) => {
+export const ComplaintDetailsTable: React.FC<ComplaintDetailsTableProps> = ({
+  complaints,
+  pageSize = DEFAULT_PAGE_SIZE,
+}) => {
   // Dates render in the newsletter's timezone, not the viewer's.
   const { timeZone } = useTenantDateFormat();
   const [sortField, setSortField] = useState<SortField>('timestamp');
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
   const [filterType, setFilterType] = useState<string>('all');
+  const [page, setPage] = useState(0);
 
+  // Re-sorting or re-filtering changes what row 1 is, so go back to page one.
   const handleSort = (field: SortField) => {
     if (sortField === field) {
       setSortDirection(sortDirection === 'asc' ? 'desc' : 'asc');
@@ -32,6 +42,12 @@ export const ComplaintDetailsTable: React.FC<ComplaintDetailsTableProps> = ({ co
       setSortField(field);
       setSortDirection('asc');
     }
+    setPage(0);
+  };
+
+  const handleFilterChange = (value: string) => {
+    setFilterType(value);
+    setPage(0);
   };
 
   const sortedAndFilteredComplaints = useMemo(() => {
@@ -55,6 +71,14 @@ export const ComplaintDetailsTable: React.FC<ComplaintDetailsTableProps> = ({ co
       return 0;
     });
   }, [complaints, sortField, sortDirection, filterType]);
+
+  // Clamped so a shorter filtered list can't leave us on a page past the end.
+  const pageCount = Math.max(1, Math.ceil(sortedAndFilteredComplaints.length / pageSize));
+  const currentPage = Math.min(page, pageCount - 1);
+  const visibleComplaints = sortedAndFilteredComplaints.slice(
+    currentPage * pageSize,
+    currentPage * pageSize + pageSize
+  );
 
   const formatTimestamp = (timestamp: string) => {
     return formatInTimeZone(timestamp, timeZone, {
@@ -92,8 +116,8 @@ export const ComplaintDetailsTable: React.FC<ComplaintDetailsTableProps> = ({ co
           <select
             id="complaint-filter"
             value={filterType}
-            onChange={(e) => setFilterType(e.target.value)}
-            className="text-xs sm:text-sm border border-gray-300 rounded px-2 py-1 touch-manipulation focus:outline-none focus:ring-2 focus:ring-blue-500"
+            onChange={(e) => handleFilterChange(e.target.value)}
+            className="text-xs sm:text-sm border border-gray-300 rounded px-2 py-2 min-h-[44px] touch-manipulation focus:outline-none focus:ring-2 focus:ring-blue-500"
             aria-label="Filter complaints by type"
           >
             <option value="all">All Types</option>
@@ -147,9 +171,16 @@ export const ComplaintDetailsTable: React.FC<ComplaintDetailsTableProps> = ({ co
               </tr>
             </thead>
             <tbody className="bg-white divide-y divide-gray-200">
-              {sortedAndFilteredComplaints.map((complaint, index) => (
+              {visibleComplaints.map((complaint, index) => (
                 <tr key={index} className="hover:bg-gray-50">
-                  <td className="px-2 sm:px-4 py-2 sm:py-3 text-xs sm:text-sm text-gray-900 truncate max-w-[150px] sm:max-w-none">{complaint.email}</td>
+                  <td className="px-2 sm:px-4 py-2 sm:py-3 text-xs sm:text-sm text-gray-900 max-w-[190px] sm:max-w-none">
+                    <span className="block truncate">{complaint.email}</span>
+                    {/* The timestamp column is hidden on phones, so keep the date
+                        with the address rather than dropping it entirely. */}
+                    <span className="block sm:hidden text-[11px] text-gray-500 mt-0.5">
+                      {formatTimestamp(complaint.timestamp)}
+                    </span>
+                  </td>
                   <td className="px-2 sm:px-4 py-2 sm:py-3 text-xs sm:text-sm text-gray-600 hidden sm:table-cell whitespace-nowrap">
                     {formatTimestamp(complaint.timestamp)}
                   </td>
@@ -171,13 +202,25 @@ export const ComplaintDetailsTable: React.FC<ComplaintDetailsTableProps> = ({ co
         </div>
       </div>
 
-      <div className="mt-3 sm:mt-4 text-xs sm:text-sm text-gray-600">
-        Showing {sortedAndFilteredComplaints.length} of {complaints.length} complaints
-      </div>
+      <TablePager
+        page={currentPage}
+        pageSize={pageSize}
+        totalItems={sortedAndFilteredComplaints.length}
+        onPageChange={setPage}
+        itemLabel={filterType === 'all' ? 'complaints' : `${filterType} complaints`}
+      />
 
-      <div className="mt-4 text-xs text-muted-foreground bg-muted/30 p-3 rounded-lg">
-        <p className="font-semibold mb-1">Understanding Complaint Types:</p>
-        <ul className="space-y-1 list-disc list-inside">
+      {sortedAndFilteredComplaints.length <= pageSize && (
+        <div className="mt-3 sm:mt-4 text-xs sm:text-sm text-gray-600">
+          Showing {sortedAndFilteredComplaints.length} of {complaints.length} complaints
+        </div>
+      )}
+
+      <details className="mt-4 text-xs text-muted-foreground bg-muted/30 p-3 rounded-lg">
+        <summary className="font-semibold cursor-pointer touch-manipulation min-h-[24px]">
+          Understanding complaint types
+        </summary>
+        <ul className="space-y-1 list-disc list-inside mt-2">
           <li><strong>Spam:</strong> Recipient marked your email as spam or junk</li>
           <li><strong>Abuse:</strong> Recipient reported your email as abusive content</li>
         </ul>
@@ -185,7 +228,7 @@ export const ComplaintDetailsTable: React.FC<ComplaintDetailsTableProps> = ({ co
           To reduce complaints: ensure recipients opted in, provide clear unsubscribe links,
           send relevant content, and honor unsubscribe requests immediately.
         </p>
-      </div>
+      </details>
     </div>
   );
 };

--- a/dashboard-ui/src/components/issues/ComplaintDetailsTable.tsx
+++ b/dashboard-ui/src/components/issues/ComplaintDetailsTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useRef } from 'react';
 import { InfoTooltip } from '../ui/InfoTooltip';
 import { TablePager } from '../ui/TablePager';
 import { ComplaintDetail } from '../../types/issues';
@@ -33,6 +33,28 @@ export const ComplaintDetailsTable: React.FC<ComplaintDetailsTableProps> = ({
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
   const [filterType, setFilterType] = useState<string>('all');
   const [page, setPage] = useState(0);
+  const listTopRef = useRef<HTMLDivElement>(null);
+
+  // The component stays mounted across issue navigation, so a fresh list can
+  // land under the previous issue's page number. Reset during render rather
+  // than in an effect so there's no flash of the wrong page.
+  const [renderedComplaints, setRenderedComplaints] = useState(complaints);
+  if (complaints !== renderedComplaints) {
+    setRenderedComplaints(complaints);
+    setPage(0);
+  }
+
+  // The pager sits below the table, so after a page change the new rows can all
+  // be above the viewport. Bring the top of the table back into view.
+  const handlePageChange = (nextPage: number) => {
+    setPage(nextPage);
+
+    const listTop = listTopRef.current;
+    if (!listTop || typeof listTop.scrollIntoView !== 'function') return;
+    if (listTop.getBoundingClientRect().top >= 0) return; // already on screen
+
+    listTop.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
 
   // Re-sorting or re-filtering changes what row 1 is, so go back to page one.
   const handleSort = (field: SortField) => {
@@ -101,7 +123,11 @@ export const ComplaintDetailsTable: React.FC<ComplaintDetailsTableProps> = ({
 
   return (
     <div className="bg-white rounded-lg shadow p-3 sm:p-6">
-      <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start mb-3 sm:mb-4 gap-2">
+      {/* Scroll target for page changes; `scroll-mt-24` clears the sticky nav. */}
+      <div
+        ref={listTopRef}
+        className="flex flex-col sm:flex-row sm:justify-between sm:items-start mb-3 sm:mb-4 gap-2 scroll-mt-24"
+      >
         <div className="flex items-start gap-2">
           <h3 className="text-base sm:text-lg font-semibold">Complaint Details</h3>
           <InfoTooltip
@@ -206,7 +232,7 @@ export const ComplaintDetailsTable: React.FC<ComplaintDetailsTableProps> = ({
         page={currentPage}
         pageSize={pageSize}
         totalItems={sortedAndFilteredComplaints.length}
-        onPageChange={setPage}
+        onPageChange={handlePageChange}
         itemLabel={filterType === 'all' ? 'complaints' : `${filterType} complaints`}
       />
 

--- a/dashboard-ui/src/components/issues/LinkPerformanceTable.tsx
+++ b/dashboard-ui/src/components/issues/LinkPerformanceTable.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import { ExternalLink, Copy, Check, MapPin, ChevronDown, ChevronUp } from 'lucide-react';
 import { InfoTooltip } from '../ui/InfoTooltip';
 import { TablePager } from '../ui/TablePager';
@@ -24,6 +24,17 @@ export const LinkPerformanceTable: React.FC<LinkPerformanceTableProps> = ({
   const [copiedUrl, setCopiedUrl] = useState<string | null>(null);
   const [expandedUrls, setExpandedUrls] = useState<Set<string>>(new Set());
   const [page, setPage] = useState(0);
+  const listTopRef = useRef<HTMLDivElement>(null);
+
+  // This component survives navigation between issues, so a new set of links can
+  // arrive under a page number from the issue before it — leaving someone on
+  // page 3 of an issue they just opened, past its best-performing links. Reset
+  // during render rather than in an effect so there's no flash of the old page.
+  const [renderedLinks, setRenderedLinks] = useState(links);
+  if (links !== renderedLinks) {
+    setRenderedLinks(links);
+    setPage(0);
+  }
 
   const handleCopyUrl = async (url: string) => {
     try {
@@ -51,6 +62,18 @@ export const LinkPerformanceTable: React.FC<LinkPerformanceTableProps> = ({
     () => [...(links || [])].sort((a, b) => b.clicks - a.clicks),
     [links]
   );
+
+  // The pager sits below ten cards, so on a phone the rows it just swapped in
+  // are all above the viewport. Bring the top of the list back into view.
+  const handlePageChange = (nextPage: number) => {
+    setPage(nextPage);
+
+    const listTop = listTopRef.current;
+    if (!listTop || typeof listTop.scrollIntoView !== 'function') return;
+    if (listTop.getBoundingClientRect().top >= 0) return; // already on screen
+
+    listTop.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
 
   // A shorter list (or a different issue) can leave `page` past the end, so the
   // page actually rendered is always clamped to what exists.
@@ -96,7 +119,9 @@ export const LinkPerformanceTable: React.FC<LinkPerformanceTableProps> = ({
 
   return (
     <div>
-      <div className="flex items-center gap-2 mb-3">
+      {/* Scroll target for page changes. `scroll-mt-24` keeps the heading clear
+          of the sticky section nav when we scroll back to it. */}
+      <div ref={listTopRef} className="flex items-center gap-2 mb-3 scroll-mt-24">
         <h3 className="text-base sm:text-lg font-semibold">Link Performance</h3>
         <InfoTooltip
           label="Link Performance"
@@ -372,7 +397,7 @@ export const LinkPerformanceTable: React.FC<LinkPerformanceTableProps> = ({
         page={currentPage}
         pageSize={pageSize}
         totalItems={sortedLinks.length}
-        onPageChange={setPage}
+        onPageChange={handlePageChange}
         itemLabel="links"
       />
 

--- a/dashboard-ui/src/components/issues/LinkPerformanceTable.tsx
+++ b/dashboard-ui/src/components/issues/LinkPerformanceTable.tsx
@@ -1,17 +1,29 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { ExternalLink, Copy, Check, MapPin, ChevronDown, ChevronUp } from 'lucide-react';
 import { InfoTooltip } from '../ui/InfoTooltip';
+import { TablePager } from '../ui/TablePager';
+import { cn } from '../../utils/cn';
 import type { LinkPerformance } from '../../types/issues';
 
 export interface LinkPerformanceTableProps {
   links: LinkPerformance[];
   totalClicks: number;
   onViewOnMap?: (linkUrl: string) => void;
+  /** Rows per page. Exposed for tests; the default suits both phone and desktop. */
+  pageSize?: number;
 }
 
-export const LinkPerformanceTable: React.FC<LinkPerformanceTableProps> = ({ links, totalClicks, onViewOnMap }) => {
+const DEFAULT_PAGE_SIZE = 10;
+
+export const LinkPerformanceTable: React.FC<LinkPerformanceTableProps> = ({
+  links,
+  totalClicks,
+  onViewOnMap,
+  pageSize = DEFAULT_PAGE_SIZE,
+}) => {
   const [copiedUrl, setCopiedUrl] = useState<string | null>(null);
   const [expandedUrls, setExpandedUrls] = useState<Set<string>>(new Set());
+  const [page, setPage] = useState(0);
 
   const handleCopyUrl = async (url: string) => {
     try {
@@ -34,6 +46,19 @@ export const LinkPerformanceTable: React.FC<LinkPerformanceTableProps> = ({ link
       return newSet;
     });
   };
+
+  const sortedLinks = useMemo(
+    () => [...(links || [])].sort((a, b) => b.clicks - a.clicks),
+    [links]
+  );
+
+  // A shorter list (or a different issue) can leave `page` past the end, so the
+  // page actually rendered is always clamped to what exists.
+  const pageCount = Math.max(1, Math.ceil(sortedLinks.length / pageSize));
+  const currentPage = Math.min(page, pageCount - 1);
+  const pageStart = currentPage * pageSize;
+  const visibleLinks = sortedLinks.slice(pageStart, pageStart + pageSize);
+
   if (!links || links.length === 0) {
     return (
       <div className="text-center py-8 text-muted-foreground">
@@ -42,7 +67,6 @@ export const LinkPerformanceTable: React.FC<LinkPerformanceTableProps> = ({ link
     );
   }
 
-  const sortedLinks = [...links].sort((a, b) => b.clicks - a.clicks);
   const hasUniqueUsers = sortedLinks.some(link =>
     (link.geoDistribution || []).some(geo =>
       typeof geo.uniqueUsers === 'number' || typeof geo.uniqueClickUsers === 'number'
@@ -66,18 +90,114 @@ export const LinkPerformanceTable: React.FC<LinkPerformanceTableProps> = ({ link
   // Helper to get max click count for bar chart scaling
   const maxClicks = sortedLinks.length > 0 ? sortedLinks[0].clicks : 1;
 
+  const actionButtonClasses =
+    'text-muted-foreground hover:text-foreground rounded touch-manipulation ' +
+    'focus:outline-none focus:ring-2 focus:ring-blue-500';
+
   return (
-    <div className="overflow-x-auto -mx-4 sm:mx-0">
-      <div className="inline-block min-w-full align-middle">
-        <div className="flex items-center justify-between mb-3">
-          <div className="flex items-center gap-2">
-            <h3 className="text-base sm:text-lg font-semibold">Link Performance</h3>
-            <InfoTooltip
-              label="Link Performance"
-              description="Shows which links in your email received the most clicks. Top 3 performing links are highlighted. Use the map icon to view geographic distribution for each link."
-            />
-          </div>
-        </div>
+    <div>
+      <div className="flex items-center gap-2 mb-3">
+        <h3 className="text-base sm:text-lg font-semibold">Link Performance</h3>
+        <InfoTooltip
+          label="Link Performance"
+          description="Shows which links in your email received the most clicks. Top 3 performing links are highlighted. Use the map icon to view geographic distribution for each link."
+        />
+      </div>
+
+      {/* Mobile: a card per link. The desktop table has five columns; squeezing
+          those into a phone-width viewport left the URL unreadable and the
+          numbers cramped, so narrow screens get a stacked layout instead. */}
+      <ol className="sm:hidden space-y-2" aria-label="Link performance">
+        {visibleLinks.map((link, index) => {
+          const rank = pageStart + index + 1;
+          const isTopThree = topThreeUrls.has(link.url);
+
+          return (
+            <li
+              key={`${link.url}-${index}`}
+              className={cn(
+                'rounded-lg border border-border p-3',
+                isTopThree && 'border-blue-200 bg-blue-50/60 dark:border-blue-900 dark:bg-blue-900/20'
+              )}
+            >
+              <div className="flex items-start gap-2">
+                <span
+                  className="flex-shrink-0 mt-0.5 w-6 h-6 rounded-full bg-muted text-[11px] font-semibold text-muted-foreground flex items-center justify-center"
+                  aria-hidden="true"
+                >
+                  {rank}
+                </span>
+                <a
+                  href={link.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex-1 min-w-0 text-sm text-blue-600 dark:text-blue-400 break-all line-clamp-2 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded"
+                  aria-label={`Open link ranked ${rank}: ${link.url}`}
+                >
+                  {link.url}
+                </a>
+              </div>
+
+              <div className="mt-2 flex items-center gap-3">
+                <div className="flex-1 h-2 bg-muted rounded-full overflow-hidden">
+                  <div
+                    className="h-full bg-blue-500"
+                    style={{ width: `${(link.clicks / maxClicks) * 100}%` }}
+                    aria-hidden="true"
+                  />
+                </div>
+                <span className="text-sm font-medium whitespace-nowrap">
+                  {link.clicks.toLocaleString()} {link.clicks === 1 ? 'click' : 'clicks'}
+                </span>
+                <span className="text-sm font-medium text-blue-600 dark:text-blue-400 whitespace-nowrap">
+                  {link.percentOfTotal.toFixed(1)}%
+                </span>
+              </div>
+
+              <div className="mt-1 flex items-center gap-1">
+                <a
+                  href={link.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={cn(actionButtonClasses, 'inline-flex items-center justify-center min-w-[44px] min-h-[44px]')}
+                  aria-label={`Open ${link.url} in a new tab`}
+                >
+                  <ExternalLink className="w-4 h-4" aria-hidden="true" />
+                </a>
+                <button
+                  type="button"
+                  onClick={() => handleCopyUrl(link.url)}
+                  className={cn(actionButtonClasses, 'inline-flex items-center justify-center min-w-[44px] min-h-[44px]')}
+                  aria-label="Copy URL to clipboard"
+                >
+                  {copiedUrl === link.url ? (
+                    <Check className="w-4 h-4 text-green-600" aria-hidden="true" />
+                  ) : (
+                    <Copy className="w-4 h-4" aria-hidden="true" />
+                  )}
+                </button>
+                {onViewOnMap && link.geoDistribution && link.geoDistribution.length > 0 && (
+                  <button
+                    type="button"
+                    onClick={() => onViewOnMap(link.url)}
+                    className={cn(actionButtonClasses, 'inline-flex items-center justify-center min-w-[44px] min-h-[44px]')}
+                    aria-label="View on map"
+                  >
+                    <MapPin className="w-4 h-4" aria-hidden="true" />
+                  </button>
+                )}
+                {link.position > 0 && (
+                  <span className="ml-auto text-xs text-muted-foreground">
+                    Position {link.position}
+                  </span>
+                )}
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+
+      <div className="hidden sm:block overflow-x-auto">
         <table className="min-w-full border-collapse">
           <thead>
             <tr className="border-b-2 border-border bg-muted/30">
@@ -90,7 +210,7 @@ export const LinkPerformanceTable: React.FC<LinkPerformanceTableProps> = ({ link
                   />
                 </div>
               </th>
-              <th className="text-right py-2 sm:py-3 px-2 sm:px-4 font-semibold text-xs sm:text-sm text-foreground hidden sm:table-cell">
+              <th className="text-right py-2 sm:py-3 px-2 sm:px-4 font-semibold text-xs sm:text-sm text-foreground">
                 <div className="flex items-center justify-end gap-1">
                   Position
                   <InfoTooltip
@@ -131,7 +251,7 @@ export const LinkPerformanceTable: React.FC<LinkPerformanceTableProps> = ({ link
             </tr>
           </thead>
           <tbody>
-            {sortedLinks.map((link, index) => {
+            {visibleLinks.map((link, index) => {
               const isTopThree = topThreeUrls.has(link.url);
               const isTruncated = shouldTruncateUrl(link.url);
               const isExpanded = expandedUrls.has(link.url);
@@ -141,9 +261,10 @@ export const LinkPerformanceTable: React.FC<LinkPerformanceTableProps> = ({ link
               return (
                 <tr
                   key={`${link.url}-${index}`}
-                  className={`border-b border-border hover:bg-muted/20 transition-colors ${
-                    isTopThree ? 'bg-blue-50/50' : ''
-                  }`}
+                  className={cn(
+                    'border-b border-border hover:bg-muted/20 transition-colors',
+                    isTopThree && 'bg-blue-50/50 dark:bg-blue-900/20'
+                  )}
                 >
                   <td className="py-2 sm:py-3 px-2 sm:px-4">
                     <div className="flex items-center gap-1 sm:gap-2">
@@ -151,7 +272,7 @@ export const LinkPerformanceTable: React.FC<LinkPerformanceTableProps> = ({ link
                         href={link.url}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="flex items-center gap-1 text-blue-600 hover:text-blue-700 hover:underline focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 rounded text-xs sm:text-sm touch-manipulation"
+                        className="flex items-center gap-1 text-blue-600 dark:text-blue-400 hover:text-blue-700 hover:underline focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 rounded text-xs sm:text-sm touch-manipulation"
                         aria-label={`Open link: ${link.url}`}
                       >
                         <span className={isTruncated && !isExpanded ? 'truncate max-w-[150px] sm:max-w-xs' : 'break-all'}>
@@ -162,7 +283,7 @@ export const LinkPerformanceTable: React.FC<LinkPerformanceTableProps> = ({ link
                       {isTruncated && (
                         <button
                           onClick={() => toggleUrlExpansion(link.url)}
-                          className="text-muted-foreground hover:text-foreground p-1 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+                          className={cn(actionButtonClasses, 'p-1')}
                           aria-label={isExpanded ? 'Collapse URL' : 'Expand URL'}
                         >
                           {isExpanded ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
@@ -170,7 +291,7 @@ export const LinkPerformanceTable: React.FC<LinkPerformanceTableProps> = ({ link
                       )}
                       <button
                         onClick={() => handleCopyUrl(link.url)}
-                        className="text-muted-foreground hover:text-foreground p-1 rounded focus:outline-none focus:ring-2 focus:ring-blue-500 touch-manipulation"
+                        className={cn(actionButtonClasses, 'p-1')}
                         aria-label="Copy URL to clipboard"
                       >
                         {copiedUrl === link.url ? (
@@ -182,7 +303,7 @@ export const LinkPerformanceTable: React.FC<LinkPerformanceTableProps> = ({ link
                       {onViewOnMap && link.geoDistribution && link.geoDistribution.length > 0 && (
                         <button
                           onClick={() => onViewOnMap(link.url)}
-                          className="text-muted-foreground hover:text-foreground p-1 rounded focus:outline-none focus:ring-2 focus:ring-blue-500 touch-manipulation"
+                          className={cn(actionButtonClasses, 'p-1')}
                           aria-label="View on map"
                         >
                           <MapPin className="w-3 h-3 sm:w-4 sm:h-4" />
@@ -190,7 +311,7 @@ export const LinkPerformanceTable: React.FC<LinkPerformanceTableProps> = ({ link
                       )}
                     </div>
                   </td>
-                  <td className="py-2 sm:py-3 px-2 sm:px-4 text-right text-xs sm:text-sm text-muted-foreground hidden sm:table-cell">
+                  <td className="py-2 sm:py-3 px-2 sm:px-4 text-right text-xs sm:text-sm text-muted-foreground">
                     {link.position > 0 ? link.position : '—'}
                   </td>
                   {hasUniqueUsers && (
@@ -200,7 +321,7 @@ export const LinkPerformanceTable: React.FC<LinkPerformanceTableProps> = ({ link
                   )}
                   <td className="py-2 sm:py-3 px-2 sm:px-4 text-right whitespace-nowrap">
                     <div className="flex items-center justify-end gap-2">
-                      <div className="hidden sm:block w-16 h-4 bg-gray-200 rounded-full overflow-hidden">
+                      <div className="hidden sm:block w-16 h-4 bg-muted rounded-full overflow-hidden">
                         <div
                           className="h-full bg-blue-500 transition-all duration-300"
                           style={{ width: `${barWidth}%` }}
@@ -212,10 +333,10 @@ export const LinkPerformanceTable: React.FC<LinkPerformanceTableProps> = ({ link
                   </td>
                   <td className="py-2 sm:py-3 px-2 sm:px-4 text-right whitespace-nowrap">
                     <div className="flex flex-col items-end gap-1">
-                      <span className="text-xs sm:text-sm font-medium text-blue-600">
+                      <span className="text-xs sm:text-sm font-medium text-blue-600 dark:text-blue-400">
                         {link.percentOfTotal.toFixed(1)}%
                       </span>
-                      <div className="w-full max-w-[60px] h-1.5 bg-gray-200 rounded-full overflow-hidden">
+                      <div className="w-full max-w-[60px] h-1.5 bg-muted rounded-full overflow-hidden">
                         <div
                           className="h-full bg-blue-600 transition-all duration-300"
                           style={{ width: `${link.percentOfTotal}%` }}
@@ -234,7 +355,7 @@ export const LinkPerformanceTable: React.FC<LinkPerformanceTableProps> = ({ link
                 className="py-2 sm:py-3 px-2 sm:px-4 font-semibold text-xs sm:text-sm text-foreground"
                 colSpan={hasUniqueUsers ? 3 : 2}
               >
-                Total
+                Total (all {sortedLinks.length.toLocaleString()} links)
               </td>
               <td className="py-2 sm:py-3 px-2 sm:px-4 text-right font-semibold text-xs sm:text-sm text-foreground whitespace-nowrap">
                 {totalClicks.toLocaleString()}
@@ -247,14 +368,24 @@ export const LinkPerformanceTable: React.FC<LinkPerformanceTableProps> = ({ link
         </table>
       </div>
 
-      <div className="mt-4 text-xs text-muted-foreground bg-muted/30 p-3 rounded-lg">
-        <p className="font-semibold mb-1">Understanding Link Performance:</p>
-        <p>
-          The top 3 performing links are highlighted with a blue background.
-          Links positioned earlier in your email typically receive more clicks.
-          Use the map icon to see geographic distribution for each link and identify regional preferences.
+      <TablePager
+        page={currentPage}
+        pageSize={pageSize}
+        totalItems={sortedLinks.length}
+        onPageChange={setPage}
+        itemLabel="links"
+      />
+
+      <details className="mt-4 text-xs text-muted-foreground bg-muted/30 p-3 rounded-lg">
+        <summary className="font-semibold cursor-pointer touch-manipulation min-h-[24px]">
+          Understanding link performance
+        </summary>
+        <p className="mt-2">
+          The top 3 performing links are highlighted. Links positioned earlier in your email
+          typically receive more clicks. Use the map icon to see geographic distribution for each
+          link and identify regional preferences.
         </p>
-      </div>
+      </details>
     </div>
   );
 };

--- a/dashboard-ui/src/components/issues/QuickNavigation.tsx
+++ b/dashboard-ui/src/components/issues/QuickNavigation.tsx
@@ -96,13 +96,17 @@ export const QuickNavigation: React.FC<QuickNavigationProps> = React.memo(({
     <nav
       className={cn(
         'bg-surface border-b border-border transition-all duration-300 z-40',
-        isSticky && 'sticky top-0 shadow-md',
+        // When pinned, bleed into the page gutter so the bar covers the full
+        // width of the screen instead of leaving content visible down its sides.
+        isSticky && 'sticky top-0 shadow-md -mx-4 px-4 sm:-mx-6 sm:px-6 lg:-mx-10 lg:px-10',
         className
       )}
       aria-label="Quick navigation to page sections"
       role="navigation"
     >
-      <div className="max-w-7xl 2xl:max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-10">
+      {/* No horizontal padding here: this bar renders inside the page container,
+          which already supplies the gutter. */}
+      <div>
         {/* Mobile Dropdown */}
         <div className="sm:hidden py-2" ref={dropdownRef}>
           <button

--- a/dashboard-ui/src/components/issues/__tests__/CollapsibleSection.test.tsx
+++ b/dashboard-ui/src/components/issues/__tests__/CollapsibleSection.test.tsx
@@ -57,7 +57,7 @@ describe('CollapsibleSection', () => {
 
       expect(screen.queryByText('Test Content')).not.toBeInTheDocument();
       const contentContainer = document.getElementById('test-section-content');
-      expect(contentContainer).toHaveClass('max-h-0');
+      expect(contentContainer).toHaveClass('grid-rows-[0fr]');
       expect(contentContainer).toHaveClass('opacity-0');
     });
 
@@ -269,7 +269,7 @@ describe('CollapsibleSection', () => {
       render(<CollapsibleSection {...defaultProps} isExpanded={false} />);
 
       const content = document.getElementById('test-section-content');
-      expect(content).toHaveClass('max-h-0');
+      expect(content).toHaveClass('grid-rows-[0fr]');
       expect(content).toHaveClass('opacity-0');
       expect(content).toHaveClass('transition-all');
       expect(content).toHaveClass('duration-300');
@@ -279,10 +279,14 @@ describe('CollapsibleSection', () => {
       render(<CollapsibleSection {...defaultProps} isExpanded={true} />);
 
       const content = screen.getByText('Test Content').closest('[id$="-content"]');
-      expect(content).toHaveClass('max-h-[5000px]');
+      expect(content).toHaveClass('grid-rows-[1fr]');
       expect(content).toHaveClass('opacity-100');
       expect(content).toHaveClass('transition-all');
       expect(content).toHaveClass('duration-300');
+
+      // Expanded content must not be height-capped: these sections stack charts
+      // and tables that easily run past any fixed max-height on a phone.
+      expect(content?.className).not.toMatch(/max-h-\[/);
     });
 
     it('should apply hover styles to header', () => {

--- a/dashboard-ui/src/components/issues/__tests__/LinkPerformanceTable.paging.test.tsx
+++ b/dashboard-ui/src/components/issues/__tests__/LinkPerformanceTable.paging.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { LinkPerformanceTable } from '../LinkPerformanceTable';
+import type { LinkPerformance } from '../../../types/issues';
+
+const makeLinks = (count: number): LinkPerformance[] => {
+  const totalClicks = (count * (count + 1)) / 2;
+  return Array.from({ length: count }, (_, index) => {
+    const clicks = count - index;
+    return {
+      url: `https://example.com/article-${index + 1}`,
+      clicks,
+      percentOfTotal: (clicks / totalClicks) * 100,
+      position: index + 1,
+    };
+  });
+};
+
+/** Rows in the desktop table body (the mobile card list renders separately). */
+const tableRowUrls = () =>
+  within(screen.getByRole('table'))
+    .getAllByRole('row')
+    .slice(1) // header
+    .map(row => row.textContent ?? '')
+    .filter(text => text.includes('https://'));
+
+describe('LinkPerformanceTable paging', () => {
+  it('renders only one page of links at a time', () => {
+    render(<LinkPerformanceTable links={makeLinks(25)} totalClicks={325} pageSize={10} />);
+
+    expect(tableRowUrls()).toHaveLength(10);
+    expect(screen.getByText(/1–10/)).toBeInTheDocument();
+    expect(screen.getByText('1 / 3')).toBeInTheDocument();
+  });
+
+  it('advances to the next page and back', () => {
+    render(<LinkPerformanceTable links={makeLinks(25)} totalClicks={325} pageSize={10} />);
+
+    // Highest click count sorts first, so page one starts with article-1.
+    expect(tableRowUrls()[0]).toContain('article-1');
+
+    fireEvent.click(screen.getByRole('button', { name: /next page/i }));
+
+    expect(screen.getByText('2 / 3')).toBeInTheDocument();
+    expect(tableRowUrls()[0]).toContain('article-11');
+    expect(screen.getByText(/11–20/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /previous page/i }));
+
+    expect(screen.getByText('1 / 3')).toBeInTheDocument();
+    expect(tableRowUrls()[0]).toContain('article-1');
+  });
+
+  it('shows a short final page and disables next at the end', () => {
+    render(<LinkPerformanceTable links={makeLinks(25)} totalClicks={325} pageSize={10} />);
+
+    const next = screen.getByRole('button', { name: /next page/i });
+    fireEvent.click(next);
+    fireEvent.click(next);
+
+    expect(tableRowUrls()).toHaveLength(5);
+    expect(screen.getByText(/21–25/)).toBeInTheDocument();
+    expect(next).toBeDisabled();
+  });
+
+  it('disables previous on the first page', () => {
+    render(<LinkPerformanceTable links={makeLinks(25)} totalClicks={325} pageSize={10} />);
+
+    expect(screen.getByRole('button', { name: /previous page/i })).toBeDisabled();
+  });
+
+  it('does not render the pager when everything fits on one page', () => {
+    render(<LinkPerformanceTable links={makeLinks(4)} totalClicks={10} pageSize={10} />);
+
+    expect(screen.queryByRole('button', { name: /next page/i })).not.toBeInTheDocument();
+    expect(tableRowUrls()).toHaveLength(4);
+  });
+
+  it('keeps the running total across all links, not just the visible page', () => {
+    render(<LinkPerformanceTable links={makeLinks(25)} totalClicks={325} pageSize={10} />);
+
+    expect(screen.getByText(/Total \(all 25 links\)/)).toBeInTheDocument();
+    expect(screen.getByText('325')).toBeInTheDocument();
+  });
+
+  it('clamps the current page when the link list shrinks', () => {
+    const { rerender } = render(
+      <LinkPerformanceTable links={makeLinks(25)} totalClicks={325} pageSize={10} />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /next page/i }));
+    fireEvent.click(screen.getByRole('button', { name: /next page/i }));
+    expect(screen.getByText('3 / 3')).toBeInTheDocument();
+
+    rerender(<LinkPerformanceTable links={makeLinks(12)} totalClicks={78} pageSize={10} />);
+
+    expect(screen.getByText('2 / 2')).toBeInTheDocument();
+    expect(tableRowUrls()).toHaveLength(2);
+  });
+
+  it('renders a stacked card per link for narrow screens', () => {
+    render(<LinkPerformanceTable links={makeLinks(25)} totalClicks={325} pageSize={10} />);
+
+    const cards = within(screen.getByRole('list', { name: /link performance/i })).getAllByRole('listitem');
+    expect(cards).toHaveLength(10);
+    expect(cards[0]).toHaveTextContent('article-1');
+  });
+
+  it('renders an empty state without a pager', () => {
+    render(<LinkPerformanceTable links={[]} totalClicks={0} />);
+
+    expect(screen.getByText('No link performance data available')).toBeInTheDocument();
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+  });
+});

--- a/dashboard-ui/src/components/issues/__tests__/LinkPerformanceTable.paging.test.tsx
+++ b/dashboard-ui/src/components/issues/__tests__/LinkPerformanceTable.paging.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, fireEvent, within } from '@testing-library/react';
 import { LinkPerformanceTable } from '../LinkPerformanceTable';
 import type { LinkPerformance } from '../../../types/issues';
@@ -25,6 +25,10 @@ const tableRowUrls = () =>
     .filter(text => text.includes('https://'));
 
 describe('LinkPerformanceTable paging', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('renders only one page of links at a time', () => {
     render(<LinkPerformanceTable links={makeLinks(25)} totalClicks={325} pageSize={10} />);
 
@@ -83,7 +87,9 @@ describe('LinkPerformanceTable paging', () => {
     expect(screen.getByText('325')).toBeInTheDocument();
   });
 
-  it('clamps the current page when the link list shrinks', () => {
+  it('goes back to the first page when a different issue supplies new links', () => {
+    // The page stays mounted while navigating between issues, so page state from
+    // the previous issue must not carry over onto the new one's links.
     const { rerender } = render(
       <LinkPerformanceTable links={makeLinks(25)} totalClicks={325} pageSize={10} />
     );
@@ -92,10 +98,72 @@ describe('LinkPerformanceTable paging', () => {
     fireEvent.click(screen.getByRole('button', { name: /next page/i }));
     expect(screen.getByText('3 / 3')).toBeInTheDocument();
 
-    rerender(<LinkPerformanceTable links={makeLinks(12)} totalClicks={78} pageSize={10} />);
+    const otherIssueLinks = makeLinks(30).map(link => ({
+      ...link,
+      url: link.url.replace('article', 'other'),
+    }));
+    rerender(<LinkPerformanceTable links={otherIssueLinks} totalClicks={465} pageSize={10} />);
+
+    expect(screen.getByText('1 / 3')).toBeInTheDocument();
+    expect(tableRowUrls()[0]).toContain('other-1');
+  });
+
+  it('keeps the page when the same links re-render', () => {
+    const links = makeLinks(25);
+    const { rerender } = render(
+      <LinkPerformanceTable links={links} totalClicks={325} pageSize={10} />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /next page/i }));
+    rerender(<LinkPerformanceTable links={links} totalClicks={325} pageSize={10} />);
+
+    expect(screen.getByText('2 / 3')).toBeInTheDocument();
+  });
+
+  it('scrolls back to the list when the new rows are above the viewport', () => {
+    const scrollIntoView = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoView;
+    // The pager sits below the rows, so on a phone the list header has scrolled
+    // off the top by the time it's tapped.
+    vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+      top: -400,
+    } as DOMRect);
+
+    render(<LinkPerformanceTable links={makeLinks(25)} totalClicks={325} pageSize={10} />);
+    fireEvent.click(screen.getByRole('button', { name: /next page/i }));
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start' });
+  });
+
+  it('leaves the scroll position alone when the list is already in view', () => {
+    const scrollIntoView = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoView;
+    vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+      top: 120,
+    } as DOMRect);
+
+    render(<LinkPerformanceTable links={makeLinks(25)} totalClicks={325} pageSize={10} />);
+    fireEvent.click(screen.getByRole('button', { name: /next page/i }));
+
+    expect(screen.getByText('2 / 3')).toBeInTheDocument();
+    expect(scrollIntoView).not.toHaveBeenCalled();
+  });
+
+  it('clamps the current page when fewer pages exist', () => {
+    const links = makeLinks(25);
+    const { rerender } = render(
+      <LinkPerformanceTable links={links} totalClicks={325} pageSize={10} />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /next page/i }));
+    fireEvent.click(screen.getByRole('button', { name: /next page/i }));
+    expect(screen.getByText('3 / 3')).toBeInTheDocument();
+
+    // Same links, bigger pages: page 3 no longer exists.
+    rerender(<LinkPerformanceTable links={links} totalClicks={325} pageSize={20} />);
 
     expect(screen.getByText('2 / 2')).toBeInTheDocument();
-    expect(tableRowUrls()).toHaveLength(2);
+    expect(tableRowUrls()).toHaveLength(5);
   });
 
   it('renders a stacked card per link for narrow screens', () => {

--- a/dashboard-ui/src/components/ui/TablePager.tsx
+++ b/dashboard-ui/src/components/ui/TablePager.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { cn } from '../../utils/cn';
+
+export interface TablePagerProps {
+  /** Zero-based index of the current page */
+  page: number;
+  pageSize: number;
+  totalItems: number;
+  onPageChange: (page: number) => void;
+  /** Plural noun for the summary line, e.g. "links" */
+  itemLabel?: string;
+  className?: string;
+}
+
+/**
+ * Pager for long analytics tables.
+ *
+ * Long lists are the worst offender on a phone — a hundred rows means a hundred
+ * screens of scrolling to get past them — so the tables page instead, with
+ * touch-sized controls and a plain "showing x-y of z" summary.
+ */
+export const TablePager: React.FC<TablePagerProps> = ({
+  page,
+  pageSize,
+  totalItems,
+  onPageChange,
+  itemLabel = 'items',
+  className,
+}) => {
+  const pageCount = Math.max(1, Math.ceil(totalItems / pageSize));
+
+  if (totalItems <= pageSize) {
+    return null;
+  }
+
+  const first = page * pageSize + 1;
+  const last = Math.min((page + 1) * pageSize, totalItems);
+  const canGoBack = page > 0;
+  const canGoForward = page < pageCount - 1;
+
+  const buttonClasses = cn(
+    'inline-flex items-center gap-1 rounded-lg border border-border px-3 min-h-[44px]',
+    'text-sm font-medium text-foreground bg-surface touch-manipulation',
+    'hover:bg-muted focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+    'disabled:opacity-40 disabled:pointer-events-none'
+  );
+
+  return (
+    <nav
+      className={cn(
+        'flex flex-wrap items-center justify-between gap-3 pt-3 mt-3 border-t border-border',
+        className
+      )}
+      aria-label={`${itemLabel} pagination`}
+    >
+      <p className="text-xs sm:text-sm text-muted-foreground" aria-live="polite">
+        Showing <span className="font-medium text-foreground">{first}–{last}</span> of{' '}
+        <span className="font-medium text-foreground">{totalItems.toLocaleString()}</span> {itemLabel}
+      </p>
+
+      <div className="flex items-center gap-2 ml-auto">
+        <button
+          type="button"
+          onClick={() => onPageChange(page - 1)}
+          disabled={!canGoBack}
+          className={buttonClasses}
+          aria-label={`Previous page of ${itemLabel}`}
+        >
+          <ChevronLeft className="w-4 h-4" aria-hidden="true" />
+          <span>Prev</span>
+        </button>
+
+        <span className="text-xs sm:text-sm text-muted-foreground whitespace-nowrap px-1">
+          {page + 1} / {pageCount}
+        </span>
+
+        <button
+          type="button"
+          onClick={() => onPageChange(page + 1)}
+          disabled={!canGoForward}
+          className={buttonClasses}
+          aria-label={`Next page of ${itemLabel}`}
+        >
+          <span>Next</span>
+          <ChevronRight className="w-4 h-4" aria-hidden="true" />
+        </button>
+      </div>
+    </nav>
+  );
+};
+
+export default TablePager;

--- a/dashboard-ui/src/pages/issues/IssueDetailPage.tsx
+++ b/dashboard-ui/src/pages/issues/IssueDetailPage.tsx
@@ -41,6 +41,8 @@ import {
   saveScrollPosition,
   loadScrollPosition,
   clearScrollPosition,
+  toSectionDomId,
+  toSectionKey,
   type UserPreferences
 } from '../../utils/issueDetailUtils';
 import { getErrorDetails, validateAnalyticsData } from '../../utils/errorMessages';
@@ -74,6 +76,9 @@ interface SectionConfig {
   defaultExpanded: boolean;
   requiredData: string[];
 }
+
+/** Room left above a section when scrolling to it, for the sticky nav bar. */
+const SECTION_SCROLL_OFFSET = 88;
 
 const SECTION_CONFIGS: SectionConfig[] = [
   {
@@ -283,13 +288,17 @@ export const IssueDetailPage: React.FC = () => {
     };
   }, [id]);
 
-  // Initialize expanded sections based on screen size, defaults, and user preferences
+  // Initialize expanded sections based on screen size, defaults, and user preferences.
+  // Deliberately no resize listener: mobile browsers fire `resize` every time the
+  // address bar hides or shows while scrolling, and collapsing sections out from
+  // under someone mid-scroll is worse than leaving them as they were.
   useEffect(() => {
     const isMobile = window.innerWidth < 768;
     const defaultExpanded = new Set<string>();
 
-    // Load user preferences for expanded sections
-    const savedExpandedSections = userPreferences.expandedSections;
+    // Load user preferences for expanded sections. Older builds saved DOM ids
+    // ("section-engagement") here, so normalize whatever we read back.
+    const savedExpandedSections = userPreferences.expandedSections.map(toSectionKey);
 
     if (savedExpandedSections.length > 0) {
       // Use saved preferences if available
@@ -307,18 +316,6 @@ export const IssueDetailPage: React.FC = () => {
 
     // Load comparison mode preference
     setComparisonMode(userPreferences.defaultComparison);
-
-    // Handle window resize to adjust section states
-    const handleResize = () => {
-      const isNowMobile = window.innerWidth < 768;
-      if (isNowMobile && expandedSections.size > 0) {
-        // Collapse all sections when switching to mobile
-        setExpandedSections(new Set());
-      }
-    };
-
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // Only run on mount
 
@@ -326,7 +323,7 @@ export const IssueDetailPage: React.FC = () => {
   useEffect(() => {
     const keyMetricsElement = document.getElementById('key-metrics-summary');
     const sectionElements = SECTION_CONFIGS.map(config =>
-      document.getElementById(`section-${config.id}`)
+      document.getElementById(toSectionDomId(config.id))
     ).filter(Boolean);
 
     // Observer for sticky navigation trigger
@@ -346,8 +343,7 @@ export const IssueDetailPage: React.FC = () => {
       (entries) => {
         entries.forEach((entry) => {
           if (entry.isIntersecting) {
-            const sectionId = entry.target.id.replace('section-', '');
-            setActiveSection(sectionId);
+            setActiveSection(toSectionKey(entry.target.id));
           }
         });
       },
@@ -372,45 +368,71 @@ export const IssueDetailPage: React.FC = () => {
     updatePreference('defaultComparison', mode);
   }, []);
 
-  // Handler for section toggle
-  const handleSectionToggle = useCallback((sectionId: string) => {
-    setExpandedSections(prev => {
-      const newSet = new Set(prev);
-      if (newSet.has(sectionId)) {
-        newSet.delete(sectionId);
-      } else {
-        newSet.add(sectionId);
-      }
+  // Mirror of expandedSections so the toggle handler can read current state
+  // without taking it as a dependency (the sections are memoized on identity).
+  const expandedSectionsRef = useRef(expandedSections);
+  useEffect(() => {
+    expandedSectionsRef.current = expandedSections;
+  }, [expandedSections]);
 
-      // Save expanded sections to preferences
-      const expandedArray = Array.from(newSet);
-      updatePreference('expandedSections', expandedArray);
+  // Bring a section's header to just under the sticky nav
+  const scrollSectionIntoView = useCallback((sectionKey: string) => {
+    const element = document.getElementById(toSectionDomId(sectionKey));
+    if (!element) return;
 
-      return newSet;
+    const offsetPosition =
+      element.getBoundingClientRect().top + window.pageYOffset - SECTION_SCROLL_OFFSET;
+
+    window.scrollTo({
+      top: Math.max(offsetPosition, 0),
+      behavior: 'smooth',
     });
   }, []);
 
+  // Handler for section toggle. `CollapsibleSection` hands back its DOM id, so
+  // normalize it to the section key the expanded-set is keyed by.
+  const handleSectionToggle = useCallback((id: string) => {
+    const sectionId = toSectionKey(id);
+    const next = new Set(expandedSectionsRef.current);
+    const isExpanding = !next.has(sectionId);
+
+    if (isExpanding) {
+      next.add(sectionId);
+    } else {
+      next.delete(sectionId);
+    }
+
+    expandedSectionsRef.current = next;
+    setExpandedSections(next);
+    updatePreference('expandedSections', Array.from(next));
+
+    // On a phone the drawer header often sits near the bottom of the screen, so
+    // the content it just revealed opens entirely below the fold and the tap
+    // reads as "nothing happened". Pull the header up when that's the case.
+    if (isExpanding) {
+      const element = document.getElementById(toSectionDomId(sectionId));
+      if (element && element.getBoundingClientRect().top > window.innerHeight * 0.4) {
+        // Wait a frame so the expand animation has started before we scroll.
+        requestAnimationFrame(() => scrollSectionIntoView(sectionId));
+      }
+    }
+  }, [scrollSectionIntoView]);
+
   // Handler for navigation click with smooth scrolling
   const handleNavigationClick = useCallback((sectionId: string) => {
-    const element = document.getElementById(`section-${sectionId}`);
-    if (element) {
-      const offset = 100; // Account for sticky header
-      const elementPosition = element.getBoundingClientRect().top + window.pageYOffset;
-      const offsetPosition = elementPosition - offset;
+    const sectionKey = toSectionKey(sectionId);
+    if (!document.getElementById(toSectionDomId(sectionKey))) return;
 
-      window.scrollTo({
-        top: offsetPosition,
-        behavior: 'smooth'
-      });
-
-      // Expand the section if it's collapsed
-      setExpandedSections(prev => {
-        const newSet = new Set(prev);
-        newSet.add(sectionId);
-        return newSet;
-      });
+    // Expand the section if it's collapsed
+    if (!expandedSectionsRef.current.has(sectionKey)) {
+      const next = new Set(expandedSectionsRef.current).add(sectionKey);
+      expandedSectionsRef.current = next;
+      setExpandedSections(next);
+      updatePreference('expandedSections', Array.from(next));
     }
-  }, []);
+
+    scrollSectionIntoView(sectionKey);
+  }, [scrollSectionIntoView]);
 
   const handleRebuildAnalytics = useCallback(async () => {
     if (!id) return;
@@ -713,7 +735,10 @@ export const IssueDetailPage: React.FC = () => {
   }
 
   return (
-    <div className="min-h-screen bg-background overflow-x-hidden">
+    // `overflow-x-clip` rather than `overflow-x-hidden`: hidden makes this a
+    // scroll container, which silently breaks `position: sticky` for the quick
+    // nav inside it. Clip contains the same overflow without that side effect.
+    <div className="min-h-screen bg-background overflow-x-clip">
       {/* Skip to main content link for keyboard navigation */}
       <a
         href="#main-content"
@@ -994,7 +1019,7 @@ export const IssueDetailPage: React.FC = () => {
         {/* Engagement Analytics Section */}
         {isPublished && analytics && shouldShowSection('engagement', analytics, issue?.stats) && (
           <CollapsibleSection
-            id="section-engagement"
+            id={toSectionDomId('engagement')}
             title="Engagement Analytics"
             description="Link performance, geographic distribution, and engagement over time"
             icon={<TrendingUp className="w-5 h-5" />}
@@ -1102,7 +1127,7 @@ export const IssueDetailPage: React.FC = () => {
         {/* Audience Insights Section */}
         {isPublished && analytics && shouldShowSection('audience', analytics, issue?.stats) && (
           <CollapsibleSection
-            id="section-audience"
+            id={toSectionDomId('audience')}
             title="Audience Insights"
             description="Device breakdown, geography, and engagement timing"
             icon={<Users className="w-5 h-5" />}
@@ -1143,7 +1168,7 @@ export const IssueDetailPage: React.FC = () => {
         {/* Deliverability & Quality Section */}
         {isPublished && analytics && shouldShowSection('deliverability', analytics, issue?.stats) && (
           <CollapsibleSection
-            id="section-deliverability"
+            id={toSectionDomId('deliverability')}
             title="Deliverability & Quality"
             description="Bounce analysis, complaints, and quality signals"
             icon={<Shield className="w-5 h-5" />}

--- a/dashboard-ui/src/pages/issues/__tests__/IssueDetailPage.sections.test.tsx
+++ b/dashboard-ui/src/pages/issues/__tests__/IssueDetailPage.sections.test.tsx
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { IssueDetailPage } from '../IssueDetailPage';
+import { issuesService } from '@/services/issuesService';
+import { dashboardService } from '@/services/dashboardService';
+import { STORAGE_KEYS } from '@/constants/brand';
+
+vi.mock('@/services/issuesService', () => ({
+  issuesService: {
+    getIssue: vi.fn(),
+    updateIssue: vi.fn(),
+    deleteIssue: vi.fn(),
+    rebuildAnalytics: vi.fn(),
+  },
+}));
+
+vi.mock('@/services/dashboardService', () => ({
+  dashboardService: {
+    getTrends: vi.fn(),
+  },
+}));
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+  useParams: () => ({ id: '42' }),
+}));
+
+vi.mock('@/components/ui/Toast', () => ({
+  useToast: () => ({ addToast: vi.fn() }),
+}));
+
+vi.mock('@/contexts/SettingsContext', () => ({
+  useTenantDateFormat: () => ({
+    formatDateTime: (value: string) => value,
+    formatDate: (value: string) => value,
+    timeZone: 'UTC',
+  }),
+}));
+
+const issue = {
+  id: '42',
+  issueNumber: 42,
+  subject: 'Weekly roundup',
+  content: '# Hello',
+  contentType: 'markdown',
+  status: 'published',
+  createdAt: '2026-07-01T12:00:00Z',
+  publishedAt: '2026-07-02T12:00:00Z',
+  stats: {
+    subscribers: 1000,
+    deliveries: 980,
+    opens: 400,
+    clicks: 120,
+    bounces: 20,
+    complaints: 1,
+    unsubscribes: 3,
+    analytics: {
+      links: [
+        { url: 'https://example.com/a', clicks: 80, percentOfTotal: 66.7, position: 1 },
+        { url: 'https://example.com/b', clicks: 40, percentOfTotal: 33.3, position: 2 },
+      ],
+      geoDistribution: [{ country: 'US', opens: 300, clicks: 90 }],
+      deviceBreakdown: { desktop: 10, mobile: 20, tablet: 1 },
+      timingMetrics: {
+        medianTimeToOpen: 2,
+        p95TimeToOpen: 20,
+        medianTimeToClick: 3,
+        p95TimeToClick: 30,
+      },
+      bounceReasons: { hard: 10, soft: 10 },
+      complaintDetails: [],
+    },
+  },
+};
+
+/** The toggle control for a collapsible section, by its visible title. */
+const sectionHeader = (title: string) =>
+  screen.getByRole('button', { name: new RegExp(`(Expand|Collapse) ${title} section`) });
+
+describe('IssueDetailPage collapsible sections', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.mocked(issuesService.getIssue).mockResolvedValue({ success: true, data: issue as never });
+    vi.mocked(dashboardService.getTrends).mockResolvedValue({ success: true, data: undefined as never });
+
+    // Phone-sized viewport: every section starts collapsed there.
+    window.innerWidth = 390;
+    window.scrollTo = vi.fn() as unknown as typeof window.scrollTo;
+    window.matchMedia = ((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })) as unknown as typeof window.matchMedia;
+    window.IntersectionObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+      takeRecords() { return []; }
+      root = null;
+      rootMargin = '';
+      thresholds = [];
+    } as unknown as typeof IntersectionObserver;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('opens a section when its header is tapped, and closes it again', async () => {
+    render(<IssueDetailPage />);
+
+    const header = await screen.findByRole('button', { name: /Expand Engagement Analytics section/ });
+    expect(header).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.click(header);
+
+    await waitFor(() => {
+      expect(sectionHeader('Engagement Analytics')).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    fireEvent.click(sectionHeader('Engagement Analytics'));
+
+    await waitFor(() => {
+      expect(sectionHeader('Engagement Analytics')).toHaveAttribute('aria-expanded', 'false');
+    });
+  });
+
+  it('opens each section independently', async () => {
+    render(<IssueDetailPage />);
+
+    await screen.findByRole('button', { name: /Expand Audience Insights section/ });
+
+    fireEvent.click(sectionHeader('Audience Insights'));
+
+    await waitFor(() => {
+      expect(sectionHeader('Audience Insights')).toHaveAttribute('aria-expanded', 'true');
+    });
+    expect(sectionHeader('Engagement Analytics')).toHaveAttribute('aria-expanded', 'false');
+    expect(sectionHeader('Deliverability & Quality')).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('remembers which sections were open', async () => {
+    render(<IssueDetailPage />);
+
+    fireEvent.click(await screen.findByRole('button', { name: /Expand Deliverability & Quality section/ }));
+
+    await waitFor(() => {
+      const saved = JSON.parse(localStorage.getItem(STORAGE_KEYS.issueDetailPreferences) || '{}');
+      expect(saved.expandedSections).toEqual(['deliverability']);
+    });
+  });
+
+  it('restores sections saved by older builds as DOM ids', async () => {
+    localStorage.setItem(
+      STORAGE_KEYS.issueDetailPreferences,
+      JSON.stringify({
+        expandedSections: ['section-engagement'],
+        defaultComparison: 'average',
+        showPercentages: true,
+        chartStyle: 'line',
+      })
+    );
+
+    render(<IssueDetailPage />);
+
+    await waitFor(() => {
+      expect(sectionHeader('Engagement Analytics')).toHaveAttribute('aria-expanded', 'true');
+    });
+  });
+});

--- a/dashboard-ui/src/utils/__tests__/issueDetailUtils.test.ts
+++ b/dashboard-ui/src/utils/__tests__/issueDetailUtils.test.ts
@@ -13,7 +13,36 @@ import {
   loadScrollPosition,
   clearScrollPosition,
   formatDate,
+  toSectionDomId,
+  toSectionKey,
 } from '../issueDetailUtils';
+
+describe('Section ids', () => {
+  it('should build the DOM id for a section key', () => {
+    expect(toSectionDomId('engagement')).toBe('section-engagement');
+  });
+
+  it('should recover the section key from a DOM id', () => {
+    expect(toSectionKey('section-engagement')).toBe('engagement');
+    expect(toSectionKey('section-deliverability')).toBe('deliverability');
+  });
+
+  it('should leave a value that is already a section key alone', () => {
+    // Preferences persisted by older builds stored DOM ids; both forms have to
+    // normalize to the same key or the section renders collapsed forever.
+    expect(toSectionKey('engagement')).toBe('engagement');
+  });
+
+  it('should round-trip every section key', () => {
+    ['engagement', 'audience', 'deliverability'].forEach(key => {
+      expect(toSectionKey(toSectionDomId(key))).toBe(key);
+    });
+  });
+
+  it('should only strip a leading section prefix', () => {
+    expect(toSectionKey('audience-section-extra')).toBe('audience-section-extra');
+  });
+});
 
 describe('User Preferences', () => {
   beforeEach(() => {

--- a/dashboard-ui/src/utils/issueDetailUtils.ts
+++ b/dashboard-ui/src/utils/issueDetailUtils.ts
@@ -117,6 +117,33 @@ export function formatPercentageValue(percentage: number, decimals: number = 1):
 }
 
 /**
+ * The DOM id for a collapsible section on the issue detail page. Used for
+ * anchors, scroll targets and the intersection observers.
+ *
+ * `CollapsibleSection` echoes its DOM id back through `onToggle`, so anything
+ * keyed by section id has to run the value through `toSectionKey` first —
+ * otherwise the toggle writes `section-engagement` while the render reads
+ * `engagement`, and the section never opens.
+ *
+ * @param sectionKey - Section identifier, e.g. 'engagement'
+ * @returns The DOM id, e.g. 'section-engagement'
+ */
+export function toSectionDomId(sectionKey: string): string {
+  return `section-${sectionKey}`;
+}
+
+/**
+ * Inverse of `toSectionDomId`. Tolerates values that are already section keys,
+ * which also migrates DOM ids persisted by older builds.
+ *
+ * @param id - A section DOM id or section key
+ * @returns The section key
+ */
+export function toSectionKey(id: string): string {
+  return id.replace(/^section-/, '');
+}
+
+/**
  * Determine if a section should be visible based on data availability
  * @param sectionId - Section identifier
  * @param analytics - Analytics data


### PR DESCRIPTION
The collapsible sections never opened on a phone. `CollapsibleSection` reports
its DOM id ("section-engagement") back through `onToggle`, but the page kept
expanded state keyed by section id ("engagement"), so every tap wrote a key the
render never read. Desktop masked it — two sections start expanded there — while
mobile starts everything collapsed, so nothing ever opened. Worse, the first tap
persisted the DOM-id form to preferences, which then wedged desktop shut too.

Section ids now go through `toSectionDomId`/`toSectionKey` helpers, and stored
preferences from older builds are normalized on load.

Also on the mobile pass for this page:

- Sections animate with grid-template-rows instead of a max-height cap, so a
  tall section can't be clipped at 5000px.
- Expanding a drawer whose header sits low on screen scrolls it up, so the
  revealed content isn't entirely below the fold.
- Dropped the resize listener that collapsed every section: mobile browsers fire
  resize whenever the address bar hides during scroll.
- Link performance and complaint details page 10 rows at a time through a shared
  TablePager, instead of one endless scroll.
- Link performance renders stacked cards under `sm` rather than squeezing five
  columns into a phone viewport.
- Quick nav no longer double-pads inside the page container, and spans the full
  width once pinned. The page root uses overflow-x-clip so it stays sticky at all
  (overflow-x-hidden made it a scroll container).
- The geo map is 320px tall on small screens instead of 500px.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TSuassx8QMNLYgRHa1kLZ4