### PR TITLE
fix(clicks): stop a missing link record from eating the whole click, and notice next time

### DIFF
--- a/functions/__tests__/aggregate-issue-analytics.test.mjs
+++ b/functions/__tests__/aggregate-issue-analytics.test.mjs
@@ -2,9 +2,11 @@ import { jest } from '@jest/globals';
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
 
 const { DynamoDBClient, QueryCommand, UpdateItemCommand, GetItemCommand } = await import('@aws-sdk/client-dynamodb');
+const { EventBridgeClient, PutEventsCommand } = await import('@aws-sdk/client-eventbridge');
 const { encrypt } = await import('../utils/helpers.mjs');
 const {
   handler,
+  describeCounterAnomaly,
   queryEventsByType,
   queryAllEventsParallel,
   calculateLinkPerformance,
@@ -1205,6 +1207,117 @@ describe('aggregate-issue-analytics', () => {
       expect(b.openRate).toBeCloseTo(40, 5);
       expect(b.clickRate).toBeCloseTo(4, 5);
       expect(b.subject).toBe('Challenger');
+    });
+  });
+});
+
+// Issue 226 sat at 949 opens and no clicks for a week without anyone noticing,
+// because nothing failed: handle-email-status swallowed the error, so no metric
+// moved and the dashboard just drew nothing. Consolidation already has the
+// counters in hand, so it is the one place that can notice.
+describe('aggregate-issue-analytics counter anomaly detection', () => {
+  describe('describeCounterAnomaly', () => {
+    test('flags opens with no clicks at all', () => {
+      // The shape of the bug: link scanners alone put clicks on any issue that
+      // was really opened, so zero is a broken pipeline, not a bad week.
+      expect(describeCounterAnomaly({ deliveries: 2280, opens: 949, clicks: 0 }))
+        .toMatch(/949 opens.*2,280 delivered.*not one click/);
+    });
+
+    test('flags a missing clicks attribute the same as a zero', () => {
+      expect(describeCounterAnomaly({ deliveries: 2280, opens: 949 })).not.toBeNull();
+    });
+
+    test('flags deliveries with no opens at all', () => {
+      expect(describeCounterAnomaly({ deliveries: 2280, opens: 0, clicks: 0 }))
+        .toMatch(/2,280 emails were delivered but not one open/);
+    });
+
+    test('stays quiet for a healthy issue', () => {
+      expect(describeCounterAnomaly({ deliveries: 2280, opens: 949, clicks: 12 })).toBeNull();
+    });
+
+    // A low-engagement issue must never trigger this, or the mail gets ignored.
+    test('stays quiet for a single open and a single click', () => {
+      expect(describeCounterAnomaly({ deliveries: 2280, opens: 1, clicks: 1 })).toBeNull();
+    });
+
+    test('stays quiet when nothing was delivered', () => {
+      expect(describeCounterAnomaly({ deliveries: 0, opens: 0, clicks: 0 })).toBeNull();
+      expect(describeCounterAnomaly({})).toBeNull();
+    });
+  });
+
+  describe('handler', () => {
+    let mockSend;
+    let mockPutEvents;
+    let originalEnv;
+
+    const runWith = async (statsRecord) => {
+      mockSend.mockImplementation((command) => {
+        // The claim returns the counters the anomaly check reads.
+        if (command instanceof UpdateItemCommand && command.input.ReturnValues === 'ALL_NEW') {
+          return Promise.resolve({ Attributes: marshall(statsRecord) });
+        }
+        if (command instanceof GetItemCommand && unmarshall(command.input.Key).sk === 'tenant') {
+          return Promise.resolve({ Item: marshall({ pk: 'tenant1', sk: 'tenant', email: 'owner@example.com' }) });
+        }
+        if (command instanceof QueryCommand) {
+          return Promise.resolve({ Items: [] });
+        }
+        return Promise.resolve({});
+      });
+
+      return handler({ tenantId: 'tenant1', issueNumber: 226, publishedAt: '2026-07-27T00:00:01.876Z' });
+    };
+
+    beforeEach(() => {
+      originalEnv = process.env.TABLE_NAME;
+      process.env.TABLE_NAME = 'test-table';
+      mockSend = jest.fn();
+      mockPutEvents = jest.fn().mockResolvedValue({});
+      DynamoDBClient.prototype.send = mockSend;
+      EventBridgeClient.prototype.send = mockPutEvents;
+      jest.clearAllMocks();
+    });
+
+    afterEach(() => {
+      process.env.TABLE_NAME = originalEnv;
+    });
+
+    test('emails the tenant when the counters cannot be real', async () => {
+      const result = await runWith({ deliveries: 2280, opens: 949 });
+
+      expect(result.success).toBe(true);
+
+      const [command] = mockPutEvents.mock.calls.at(-1);
+      expect(command).toBeInstanceOf(PutEventsCommand);
+
+      const entry = command.input.Entries[0];
+      expect(entry.Source).toBe('newsletter-service');
+      expect(entry.DetailType).toBe('Send Email v2');
+
+      const detail = JSON.parse(entry.Detail);
+      expect(detail.to.email).toBe('owner@example.com');
+      expect(detail.tenantId).toBe('tenant1');
+      expect(detail.subject).toContain('226');
+      expect(detail.html).toContain('not one click');
+    });
+
+    test('sends nothing for a healthy issue', async () => {
+      await runWith({ deliveries: 2280, opens: 949, clicks: 12 });
+
+      expect(mockPutEvents).not.toHaveBeenCalled();
+    });
+
+    // The analytics are already written by the time this runs. A warning that
+    // fails must not take the consolidation down with it.
+    test('still reports success when the warning cannot be sent', async () => {
+      mockPutEvents.mockRejectedValue(new Error('event bus unavailable'));
+
+      const result = await runWith({ deliveries: 2280, opens: 949 });
+
+      expect(result.success).toBe(true);
     });
   });
 });

--- a/functions/__tests__/aggregate-issue-analytics.test.mjs
+++ b/functions/__tests__/aggregate-issue-analytics.test.mjs
@@ -1230,21 +1230,55 @@ describe('aggregate-issue-analytics counter anomaly detection', () => {
 
     test('flags deliveries with no opens at all', () => {
       expect(describeCounterAnomaly({ deliveries: 2280, opens: 0, clicks: 0 }))
-        .toMatch(/2,280 emails were delivered but not one open/);
+        .toMatch(/2,280 emails were delivered, but not one open/);
     });
 
     test('stays quiet for a healthy issue', () => {
       expect(describeCounterAnomaly({ deliveries: 2280, opens: 949, clicks: 12 })).toBeNull();
     });
 
-    // A low-engagement issue must never trigger this, or the mail gets ignored.
-    test('stays quiet for a single open and a single click', () => {
-      expect(describeCounterAnomaly({ deliveries: 2280, opens: 1, clicks: 1 })).toBeNull();
-    });
-
     test('stays quiet when nothing was delivered', () => {
       expect(describeCounterAnomaly({ deliveries: 0, opens: 0, clicks: 0 })).toBeNull();
       expect(describeCounterAnomaly({})).toBeNull();
+    });
+
+    // A zero only carries information when there is enough volume above it. Left
+    // unbounded this fires on every quiet issue, and a warning that cries wolf
+    // is one the reader learns to delete — the only way this feature can fail.
+    describe('needs volume before a zero means anything', () => {
+      test('a lightly-opened issue with no clicks is not an anomaly', () => {
+        expect(describeCounterAnomaly({ deliveries: 2280, opens: 1, clicks: 0 })).toBeNull();
+        expect(describeCounterAnomaly({ deliveries: 2280, opens: 24, clicks: 0 })).toBeNull();
+      });
+
+      test('a small send with no opens is not an anomaly', () => {
+        expect(describeCounterAnomaly({ deliveries: 12, opens: 0, clicks: 0 })).toBeNull();
+        expect(describeCounterAnomaly({ deliveries: 49, opens: 0, clicks: 0 })).toBeNull();
+      });
+
+      test('fires once the volume makes the zero implausible', () => {
+        expect(describeCounterAnomaly({ deliveries: 2280, opens: 25, clicks: 0 })).not.toBeNull();
+        expect(describeCounterAnomaly({ deliveries: 50, opens: 0, clicks: 0 })).not.toBeNull();
+      });
+    });
+
+    // Checked against this tenant's real history: these five are every issue the
+    // check would ever have fired on, and all five were genuinely broken.
+    describe('against real history', () => {
+      test.each([
+        ['#174', { deliveries: 1272, opens: 45, clicks: 0 }],
+        ['#175', { deliveries: 1268, opens: 68, clicks: 0 }],
+        ['#176', { deliveries: 1268, opens: 81, clicks: 0 }],
+        ['#177', { deliveries: 1269, opens: 163, clicks: 0 }],
+        ['#226', { deliveries: 2280, opens: 954, clicks: 0 }]
+      ])('fires on %s, which was broken', (_label, counters) => {
+        expect(describeCounterAnomaly(counters)).not.toBeNull();
+      });
+
+      // The smallest issue that did record clicks. Nothing about it should alarm.
+      test('stays quiet on #200, the smallest healthy issue on record', () => {
+        expect(describeCounterAnomaly({ deliveries: 64, opens: 30, clicks: 23 })).toBeNull();
+      });
     });
   });
 

--- a/functions/__tests__/handle-email-status.test.mjs
+++ b/functions/__tests__/handle-email-status.test.mjs
@@ -83,6 +83,126 @@ describe('handle-email-status click position capture', () => {
   });
 });
 
+// An issue whose 'Extract Links' step never ran has no `link#` records, and the
+// nested `byDay` increment cannot address a record that isn't there. That used to
+// throw straight out of the click branch into the handler's outer catch, which
+// dropped the `clicks` counter and the click event with it — the issue reported
+// zero clicks while SES delivered thousands.
+describe('handle-email-status click tracking without link records', () => {
+  let mockSend;
+  let originalTable;
+
+  const clickEvent = {
+    detail: {
+      eventType: 'Click',
+      click: { link: 'https://example.com/article', timestamp: '2025-01-29T10:05:00.000Z' },
+      mail: {
+        destination: ['reader@example.com'],
+        tags: { referenceNumber: ['tenant123_42'] }
+      }
+    }
+  };
+
+  const conditionalCheckFailed = () => {
+    const err = new Error('The conditional request failed');
+    err.name = 'ConditionalCheckFailedException';
+    return err;
+  };
+
+  const statsUpdate = () =>
+    mockSend.mock.calls
+      .map(([command]) => command)
+      .find(
+        (command) =>
+          command instanceof UpdateItemCommand &&
+          unmarshall(command.input.Key).sk === 'stats'
+      );
+
+  const clickEventPut = () =>
+    mockSend.mock.calls
+      .map(([command]) => command)
+      .find(
+        (command) =>
+          command instanceof PutItemCommand &&
+          unmarshall(command.input.Item).eventType === 'click'
+      );
+
+  beforeEach(() => {
+    originalTable = process.env.TABLE_NAME;
+    process.env.TABLE_NAME = 'test-table';
+    mockSend = jest.fn();
+    DynamoDBClient.prototype.send = mockSend;
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.env.TABLE_NAME = originalTable;
+  });
+
+  test('counts the click when the link record is missing', async () => {
+    mockSend.mockImplementation((command) => {
+      // No link record exists, so the guarded counter update fails its condition.
+      if (command instanceof UpdateItemCommand && unmarshall(command.input.Key).sk.startsWith('link#')) {
+        return Promise.reject(conditionalCheckFailed());
+      }
+      return Promise.resolve({});
+    });
+
+    await expect(handler(clickEvent)).resolves.toBe(true);
+
+    expect(statsUpdate()?.input.ExpressionAttributeNames['#stat']).toBe('clicks');
+    expect(clickEventPut()).toBeDefined();
+  });
+
+  // Belt to the condition's braces: whatever else the per-link counter can fail
+  // on, the click is still counted and still recorded.
+  test('counts the click when the counter update fails outright', async () => {
+    mockSend.mockImplementation((command) => {
+      if (command instanceof UpdateItemCommand && unmarshall(command.input.Key).sk.startsWith('link#')) {
+        return Promise.reject(new Error('ValidationException'));
+      }
+      return Promise.resolve({});
+    });
+
+    await expect(handler(clickEvent)).resolves.toBe(true);
+
+    expect(statsUpdate()?.input.ExpressionAttributeNames['#stat']).toBe('clicks');
+    expect(clickEventPut()).toBeDefined();
+  });
+
+  test('guards the counter update so it cannot create a record link extraction owns', async () => {
+    mockSend.mockResolvedValue({});
+
+    await handler(clickEvent);
+
+    const counterUpdate = mockSend.mock.calls
+      .map(([command]) => command)
+      .find(
+        (command) =>
+          command instanceof UpdateItemCommand &&
+          unmarshall(command.input.Key).sk.startsWith('link#')
+      );
+
+    expect(counterUpdate.input.ConditionExpression).toBe(
+      'attribute_exists(pk) AND attribute_exists(sk)'
+    );
+  });
+
+  // A failed click-event write must not take the counter with it either.
+  test('counts the click when the event capture fails', async () => {
+    mockSend.mockImplementation((command) => {
+      if (command instanceof PutItemCommand && unmarshall(command.input.Item).eventType === 'click') {
+        return Promise.reject(new Error('throughput exceeded'));
+      }
+      return Promise.resolve({});
+    });
+
+    await expect(handler(clickEvent)).resolves.toBe(true);
+
+    expect(statsUpdate()?.input.ExpressionAttributeNames['#stat']).toBe('clicks');
+  });
+});
+
 describe('handle-email-status interest scoring on email click', () => {
   let mockSend;
   let originalTable;

--- a/functions/__tests__/helpers-tenant-cache.test.mjs
+++ b/functions/__tests__/helpers-tenant-cache.test.mjs
@@ -1,0 +1,66 @@
+import { jest } from '@jest/globals';
+import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
+
+const { DynamoDBClient, GetItemCommand } = await import('@aws-sdk/client-dynamodb');
+const { getTenant } = await import('../utils/helpers.mjs');
+
+// getTenant memoizes for the life of the execution environment, and it used to
+// write every tenant to a property literally named `tenantId` rather than to the
+// id itself. One slot for all tenants means the first tenant a warm container
+// saw was handed back for every tenant after it — and callers use this for the
+// address outbound mail goes to and for the tenant's own GitHub credential.
+describe('getTenant cache', () => {
+  let mockSend;
+  let originalEnv;
+
+  const tenantRecord = (id) => ({
+    Item: marshall({ pk: id, sk: 'tenant', email: `${id}@example.com`, apiKeyParameter: `/${id}/key` })
+  });
+
+  beforeEach(() => {
+    originalEnv = process.env.TABLE_NAME;
+    process.env.TABLE_NAME = 'test-table';
+    mockSend = jest.fn((command) => {
+      const key = unmarshall(command.input.Key);
+      return Promise.resolve(tenantRecord(key.pk));
+    });
+    DynamoDBClient.prototype.send = mockSend;
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.env.TABLE_NAME = originalEnv;
+  });
+
+  test('returns each tenant its own record', async () => {
+    const first = await getTenant('tenant-a');
+    const second = await getTenant('tenant-b');
+
+    expect(first.email).toBe('tenant-a@example.com');
+    expect(second.email).toBe('tenant-b@example.com');
+    expect(second.apiKeyParameter).toBe('/tenant-b/key');
+  });
+
+  test('serves a repeat lookup from cache rather than DynamoDB', async () => {
+    await getTenant('tenant-c');
+    const reads = mockSend.mock.calls.length;
+
+    const cached = await getTenant('tenant-c');
+
+    expect(cached.email).toBe('tenant-c@example.com');
+    expect(mockSend.mock.calls.length).toBe(reads);
+  });
+
+  test('throws when the tenant does not exist', async () => {
+    mockSend.mockResolvedValue({});
+
+    await expect(getTenant('missing-tenant')).rejects.toThrow("Tenant 'missing-tenant' not found");
+  });
+
+  test('reads the tenant record by its own key', async () => {
+    await getTenant('tenant-d');
+
+    const command = mockSend.mock.calls.map(([c]) => c).find((c) => c instanceof GetItemCommand);
+    expect(unmarshall(command.input.Key)).toEqual({ pk: 'tenant-d', sk: 'tenant' });
+  });
+});

--- a/functions/__tests__/helpers-tenant-cache.test.mjs
+++ b/functions/__tests__/helpers-tenant-cache.test.mjs
@@ -57,6 +57,18 @@ describe('getTenant cache', () => {
     await expect(getTenant('missing-tenant')).rejects.toThrow("Tenant 'missing-tenant' not found");
   });
 
+  // Tenant ids are external input. On a plain object these hit Object.prototype
+  // and come back as a built-in before DynamoDB is ever consulted.
+  test.each(['constructor', 'toString', 'hasOwnProperty', '__proto__'])(
+    'treats %s as an ordinary tenant id',
+    async (tenantId) => {
+      const tenant = await getTenant(tenantId);
+
+      expect(tenant.email).toBe(`${tenantId}@example.com`);
+      expect(typeof tenant).toBe('object');
+    }
+  );
+
   test('reads the tenant record by its own key', async () => {
     await getTenant('tenant-d');
 

--- a/functions/aggregate-issue-analytics.mjs
+++ b/functions/aggregate-issue-analytics.mjs
@@ -1,8 +1,10 @@
 import { DynamoDBClient, QueryCommand, UpdateItemCommand, GetItemCommand } from '@aws-sdk/client-dynamodb';
+import { EventBridgeClient, PutEventsCommand } from '@aws-sdk/client-eventbridge';
 import { unmarshall, marshall } from '@aws-sdk/util-dynamodb';
-import { decrypt } from './utils/helpers.mjs';
+import { decrypt, getTenant } from './utils/helpers.mjs';
 
 const ddb = new DynamoDBClient();
+const eventBridge = new EventBridgeClient();
 
 export const handler = async (event) => {
   const { tenantId, issueNumber, publishedAt } = event;
@@ -19,8 +21,11 @@ export const handler = async (event) => {
     const pk = `${tenantId}#${issueNumber}`;
     const sk = 'stats';
 
+    // ALL_NEW so the realtime counters come back on the claim itself — the
+    // anomaly check below reads them and would otherwise need its own GetItem.
+    let counters = {};
     try {
-      await ddb.send(new UpdateItemCommand({
+      const claim = await ddb.send(new UpdateItemCommand({
         TableName: process.env.TABLE_NAME,
         Key: marshall({ pk, sk }),
         UpdateExpression: 'SET statsPhase = :aggregating',
@@ -28,8 +33,10 @@ export const handler = async (event) => {
         ExpressionAttributeValues: marshall({
           ':aggregating': 'aggregating',
           ':consolidated': 'consolidated'
-        })
+        }),
+        ReturnValues: 'ALL_NEW'
       }));
+      counters = claim.Attributes ? unmarshall(claim.Attributes) : {};
     } catch (err) {
       if (err.name === 'ConditionalCheckFailedException') {
         console.log(`Aggregation already in progress or completed for ${pk}`);
@@ -76,6 +83,8 @@ export const handler = async (event) => {
 
     console.log(`Successfully consolidated analytics for ${pk}`);
 
+    await reportCounterAnomalies(tenantId, issueNumber, counters);
+
     return {
       success: true,
       issueNumber,
@@ -106,6 +115,98 @@ export const handler = async (event) => {
       statusCode: 500,
       body: JSON.stringify({ message: 'Aggregation failed', error: err.message })
     };
+  }
+};
+
+/**
+ * Decides whether an issue's realtime counters are shaped like a broken
+ * pipeline rather than a quiet week.
+ *
+ * The conditions are deliberately narrow enough that firing means something is
+ * actually wrong. An issue that was delivered and opened always picks up clicks
+ * — corporate link scanners alone guarantee it, they prefetch every link in the
+ * mail within seconds of delivery — and an issue that was delivered always picks
+ * up opens. Anything looser trains the reader to ignore the mail, which is the
+ * only way this can fail.
+ *
+ * Counters, not events: the click *events* for a broken issue are not
+ * necessarily zero, because the web-version redirect path writes its own and is
+ * unaffected by anything on the email path. Issue 226 had 52 of them while its
+ * `clicks` counter did not exist at all.
+ *
+ * @param {Object} counters - The issue's stats record
+ * @returns {string|null} Human-readable description of the anomaly, or null
+ */
+export function describeCounterAnomaly(counters) {
+  const deliveries = counters?.deliveries || 0;
+  const opens = counters?.opens || 0;
+  const clicks = counters?.clicks || 0;
+
+  // Nothing was delivered, so nothing downstream is expected either.
+  if (deliveries === 0) {
+    return null;
+  }
+
+  if (opens === 0) {
+    return `${deliveries.toLocaleString('en-US')} emails were delivered but not one open was recorded.`;
+  }
+
+  if (clicks === 0) {
+    return `${opens.toLocaleString('en-US')} opens were recorded across ${deliveries.toLocaleString('en-US')} delivered emails, but not one click.`;
+  }
+
+  return null;
+}
+
+/**
+ * Emails the tenant when consolidation finds counters that can't be real.
+ *
+ * Issue 226 recorded 949 opens and zero clicks for a week before anyone noticed:
+ * handle-email-status threw on every SES click event and swallowed it, so no
+ * invocation failed, the Lambda error metric never moved, and the dashboard
+ * simply had nothing to draw. A CloudWatch alarm would have been just as
+ * invisible — so this reuses the 'Send Email v2' path the publish workflow
+ * already notifies on, and the warning lands in the same inbox as the issue's
+ * own scheduling mail.
+ *
+ * Never throws: a warning that fails must not fail the consolidation it rode in
+ * on, which has already been written by this point.
+ */
+const reportCounterAnomalies = async (tenantId, issueNumber, counters) => {
+  try {
+    const anomaly = describeCounterAnomaly(counters);
+    if (!anomaly) {
+      return;
+    }
+
+    const tenant = await getTenant(tenantId);
+    if (!tenant?.email) {
+      console.warn('Counter anomaly found but the tenant has no email', { tenantId, issueNumber });
+      return;
+    }
+
+    console.warn(`Counter anomaly for ${tenantId}#${issueNumber}: ${anomaly}`);
+
+    await eventBridge.send(new PutEventsCommand({
+      Entries: [{
+        Source: 'newsletter-service',
+        DetailType: 'Send Email v2',
+        Detail: JSON.stringify({
+          to: { email: tenant.email },
+          subject: `[Check] Issue ${issueNumber} analytics look wrong`,
+          html: [
+            '<div>',
+            `<p>Analytics for issue ${issueNumber} were just consolidated, and the numbers don't look possible:</p>`,
+            `<p><b>${anomaly}</b></p>`,
+            '<p>That pattern usually means a tracking pipeline is dropping events rather than that the issue underperformed. Worth a look at the issue in the dashboard, and at the CloudWatch logs for the stat handler.</p>',
+            '</div>'
+          ].join(''),
+          tenantId
+        })
+      }]
+    }));
+  } catch (err) {
+    console.error('Failed to report counter anomaly', { tenantId, issueNumber, error: err.message });
   }
 };
 

--- a/functions/aggregate-issue-analytics.mjs
+++ b/functions/aggregate-issue-analytics.mjs
@@ -118,21 +118,37 @@ export const handler = async (event) => {
   }
 };
 
+// A zero only means something once there is enough volume above it for the zero
+// to be implausible. Below these, zero is ordinary: a handful of recipients can
+// all decline the tracking pixel, and a lightly-opened issue genuinely may go
+// unclicked. Both are set against this tenant's own history, where the lowest
+// issue that recorded clicks did so on 30 opens from 64 deliveries (#200, 23
+// clicks). Every issue these would have fired on — #174-177, all ~1,270
+// delivered with 45-163 opens and no clicks at all, and #226 — was in fact
+// broken.
+const MIN_DELIVERIES_TO_EXPECT_AN_OPEN = 50;
+const MIN_OPENS_TO_EXPECT_A_CLICK = 25;
+
 /**
  * Decides whether an issue's realtime counters are shaped like a broken
  * pipeline rather than a quiet week.
  *
- * The conditions are deliberately narrow enough that firing means something is
- * actually wrong. An issue that was delivered and opened always picks up clicks
- * — corporate link scanners alone guarantee it, they prefetch every link in the
- * mail within seconds of delivery — and an issue that was delivered always picks
- * up opens. Anything looser trains the reader to ignore the mail, which is the
- * only way this can fail.
+ * Firing has to mean something is actually wrong, because the only way this can
+ * fail is by training the reader to ignore it. So it reports a zero only where
+ * the volume above it makes zero implausible — an issue opened by 25+ readers
+ * that records no click at all is a dead click path, not a boring issue, and
+ * corporate link scanners prefetching every link within seconds of delivery put
+ * a floor under it well below that.
  *
  * Counters, not events: the click *events* for a broken issue are not
  * necessarily zero, because the web-version redirect path writes its own and is
  * unaffected by anything on the email path. Issue 226 had 52 of them while its
  * `clicks` counter did not exist at all.
+ *
+ * Known blind spot: an issue with no trackable links in it would read as a dead
+ * click path. That is not a real shape for this product — every issue is a link
+ * roundup — and the cost is one nuisance mail rather than a recurring one, so
+ * it is not worth reading the issue content here to rule out.
  *
  * @param {Object} counters - The issue's stats record
  * @returns {string|null} Human-readable description of the anomaly, or null
@@ -142,17 +158,14 @@ export function describeCounterAnomaly(counters) {
   const opens = counters?.opens || 0;
   const clicks = counters?.clicks || 0;
 
-  // Nothing was delivered, so nothing downstream is expected either.
-  if (deliveries === 0) {
-    return null;
+  const count = (n) => n.toLocaleString('en-US');
+
+  if (opens === 0 && deliveries >= MIN_DELIVERIES_TO_EXPECT_AN_OPEN) {
+    return `${count(deliveries)} emails were delivered, but not one open was recorded.`;
   }
 
-  if (opens === 0) {
-    return `${deliveries.toLocaleString('en-US')} emails were delivered but not one open was recorded.`;
-  }
-
-  if (clicks === 0) {
-    return `${opens.toLocaleString('en-US')} opens were recorded across ${deliveries.toLocaleString('en-US')} delivered emails, but not one click.`;
+  if (clicks === 0 && opens >= MIN_OPENS_TO_EXPECT_A_CLICK) {
+    return `${count(opens)} opens were recorded across ${count(deliveries)} delivered emails, but not one click.`;
   }
 
   return null;
@@ -196,9 +209,9 @@ const reportCounterAnomalies = async (tenantId, issueNumber, counters) => {
           subject: `[Check] Issue ${issueNumber} analytics look wrong`,
           html: [
             '<div>',
-            `<p>Analytics for issue ${issueNumber} were just consolidated, and the numbers don't look possible:</p>`,
+            `<p>Analytics for issue ${issueNumber} were just consolidated, and one of the numbers looks off:</p>`,
             `<p><b>${anomaly}</b></p>`,
-            '<p>That pattern usually means a tracking pipeline is dropping events rather than that the issue underperformed. Worth a look at the issue in the dashboard, and at the CloudWatch logs for the stat handler.</p>',
+            '<p>At this volume that usually means a tracking pipeline is dropping events rather than that the issue underperformed. Worth a look at the issue in the dashboard, and at the CloudWatch logs for the stat handler.</p>',
             '</div>'
           ].join(''),
           tenantId

--- a/functions/handle-email-status.mjs
+++ b/functions/handle-email-status.mjs
@@ -64,8 +64,24 @@ export const handler = async (event) => {
         break;
       case 'click':
         stat = 'clicks';
-        await trackLinkClick(issueId, detail.click.link, detail.click.ipAddress);
-        await captureClickEvent(issueId, detail.mail.destination[0], detail.click);
+        // Every step below is a side effect of the click, and none of them may
+        // cost the click itself. `stat` is only applied after this switch, so a
+        // throw escaping here takes the counter, the click event, the engagement
+        // update, interest scoring, the timezone observation and the activity
+        // entry down with it — the handler's outer catch swallows the lot and
+        // the issue silently reports zero clicks. That is not hypothetical: an
+        // issue that shipped without its `link#` records lost every one of its
+        // email clicks to a ValidationException out of trackLinkClick.
+        try {
+          await trackLinkClick(issueId, detail.click.link, detail.click.ipAddress);
+        } catch (err) {
+          console.error('Link click counter update failed', { issueId, error: err.message });
+        }
+        try {
+          await captureClickEvent(issueId, detail.mail.destination[0], detail.click);
+        } catch (err) {
+          console.error('Click event capture failed', { issueId, error: err.message });
+        }
         try {
           await updateSubscriberEngagement(tenantId, detail.mail.destination[0], parseInt(issueNumber, 10));
         } catch (err) {
@@ -404,29 +420,59 @@ const trackUniqueOpen = async (issueId, emailAddress, openEvent) => {
   }
 };
 
+/**
+ * Increments the issue's per-link click counters on the `link#<hash(url)>`
+ * record that 'Extract Links' writes at stage time.
+ *
+ * A missing record is a state this has to survive. Link extraction is
+ * best-effort by design — its state catches States.ALL and times out rather than
+ * delay a send — and before the content-type fork was removed it did not run for
+ * json or html issues at all. `SET #by.#day` cannot survive it: the nested path
+ * only resolves when `byDay` already exists, so with no record DynamoDB rejects
+ * the whole update as `ValidationException: The document path provided in the
+ * update expression is invalid for update`.
+ *
+ * The condition turns that into a cheap, explicit miss, matching what
+ * process-link-click already does on the redirect path. It deliberately does not
+ * create the record: a counter-only record carries no url, position or topic
+ * classification, and would then block the real one, which update-link-tracking
+ * writes under `attribute_not_exists(pk)`.
+ */
 const trackLinkClick = async (issueId, link, ipAddress) => {
   const countryData = ipAddress ? await lookupCountry(ipAddress) : null;
   const country = countryData?.countryCode || 'unknown';
 
+  const sk = `link#${hash(link)}`;
   const day = new Date().toISOString().slice(0, 10);
-  await ddb.send(new UpdateItemCommand({
-    TableName: process.env.TABLE_NAME,
-    Key: marshall({
-      pk: issueId,
-      sk: `link#${hash(link)}`
-    }),
-    UpdateExpression: 'ADD clicks_total :one SET #by.#day = if_not_exists(#by.#day, :zero) + :one, #country = if_not_exists(#country, :country)',
-    ExpressionAttributeNames: {
-      '#by': 'byDay',
-      '#day': day,
-      '#country': 'country'
-    },
-    ExpressionAttributeValues: marshall({
-      ':one': 1,
-      ':zero': 0,
-      ':country': country
-    })
-  }));
+
+  try {
+    await ddb.send(new UpdateItemCommand({
+      TableName: process.env.TABLE_NAME,
+      Key: marshall({
+        pk: issueId,
+        sk
+      }),
+      UpdateExpression: 'ADD clicks_total :one SET #by.#day = if_not_exists(#by.#day, :zero) + :one, #country = if_not_exists(#country, :country)',
+      ConditionExpression: 'attribute_exists(pk) AND attribute_exists(sk)',
+      ExpressionAttributeNames: {
+        '#by': 'byDay',
+        '#day': day,
+        '#country': 'country'
+      },
+      ExpressionAttributeValues: marshall({
+        ':one': 1,
+        ':zero': 0,
+        ':country': country
+      })
+    }));
+  } catch (err) {
+    if (err.name !== 'ConditionalCheckFailedException') {
+      throw err;
+    }
+    // The click still counts everywhere else; only this link's own tally and
+    // the top-link reporting built on it lose the event.
+    console.warn('No link record to count this click against', { issueId, sk });
+  }
 };
 
 const getStoredLinkPosition = async (issueId, link) => {

--- a/functions/utils/helpers.mjs
+++ b/functions/utils/helpers.mjs
@@ -30,9 +30,18 @@ export const getOctokit = async (tenantId) => {
   return octokit;
 };
 
+/**
+ * Loads a tenant record, memoized for the life of the execution environment.
+ *
+ * The cache is keyed by `tenantId`, which it previously was not: it wrote every
+ * tenant to a property literally named `tenantId`, so the first tenant a warm
+ * container saw was returned for every tenant after it. That is a cross-tenant
+ * leak, not just a stale read — callers use this for the address outbound mail
+ * is sent to and for `apiKeyParameter`, the tenant's own GitHub credential.
+ */
 export const getTenant = async (tenantId) => {
-  if (tenants.tenantId) {
-    return tenants.tenantId;
+  if (tenants[tenantId]) {
+    return tenants[tenantId];
   } else {
     const result = await ddb.send(new GetItemCommand({
       TableName: process.env.TABLE_NAME,
@@ -47,7 +56,7 @@ export const getTenant = async (tenantId) => {
     }
 
     const data = unmarshall(result.Item);
-    tenants.tenantId = data;
+    tenants[tenantId] = data;
     return data;
   }
 };

--- a/functions/utils/helpers.mjs
+++ b/functions/utils/helpers.mjs
@@ -6,7 +6,10 @@ import { DynamoDBClient, GetItemCommand } from '@aws-sdk/client-dynamodb';
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
 
 let octokit;
-let tenants = {};
+// A Map, not an object: tenant ids are external input, and on a plain object an
+// id like `constructor` or `toString` hits an inherited property and returns a
+// built-in instead of ever reaching DynamoDB.
+const tenants = new Map();
 const ddb = new DynamoDBClient();
 const ivLength = 16;
 const algorithm = 'aes-256-gcm';
@@ -38,10 +41,13 @@ export const getOctokit = async (tenantId) => {
  * container saw was returned for every tenant after it. That is a cross-tenant
  * leak, not just a stale read — callers use this for the address outbound mail
  * is sent to and for `apiKeyParameter`, the tenant's own GitHub credential.
+ *
+ * A cache miss still throws for an unknown tenant, so a miss is never silently
+ * a success.
  */
 export const getTenant = async (tenantId) => {
-  if (tenants[tenantId]) {
-    return tenants[tenantId];
+  if (tenants.has(tenantId)) {
+    return tenants.get(tenantId);
   } else {
     const result = await ddb.send(new GetItemCommand({
       TableName: process.env.TABLE_NAME,
@@ -56,7 +62,7 @@ export const getTenant = async (tenantId) => {
     }
 
     const data = unmarshall(result.Item);
-    tenants[tenantId] = data;
+    tenants.set(tenantId, data);
     return data;
   }
 };

--- a/scripts/backfill-link-records.mjs
+++ b/scripts/backfill-link-records.mjs
@@ -17,16 +17,31 @@
  *   node scripts/backfill-link-records.mjs --table TABLE_NAME --tenant TENANT_ID [--issue N] [--dry-run]
  *
  * Options:
- *   --table     DynamoDB newsletter table name (required)
- *   --tenant    Tenant id, e.g. readysetcloud (required)
- *   --issue     Single issue number. Omit to sweep every published issue.
- *   --model     Bedrock model id for classification
- *               (default us.amazon.nova-lite-v1:0, matching the deployed function)
- *   --dry-run   Report what would be written without calling Bedrock or DynamoDB
+ *   --table          DynamoDB newsletter table name (required)
+ *   --tenant         Tenant id, e.g. readysetcloud (required)
+ *   --issue          Single issue number, processed whatever its age. Omit to
+ *                    sweep recent published issues.
+ *   --max-age-days   How far back the sweep reaches (default 30). Ignored by
+ *                    --issue. See the note below on why the default is not
+ *                    "everything".
+ *   --model          Bedrock model id for classification
+ *                    (default us.amazon.nova-lite-v1:0, matching the deployed function)
+ *   --dry-run        Report what would be written without calling Bedrock or DynamoDB
  *
- * Safe to re-run: an issue that already has any link record is skipped, and the
- * handler itself creates records under `attribute_not_exists(pk)` and re-uses an
- * existing classification rather than paying for a second one.
+ * Safe to re-run, and re-running is sometimes required: an issue is processed
+ * whenever its content implies a link record the table does not have, so a
+ * partially extracted issue is repaired rather than skipped. The handler creates
+ * records under `attribute_not_exists(pk)` and re-uses an existing
+ * classification rather than paying for a second one, so replaying a complete
+ * issue costs one GetItem per link and no LLM calls.
+ *
+ * The sweep is bounded to recent issues on purpose. Link records carry a 90-day
+ * TTL and only earn their keep while clicks are still arriving — an old issue
+ * reads as "missing every record" simply because its originals aged out
+ * naturally, and rewriting them buys nothing: the clicks they would have counted
+ * happened months ago, so `clicks_total` stays at 0 and no interest scoring will
+ * ever read them. Unbounded, this tenant's sweep wanted to write ~400 Bedrock
+ * classifications to recreate records nothing would read.
  */
 
 import { DynamoDBClient, QueryCommand } from '@aws-sdk/client-dynamodb';
@@ -35,11 +50,12 @@ import { unmarshall, marshall } from '@aws-sdk/util-dynamodb';
 // ── Parse CLI args ─────────────────────────────────────────────────────
 
 function parseArgs(argv) {
-  const args = { table: null, tenant: null, issue: null, model: 'us.amazon.nova-lite-v1:0', dryRun: false };
+  const args = { table: null, tenant: null, issue: null, maxAgeDays: 30, model: 'us.amazon.nova-lite-v1:0', dryRun: false };
   for (let i = 2; i < argv.length; i++) {
     if (argv[i] === '--table' && argv[i + 1]) { args.table = argv[++i]; }
     else if (argv[i] === '--tenant' && argv[i + 1]) { args.tenant = argv[++i]; }
     else if (argv[i] === '--issue' && argv[i + 1]) { args.issue = argv[++i]; }
+    else if (argv[i] === '--max-age-days' && argv[i + 1]) { args.maxAgeDays = Number(argv[++i]); }
     else if (argv[i] === '--model' && argv[i + 1]) { args.model = argv[++i]; }
     else if (argv[i] === '--dry-run') { args.dryRun = true; }
   }
@@ -49,7 +65,12 @@ function parseArgs(argv) {
 const args = parseArgs(process.argv);
 
 if (!args.table || !args.tenant) {
-  console.error('Usage: node scripts/backfill-link-records.mjs --table TABLE_NAME --tenant TENANT_ID [--issue N] [--dry-run]');
+  console.error('Usage: node scripts/backfill-link-records.mjs --table TABLE_NAME --tenant TENANT_ID [--issue N] [--max-age-days N] [--dry-run]');
+  process.exit(1);
+}
+
+if (!Number.isFinite(args.maxAgeDays) || args.maxAgeDays <= 0) {
+  console.error('--max-age-days must be a positive number of days');
   process.exit(1);
 }
 
@@ -59,14 +80,28 @@ process.env.TABLE_NAME = args.table;
 process.env.MODEL_ID = args.model;
 
 const { handler: extractLinks, extractIssueLinks } = await import('../functions/update-link-tracking.mjs');
+const { hash } = await import('../functions/utils/helpers.mjs');
 
 const ddb = new DynamoDBClient();
 
 // ── Issue discovery ────────────────────────────────────────────────────
 
-/** Every published issue for the tenant, oldest first. */
+/**
+ * The issue number, taken from the `pk` rather than the `issueNumber`
+ * attribute. Records from issues 202-225 predate that attribute entirely, and
+ * reading it instead of the key silently drops that whole era from the sweep —
+ * including the partially extracted issues this script exists to repair.
+ */
+function issueNumberFromKey(pk) {
+  const tail = String(pk ?? '').split('#').slice(1).join('#');
+  return /^\d+$/.test(tail) ? Number(tail) : null;
+}
+
+/** Recently published issues for the tenant, oldest first. */
 async function listPublishedIssues() {
   const issues = [];
+  const cutoff = Date.now() - (args.maxAgeDays * 24 * 60 * 60 * 1000);
+  let skippedAsOld = 0;
   let exclusiveStartKey;
 
   do {
@@ -85,13 +120,28 @@ async function listPublishedIssues() {
 
     for (const rawItem of (result.Items || [])) {
       const item = unmarshall(rawItem);
-      if (item.issueNumber != null) {
-        issues.push(item);
+      const issueNumber = issueNumberFromKey(item.pk);
+      // Legacy records key on a file path rather than an issue number. There is
+      // no issue to backfill for those and no `link#` records hang off them.
+      if (issueNumber == null) {
+        continue;
       }
+
+      const publishedAt = Date.parse(item.publishedAt || item.GSI1SK || '');
+      if (Number.isNaN(publishedAt) || publishedAt < cutoff) {
+        skippedAsOld++;
+        continue;
+      }
+
+      issues.push({ ...item, issueNumber });
     }
 
     exclusiveStartKey = result.LastEvaluatedKey;
   } while (exclusiveStartKey);
+
+  if (skippedAsOld > 0) {
+    console.log(`Ignoring ${skippedAsOld} issue(s) older than ${args.maxAgeDays} days — pass --max-age-days to widen, or --issue N to target one directly`);
+  }
 
   return issues.sort((a, b) => a.issueNumber - b.issueNumber);
 }
@@ -107,37 +157,74 @@ async function getIssue(issueNumber) {
   }));
 
   const item = result.Items?.[0];
-  return item ? unmarshall(item) : null;
+  return item ? { ...unmarshall(item), issueNumber: Number(issueNumber) } : null;
 }
 
-/** Link records already present for an issue. Any hit means it was extracted. */
-async function countLinkRecords(issueNumber) {
-  const result = await ddb.send(new QueryCommand({
-    TableName: args.table,
-    KeyConditionExpression: 'pk = :pk AND begins_with(sk, :sk)',
-    ExpressionAttributeValues: marshall({
-      ':pk': `${args.tenant}#${issueNumber}`,
-      ':sk': 'link#'
-    }),
-    Select: 'COUNT'
-  }));
+/** Sort keys of the link records already present for an issue. */
+async function listLinkRecordKeys(issueNumber) {
+  const keys = new Set();
+  let exclusiveStartKey;
 
-  return result.Count ?? 0;
+  do {
+    const result = await ddb.send(new QueryCommand({
+      TableName: args.table,
+      KeyConditionExpression: 'pk = :pk AND begins_with(sk, :sk)',
+      ExpressionAttributeValues: marshall({
+        ':pk': `${args.tenant}#${issueNumber}`,
+        ':sk': 'link#'
+      }),
+      ProjectionExpression: 'sk',
+      ExclusiveStartKey: exclusiveStartKey
+    }));
+
+    for (const item of (result.Items || [])) {
+      keys.add(unmarshall(item).sk);
+    }
+
+    exclusiveStartKey = result.LastEvaluatedKey;
+  } while (exclusiveStartKey);
+
+  return keys;
+}
+
+/**
+ * The link records an issue's content should have produced, keyed the same way
+ * update-link-tracking keys them.
+ */
+function expectedLinkKeys(content, contentType) {
+  const keys = new Set();
+
+  for (const { url } of extractIssueLinks(content, contentType)) {
+    if (url && /^https?:\/\//i.test(url)) {
+      keys.add(`link#${hash(url)}`);
+    }
+  }
+
+  return keys;
 }
 
 // ── Backfill ───────────────────────────────────────────────────────────
 
 async function backfillIssue(issue) {
   const issueNumber = issue.issueNumber;
-  const existing = await countLinkRecords(issueNumber);
-
-  if (existing > 0) {
-    console.log(`  #${issueNumber}  skipped — already has ${existing} link record(s)`);
-    return 'skipped';
-  }
 
   if (!issue.content) {
     console.log(`  #${issueNumber}  skipped — no stored content to extract from`);
+    return 'skipped';
+  }
+
+  // A partially extracted issue is the common case, not an edge case: 'Extract
+  // Links' calls Bedrock per link three at a time under a 60s Lambda timeout,
+  // and its state is built to accept the timeout with whatever records it
+  // managed to write. Presence of *some* records therefore proves nothing —
+  // issues 222/223/224 have 6 of 16, 6 of 11 and 5 of 14. Diff the two sets.
+  const expected = expectedLinkKeys(issue.content, issue.contentType);
+  const present = await listLinkRecordKeys(issueNumber);
+  const missing = [...expected].filter(key => !present.has(key));
+
+  if (missing.length === 0) {
+    const detail = expected.size === 0 ? 'no trackable links' : `all ${expected.size} link record(s) present`;
+    console.log(`  #${issueNumber}  skipped — ${detail}`);
     return 'skipped';
   }
 
@@ -152,21 +239,34 @@ async function backfillIssue(issue) {
   };
 
   if (args.dryRun) {
-    const urls = new Set(
-      extractIssueLinks(state.content, state.contentType)
-        .map(link => link.url)
-        .filter(url => /^https?:\/\//i.test(url))
-    );
-    console.log(`  #${issueNumber}  [would write] ${urls.size} link record(s) from ${issue.contentType} content`);
-    for (const url of urls) {
-      console.log(`      ${url}`);
+    console.log(`  #${issueNumber}  [would write] ${missing.length} of ${expected.size} link record(s) from ${issue.contentType} content (${present.size} already present)`);
+    for (const { url } of extractIssueLinks(state.content, state.contentType)) {
+      if (missing.includes(`link#${hash(url)}`)) {
+        console.log(`      ${url}`);
+      }
     }
     return 'written';
   }
 
+  // The handler re-walks every link, not just the missing ones. That is the
+  // point of replaying it rather than writing records here: an already-complete
+  // record costs one GetItem and no LLM call, and one that exists without a
+  // classification gets the classification it never got.
   const result = await extractLinks(state);
-  const written = await countLinkRecords(issueNumber);
-  console.log(`  #${issueNumber}  wrote ${written} link record(s) (${result.linkCount} link position(s) in ${issue.contentType} content)`);
+  const after = await listLinkRecordKeys(issueNumber);
+  const stillMissing = [...expected].filter(key => !after.has(key));
+
+  console.log(
+    `  #${issueNumber}  wrote ${after.size - present.size} link record(s), now ${after.size} of ${expected.size}` +
+    ` (${result.linkCount} link position(s) in ${issue.contentType} content)`
+  );
+
+  if (stillMissing.length > 0) {
+    // Bedrock is on the critical path, so a slow classification can time the
+    // handler out mid-sweep exactly as it did on the original run. Re-runnable.
+    console.warn(`  #${issueNumber}  WARNING: ${stillMissing.length} link record(s) still missing — re-run to finish`);
+    return 'partial';
+  }
 
   return 'written';
 }
@@ -191,7 +291,7 @@ async function backfill() {
     console.log(`Found ${issues.length} published issue(s)\n`);
   }
 
-  const counts = { written: 0, skipped: 0, failed: 0 };
+  const counts = { written: 0, partial: 0, skipped: 0, failed: 0 };
 
   for (const issue of issues) {
     try {
@@ -205,6 +305,7 @@ async function backfill() {
   const verb = args.dryRun ? 'Would backfill' : 'Backfilled';
   console.log(`\n[${mode}] Complete:`);
   console.log(`  ${verb}:  ${counts.written}`);
+  console.log(`  Incomplete:   ${counts.partial}${counts.partial > 0 ? '  <- re-run to finish' : ''}`);
   console.log(`  Skipped:      ${counts.skipped}`);
   console.log(`  Failed:       ${counts.failed}`);
 }

--- a/scripts/backfill-link-records.mjs
+++ b/scripts/backfill-link-records.mjs
@@ -1,0 +1,215 @@
+/**
+ * One-off backfill: create the missing `link#<hash(url)>` records for issues
+ * that went out without them.
+ *
+ * Before the content-type fork was removed from stage-issue, 'Extract Links'
+ * only ran on the markdown branch, so json and html issues shipped with no link
+ * records at all. Those records are what per-link click counters, top-link
+ * reporting and interest scoring read, and — until the fix that ships alongside
+ * this script — their absence made handle-email-status throw on every email
+ * click, which cost the issue its entire click stat.
+ *
+ * Extraction, ordering and LLM classification are not reimplemented here: this
+ * reads the stored issue content and calls the real update-link-tracking handler,
+ * so a backfilled issue gets byte-identical records to one staged today.
+ *
+ * Usage:
+ *   node scripts/backfill-link-records.mjs --table TABLE_NAME --tenant TENANT_ID [--issue N] [--dry-run]
+ *
+ * Options:
+ *   --table     DynamoDB newsletter table name (required)
+ *   --tenant    Tenant id, e.g. readysetcloud (required)
+ *   --issue     Single issue number. Omit to sweep every published issue.
+ *   --model     Bedrock model id for classification
+ *               (default us.amazon.nova-lite-v1:0, matching the deployed function)
+ *   --dry-run   Report what would be written without calling Bedrock or DynamoDB
+ *
+ * Safe to re-run: an issue that already has any link record is skipped, and the
+ * handler itself creates records under `attribute_not_exists(pk)` and re-uses an
+ * existing classification rather than paying for a second one.
+ */
+
+import { DynamoDBClient, QueryCommand } from '@aws-sdk/client-dynamodb';
+import { unmarshall, marshall } from '@aws-sdk/util-dynamodb';
+
+// ── Parse CLI args ─────────────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const args = { table: null, tenant: null, issue: null, model: 'us.amazon.nova-lite-v1:0', dryRun: false };
+  for (let i = 2; i < argv.length; i++) {
+    if (argv[i] === '--table' && argv[i + 1]) { args.table = argv[++i]; }
+    else if (argv[i] === '--tenant' && argv[i + 1]) { args.tenant = argv[++i]; }
+    else if (argv[i] === '--issue' && argv[i + 1]) { args.issue = argv[++i]; }
+    else if (argv[i] === '--model' && argv[i + 1]) { args.model = argv[++i]; }
+    else if (argv[i] === '--dry-run') { args.dryRun = true; }
+  }
+  return args;
+}
+
+const args = parseArgs(process.argv);
+
+if (!args.table || !args.tenant) {
+  console.error('Usage: node scripts/backfill-link-records.mjs --table TABLE_NAME --tenant TENANT_ID [--issue N] [--dry-run]');
+  process.exit(1);
+}
+
+// The handler and the classifier read these at call time. Set them before the
+// import so a misconfigured run fails here rather than halfway through an issue.
+process.env.TABLE_NAME = args.table;
+process.env.MODEL_ID = args.model;
+
+const { handler: extractLinks, extractIssueLinks } = await import('../functions/update-link-tracking.mjs');
+
+const ddb = new DynamoDBClient();
+
+// ── Issue discovery ────────────────────────────────────────────────────
+
+/** Every published issue for the tenant, oldest first. */
+async function listPublishedIssues() {
+  const issues = [];
+  let exclusiveStartKey;
+
+  do {
+    const result = await ddb.send(new QueryCommand({
+      TableName: args.table,
+      IndexName: 'GSI1',
+      KeyConditionExpression: 'GSI1PK = :gsi1pk',
+      FilterExpression: '#status = :published',
+      ExpressionAttributeNames: { '#status': 'status' },
+      ExpressionAttributeValues: marshall({
+        ':gsi1pk': `${args.tenant}#newsletter`,
+        ':published': 'published'
+      }),
+      ExclusiveStartKey: exclusiveStartKey
+    }));
+
+    for (const rawItem of (result.Items || [])) {
+      const item = unmarshall(rawItem);
+      if (item.issueNumber != null) {
+        issues.push(item);
+      }
+    }
+
+    exclusiveStartKey = result.LastEvaluatedKey;
+  } while (exclusiveStartKey);
+
+  return issues.sort((a, b) => a.issueNumber - b.issueNumber);
+}
+
+async function getIssue(issueNumber) {
+  const result = await ddb.send(new QueryCommand({
+    TableName: args.table,
+    KeyConditionExpression: 'pk = :pk AND sk = :sk',
+    ExpressionAttributeValues: marshall({
+      ':pk': `${args.tenant}#${issueNumber}`,
+      ':sk': 'newsletter'
+    })
+  }));
+
+  const item = result.Items?.[0];
+  return item ? unmarshall(item) : null;
+}
+
+/** Link records already present for an issue. Any hit means it was extracted. */
+async function countLinkRecords(issueNumber) {
+  const result = await ddb.send(new QueryCommand({
+    TableName: args.table,
+    KeyConditionExpression: 'pk = :pk AND begins_with(sk, :sk)',
+    ExpressionAttributeValues: marshall({
+      ':pk': `${args.tenant}#${issueNumber}`,
+      ':sk': 'link#'
+    }),
+    Select: 'COUNT'
+  }));
+
+  return result.Count ?? 0;
+}
+
+// ── Backfill ───────────────────────────────────────────────────────────
+
+async function backfillIssue(issue) {
+  const issueNumber = issue.issueNumber;
+  const existing = await countLinkRecords(issueNumber);
+
+  if (existing > 0) {
+    console.log(`  #${issueNumber}  skipped — already has ${existing} link record(s)`);
+    return 'skipped';
+  }
+
+  if (!issue.content) {
+    console.log(`  #${issueNumber}  skipped — no stored content to extract from`);
+    return 'skipped';
+  }
+
+  // Same shape the 'Extract Links' state passes, and the same issueId: the
+  // records must key on `<tenant>#<issueNumber>` to match what click tracking
+  // and interest scoring look up.
+  const state = {
+    content: issue.content,
+    contentType: issue.contentType,
+    tenantId: args.tenant,
+    issueId: String(issueNumber)
+  };
+
+  if (args.dryRun) {
+    const urls = new Set(
+      extractIssueLinks(state.content, state.contentType)
+        .map(link => link.url)
+        .filter(url => /^https?:\/\//i.test(url))
+    );
+    console.log(`  #${issueNumber}  [would write] ${urls.size} link record(s) from ${issue.contentType} content`);
+    for (const url of urls) {
+      console.log(`      ${url}`);
+    }
+    return 'written';
+  }
+
+  const result = await extractLinks(state);
+  const written = await countLinkRecords(issueNumber);
+  console.log(`  #${issueNumber}  wrote ${written} link record(s) (${result.linkCount} link position(s) in ${issue.contentType} content)`);
+
+  return 'written';
+}
+
+async function backfill() {
+  const mode = args.dryRun ? 'DRY RUN' : 'LIVE';
+  console.log(`[${mode}] Backfilling link records`);
+  console.log(`  Table:   ${args.table}`);
+  console.log(`  Tenant:  ${args.tenant}`);
+  console.log(`  Model:   ${args.model}\n`);
+
+  let issues;
+  if (args.issue) {
+    const issue = await getIssue(args.issue);
+    if (!issue) {
+      console.error(`No issue record found at ${args.tenant}#${args.issue}`);
+      process.exit(1);
+    }
+    issues = [issue];
+  } else {
+    issues = await listPublishedIssues();
+    console.log(`Found ${issues.length} published issue(s)\n`);
+  }
+
+  const counts = { written: 0, skipped: 0, failed: 0 };
+
+  for (const issue of issues) {
+    try {
+      counts[await backfillIssue(issue)]++;
+    } catch (err) {
+      counts.failed++;
+      console.error(`  #${issue.issueNumber}  FAILED — ${err.message}`);
+    }
+  }
+
+  const verb = args.dryRun ? 'Would backfill' : 'Backfilled';
+  console.log(`\n[${mode}] Complete:`);
+  console.log(`  ${verb}:  ${counts.written}`);
+  console.log(`  Skipped:      ${counts.skipped}`);
+  console.log(`  Failed:       ${counts.failed}`);
+}
+
+backfill().catch((err) => {
+  console.error('Backfill failed:', err);
+  process.exit(1);
+});

--- a/template.yaml
+++ b/template.yaml
@@ -4424,10 +4424,16 @@ Resources:
         - AWSLambdaBasicExecutionRole
         - Version: 2012-10-17
           Statement:
+            # GetItem was missing, and three call sites needed it: the abTest
+            # config and its per-variant counters (so every consolidated
+            # analytics record has been written without its A/B summary, the
+            # AccessDenied swallowed by calculateAbTestSummary's own catch), and
+            # the tenant lookup the anomaly warning sends to.
             - Effect: Allow
               Action:
                 - dynamodb:Query
                 - dynamodb:UpdateItem
+                - dynamodb:GetItem
               Resource: !GetAtt NewsletterTable.Arn
             - Effect: Allow
               Action:
@@ -4435,6 +4441,10 @@ Resources:
                 - dynamodb:GetItem
                 - dynamodb:Query
               Resource: !GetAtt SubscribersTable.Arn
+            # Emits 'Send Email v2' when an issue's counters can't be real.
+            - Effect: Allow
+              Action: events:PutEvents
+              Resource: !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:event-bus/default
       Environment:
         Variables:
           AWS_NODEJS_CONNECTION_REUSE_ENABLED: 1


### PR DESCRIPTION
## The symptom

Issue 226 showed nothing for clicks. That was correct rendering — the `stats` record had **no `clicks` attribute at all**, against `opens: 949` and `deliveries: 2280`. SES *was* delivering CLICK events; each one was immediately followed by `ValidationException: The document path provided in the update expression is invalid for update`. ~1,030 of them.

## Root cause

Issue 226 was staged as `contentType: html` on the state machine definition that still forked by content type, where `Extract Links` only ran on the markdown branch. It went out with **zero** `link#<hash(url)>` records (issue 225 has 22).

`trackLinkClick` increments those with `SET #by.#day = if_not_exists(#by.#day, :zero) + :one`. That nested path only resolves when `byDay` already exists, so with no record DynamoDB rejects the update.

Nothing caught it. The throw escaped `case 'click'` into the handler's outer `try/catch`, and since `stat` is only applied *after* the switch, it took down the `clicks` counter, `captureClickEvent` (the `click#` records feeding `analytics.links`, `clickDecay`, `geoDistribution`, `engagementType`), the engagement update, interest scoring, the timezone observation and the activity timeline. Opens were untouched — that branch never reads `link#`.

## 1. The fix

Link extraction is best-effort by design — its state catches `States.ALL` and times out rather than delay a send — so click tracking has to survive a missing record.

- `trackLinkClick`'s update is conditioned on the record existing, matching what `process-link-click` already does on the redirect path; a miss is logged, not thrown.
- It and `captureClickEvent` are isolated at the call site, so neither can cost the click.

The condition deliberately does **not** create the record: a counter-only record has no `url`, `position` or topic classification, and would block the real one that `update-link-tracking` writes under `attribute_not_exists(pk)`.

## 2. The backfill

`scripts/backfill-link-records.mjs` replays the real `update-link-tracking` handler over an issue's stored content, so a backfilled issue gets identical records to one staged today.

It diffs the link set an issue's content implies against the records that exist, rather than skipping on the first hit — extraction is **not** all-or-nothing, since it calls Bedrock per link under a 60s timeout its state is built to absorb. Production has three partially extracted issues: #222 at 6 of 16, #223 at 6 of 11, #224 at 5 of 14.

The default sweep reaches back 30 days (`--max-age-days` widens it, `--issue N` targets one at any age). Older issues are excluded on purpose: their link records aged out of their own 90-day TTL naturally, and recreating them buys nothing because the clicks they'd have counted are long past, so `clicks_total` stays 0 and nothing reads them. Unbounded, this tenant's sweep wanted ~400 Bedrock classifications to rebuild history nothing would read.

```bash
node scripts/backfill-link-records.mjs --table newsletter-service-NewsletterTable-EM0239ZZNRJV --tenant readysetcloud --dry-run
```

Currently reports **#224** (9 of 14 missing) and **#226** (all 20). Idempotent, and re-runnable if the same timeout truncates the repair — it reports `Incomplete` when that happens.

## 3. Noticing next time

The fix stops this bug. This is the part that would have *told* us: nothing failed, so no metric moved. A CloudWatch alarm would have been equally silent — it would have watched a metric pinned at zero, and the stack's alerts topic (`newsletter-service-billing-critical-alerts`) has **no subscriptions**, so its four existing alarms notify nobody.

Consolidation already runs per issue at publish+24h and already holds the counters, so it's the one place that can notice for free. When they can't be real — delivered and opened but not one click, or delivered and not one open — it emails the tenant over the `Send Email v2` event the publish workflow already uses, landing in the same inbox as the issue's own scheduling mail.

The conditions are narrow on purpose. An issue that was really opened always picks up clicks — corporate scanners prefetch every link within seconds of delivery. Anything looser trains the reader to ignore the mail, which is the only way this can fail. It reads **counters, not events**: a broken issue's event count isn't necessarily zero, because the web-version redirect path writes its own. Issue 226 had 52 such events while its `clicks` counter didn't exist.

## 4. Two pre-existing defects found on the way

Both are fixed here because the new code needs them correct.

**`dynamodb:GetItem` was missing from the aggregation function's policy entirely.** `calculateAbTestSummary` has been failing with AccessDenied on every run since it landed, swallowed by its own catch — so every consolidated analytics record is silently missing its A/B summary. Confirmed in the logs for issue 225. The tenant lookup needs the same permission.

**`getTenant` cached every tenant under a property literally named `tenantId`** rather than under the id, so one slot served all tenants and a warm container handed the first tenant it saw to every tenant after it. A cross-tenant leak, not a stale read — callers use it for the address outbound mail goes to (including this new warning) and for `apiKeyParameter`, the tenant's own GitHub credential. Single-tenant today, which is why it's gone unnoticed.

## Not in scope

The ~1,030 already-dropped clicks exist only in CloudWatch Logs (7-day retention) and are **not** recovered. We looked at replaying them and decided against it: the clicks-per-recipient histogram shows 45 recipients clicking *exactly* 10 links and 10 more clicking 20–68, so ~90% is scanner prefetch. Issue 225 is the same — 79 recipients at exactly 10 clicks, 39 at exactly 9, which is why its "78% click rate" (1,769 clicks against 658 opens) isn't real. Replaying would restore consistency with an inflated baseline, not accuracy.

That points at a genuinely separate piece of work: there's no scanner filtering anywhere on the click path (`bot-protection.mjs` is wired only into `add-subscriber.mjs`), so every issue's click rate is inflated roughly 10×.

## Testing

- 4 tests on the click-branch blast radius, 18 on the anomaly check (including every issue in 55 issues of real history that it fires on, and the smallest healthy issue on record), 8 on the tenant cache.
- Full suite: **1244 passed**. `__tests__/state-machines/stage-issue-definition.test.mjs` fails to run, but does so on `main` too (unrelated `StageIssueStateMachine` resource-name lookup) — verified by re-running with these changes stashed. `sam validate --lint` reports the same pre-existing authorizer findings before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
