### PR TITLE
feat(local-send): surface detected timezones and audience coverage

### DIFF
--- a/dashboard-ui/src/pages/issues/IssueFormPage.tsx
+++ b/dashboard-ui/src/pages/issues/IssueFormPage.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/components/issues/AbTestConfig';
 import { issuesService } from '@/services/issuesService';
 import { templateService } from '@/services/templateService';
+import { subscriberService } from '@/services/subscriberService';
 import { timezoneOptions } from '@/schemas/profileSchema';
 import { useTenantDateFormat, useTenantSettings } from '@/contexts/SettingsContext';
 import {
@@ -28,6 +29,7 @@ import {
 } from '@/utils/dateFormatting';
 import type { Issue, CreateIssueRequest, UpdateIssueRequest, IssueContentType, AbTest } from '@/types/issues';
 import type { TemplateSummary } from '@/types/api';
+import type { TimeZoneCoverage } from '@/types/subscribers';
 
 // Sentinel value used for the "Default template" option (no templateId persisted).
 const DEFAULT_TEMPLATE_VALUE = '';
@@ -126,6 +128,11 @@ export const IssueFormPage: React.FC = () => {
   const [localSendTimeZone, setLocalSendTimeZone] = useState(timeZone);
   /** Set once the author (or a saved issue) picks a zone explicitly. */
   const localSendTouched = useRef(false);
+  /** Local-send readiness counts; null until fetched (or if the fetch fails). */
+  const [tzCoverage, setTzCoverage] = useState<TimeZoneCoverage | null>(null);
+  const [tzCoverageLoading, setTzCoverageLoading] = useState(false);
+  /** Guards the one-shot coverage fetch against re-renders and re-toggles. */
+  const tzCoverageRequested = useRef(false);
   /** The issue id already fetched, so a re-render can't trigger a second GET. */
   const loadedIssueId = useRef<string | null>(null);
   // Interest-aware assembly: personalized section order (contentAssembly).
@@ -149,6 +156,56 @@ export const IssueFormPage: React.FC = () => {
       setLocalSendTimeZone(timeZone);
     }
   }, [timeZone]);
+
+  // Coverage answers "how much of my list will this actually place?", so it is
+  // only worth fetching once local send is in play. The query walks the tenant's
+  // whole subscriber partition, so it fires on first interest — the author
+  // switching local send on, or an edited issue loading with it already on — and
+  // is then kept for the life of the form rather than refetched per toggle.
+  useEffect(() => {
+    if (!localSendEnabled || tzCoverageRequested.current) return;
+    tzCoverageRequested.current = true;
+
+    let cancelled = false;
+    setTzCoverageLoading(true);
+    subscriberService
+      .getTimeZoneCoverage()
+      .then((response) => {
+        if (!cancelled && response.success && response.data) {
+          setTzCoverage(response.data);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setTzCoverageLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [localSendEnabled]);
+
+  // What the selected mode can actually place, and who falls back. Null when
+  // coverage hasn't loaded or the list is empty — there is no honest percentage
+  // of zero subscribers, and the readiness line stays hidden rather than
+  // rendering "NaN%".
+  const localSendReadiness = useMemo(() => {
+    if (!tzCoverage || tzCoverage.totalSubscribers === 0) return null;
+
+    const placed = localSendMode === 'peak-hour'
+      ? tzCoverage.peakHourEligible
+      : tzCoverage.confirmedTimeZone;
+    const total = tzCoverage.totalSubscribers;
+
+    return {
+      placed,
+      total,
+      fallback: total - placed,
+      percent: Math.round((placed / total) * 100),
+      label: localSendMode === 'peak-hour'
+        ? 'have enough opens for a peak hour'
+        : 'have a detected timezone',
+    };
+  }, [tzCoverage, localSendMode]);
 
   // The local-send picker offers a curated shortlist; the newsletter's own zone
   // may not be on it, and a `<select>` whose value isn't an option silently
@@ -860,6 +917,52 @@ export const IssueFormPage: React.FC = () => {
                     The scheduled time is read as a wall-clock time in this timezone. Defaults to
                     your newsletter&rsquo;s timezone.
                   </p>
+                </div>
+              )}
+
+              {/* Readiness: how much of the list this mode can actually place.
+                  Detection is cumulative across issues, so early on most
+                  subscribers land in the fallback group — saying so here beats
+                  letting the author discover it in the send progress card. */}
+              {localSendEnabled && (
+                <div className="pl-7" aria-live="polite">
+                  {tzCoverageLoading && !localSendReadiness ? (
+                    <p className="text-xs text-muted-foreground">Checking audience coverage&hellip;</p>
+                  ) : localSendReadiness ? (
+                    <>
+                      <div className="flex items-center gap-2">
+                        <div
+                          className="h-1.5 flex-1 rounded-full bg-muted overflow-hidden"
+                          role="progressbar"
+                          aria-valuenow={localSendReadiness.percent}
+                          aria-valuemin={0}
+                          aria-valuemax={100}
+                          aria-label="Local send audience coverage"
+                        >
+                          <div
+                            className="h-full rounded-full bg-primary-500"
+                            style={{ width: `${localSendReadiness.percent}%` }}
+                          />
+                        </div>
+                        <span className="text-xs font-medium text-foreground tabular-nums">
+                          {localSendReadiness.percent}%
+                        </span>
+                      </div>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        {localSendReadiness.placed.toLocaleString()} of{' '}
+                        {localSendReadiness.total.toLocaleString()} subscribers{' '}
+                        {localSendReadiness.label}.
+                        {localSendReadiness.fallback > 0 && (
+                          <>
+                            {' '}
+                            The other {localSendReadiness.fallback.toLocaleString()} receive the
+                            issue at the scheduled time in{' '}
+                            {localSendTimeZone.replace(/_/g, ' ')}.
+                          </>
+                        )}
+                      </p>
+                    </>
+                  ) : null}
                 </div>
               )}
 

--- a/dashboard-ui/src/pages/issues/IssueFormPage.tsx
+++ b/dashboard-ui/src/pages/issues/IssueFormPage.tsx
@@ -162,26 +162,30 @@ export const IssueFormPage: React.FC = () => {
   // whole subscriber partition, so it fires on first interest — the author
   // switching local send on, or an edited issue loading with it already on — and
   // is then kept for the life of the form rather than refetched per toggle.
+  //
+  // Deliberately not cancelled on cleanup. Cleanup here runs on every change of
+  // `localSendEnabled`, not only on unmount, so discarding the response when the
+  // author toggles local send back off would strand the one-shot guard: the
+  // result and the loading reset would both be dropped, and re-enabling would
+  // hit the guard instead of retrying, leaving "Checking audience coverage…" up
+  // for the rest of the form session. The count isn't toggle-scoped — it is just
+  // as true after a toggle as before — so letting it land is both correct and
+  // cheaper than re-querying the partition.
   useEffect(() => {
     if (!localSendEnabled || tzCoverageRequested.current) return;
     tzCoverageRequested.current = true;
 
-    let cancelled = false;
     setTzCoverageLoading(true);
     subscriberService
       .getTimeZoneCoverage()
       .then((response) => {
-        if (!cancelled && response.success && response.data) {
+        if (response.success && response.data) {
           setTzCoverage(response.data);
         }
       })
       .finally(() => {
-        if (!cancelled) setTzCoverageLoading(false);
+        setTzCoverageLoading(false);
       });
-
-    return () => {
-      cancelled = true;
-    };
   }, [localSendEnabled]);
 
   // What the selected mode can actually place, and who falls back. Null when

--- a/dashboard-ui/src/pages/issues/__tests__/IssueFormPage.test.tsx
+++ b/dashboard-ui/src/pages/issues/__tests__/IssueFormPage.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import { IssueFormPage } from '../IssueFormPage';
 import { issuesService } from '@/services/issuesService';
 import { templateService } from '@/services/templateService';
+import { subscriberService } from '@/services/subscriberService';
 import { settingsService } from '@/services/settingsService';
 import { SettingsProvider } from '@/contexts/SettingsContext';
 
@@ -18,6 +19,12 @@ vi.mock('@/services/templateService', () => ({
   templateService: {
     listTemplates: vi.fn(),
     getTemplate: vi.fn(),
+  },
+}));
+
+vi.mock('@/services/subscriberService', () => ({
+  subscriberService: {
+    getTimeZoneCoverage: vi.fn(),
   },
 }));
 
@@ -218,6 +225,10 @@ describe('IssueFormPage local send', () => {
       success: true,
       data: { id: '1' } as never,
     });
+    vi.mocked(subscriberService.getTimeZoneCoverage).mockResolvedValue({
+      success: true,
+      data: { totalSubscribers: 200, confirmedTimeZone: 50, peakHourEligible: 120 },
+    });
   });
 
   const fillRequiredFields = () => {
@@ -302,6 +313,121 @@ describe('IssueFormPage local send', () => {
         expect.objectContaining({
           localSend: expect.objectContaining({ enabled: true, mode: 'peak-hour' }),
         })
+      );
+    });
+  });
+
+  it('does not fetch coverage until local send is enabled', async () => {
+    render(<IssueFormPage />);
+
+    expect(subscriberService.getTimeZoneCoverage).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /local send/i }));
+
+    await waitFor(() => {
+      expect(subscriberService.getTimeZoneCoverage).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('fetches coverage once across repeated toggles and mode switches', async () => {
+    render(<IssueFormPage />);
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /local send/i }));
+    await waitFor(() => {
+      expect(subscriberService.getTimeZoneCoverage).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /local send/i }));
+    fireEvent.click(screen.getByRole('checkbox', { name: /local send/i }));
+    fireEvent.click(screen.getByRole('radio', { name: /personal best hour/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/have enough opens for a peak hour/i)).toBeInTheDocument();
+    });
+    expect(subscriberService.getTimeZoneCoverage).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports timezone coverage and who falls back for timezone mode', async () => {
+    render(<IssueFormPage />);
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /local send/i }));
+
+    // 50 of 200 confirmed = 25%; the other 150 send at the default zone's time.
+    expect(await screen.findByText(/50 of 200 subscribers/i)).toBeInTheDocument();
+    expect(screen.getByText(/have a detected timezone/i)).toBeInTheDocument();
+    expect(screen.getByText(/The other 150 receive the issue/i)).toBeInTheDocument();
+    expect(screen.getByRole('progressbar', { name: /coverage/i })).toHaveAttribute(
+      'aria-valuenow',
+      '25'
+    );
+  });
+
+  it('switches the coverage figure to the open histogram in peak-hour mode', async () => {
+    render(<IssueFormPage />);
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /local send/i }));
+    await screen.findByText(/50 of 200 subscribers/i);
+
+    fireEvent.click(screen.getByRole('radio', { name: /personal best hour/i }));
+
+    // 120 of 200 eligible = 60%, a different audience than the confirmed zones.
+    expect(await screen.findByText(/120 of 200 subscribers/i)).toBeInTheDocument();
+    expect(screen.getByText(/have enough opens for a peak hour/i)).toBeInTheDocument();
+    expect(screen.getByRole('progressbar', { name: /coverage/i })).toHaveAttribute(
+      'aria-valuenow',
+      '60'
+    );
+  });
+
+  it('omits the fallback sentence when every subscriber can be placed', async () => {
+    vi.mocked(subscriberService.getTimeZoneCoverage).mockResolvedValue({
+      success: true,
+      data: { totalSubscribers: 80, confirmedTimeZone: 80, peakHourEligible: 80 },
+    });
+    render(<IssueFormPage />);
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /local send/i }));
+
+    expect(await screen.findByText(/80 of 80 subscribers/i)).toBeInTheDocument();
+    expect(screen.queryByText(/receive the issue at the scheduled time/i)).not.toBeInTheDocument();
+  });
+
+  it('stays silent rather than showing a percentage of an empty list', async () => {
+    vi.mocked(subscriberService.getTimeZoneCoverage).mockResolvedValue({
+      success: true,
+      data: { totalSubscribers: 0, confirmedTimeZone: 0, peakHourEligible: 0 },
+    });
+    render(<IssueFormPage />);
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /local send/i }));
+
+    await waitFor(() => {
+      expect(subscriberService.getTimeZoneCoverage).toHaveBeenCalled();
+    });
+    expect(screen.queryByRole('progressbar', { name: /coverage/i })).not.toBeInTheDocument();
+    expect(screen.queryByText(/subscribers have/i)).not.toBeInTheDocument();
+  });
+
+  it('leaves the toggle usable when the coverage lookup fails', async () => {
+    vi.mocked(subscriberService.getTimeZoneCoverage).mockResolvedValue({
+      success: false,
+      error: 'boom',
+    });
+    render(<IssueFormPage />);
+    fillRequiredFields();
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /local send/i }));
+
+    await waitFor(() => {
+      expect(subscriberService.getTimeZoneCoverage).toHaveBeenCalled();
+    });
+    expect(screen.queryByRole('progressbar', { name: /coverage/i })).not.toBeInTheDocument();
+
+    // Coverage is advisory — a failed lookup must not block configuring a send.
+    fireEvent.click(screen.getByRole('button', { name: /create new issue/i }));
+    await waitFor(() => {
+      expect(issuesService.createIssue).toHaveBeenCalledWith(
+        expect.objectContaining({ localSend: expect.objectContaining({ enabled: true }) })
       );
     });
   });

--- a/dashboard-ui/src/pages/issues/__tests__/IssueFormPage.test.tsx
+++ b/dashboard-ui/src/pages/issues/__tests__/IssueFormPage.test.tsx
@@ -347,6 +347,41 @@ describe('IssueFormPage local send', () => {
     expect(subscriberService.getTimeZoneCoverage).toHaveBeenCalledTimes(1);
   });
 
+  it('still shows coverage when the toggle is switched off and on mid-request', async () => {
+    // Regression: cleanup runs on every localSendEnabled change, not just on
+    // unmount. Discarding the in-flight response on toggle-off used to strand
+    // the one-shot guard — re-enabling never retried, so the box sat on
+    // "Checking audience coverage…" for the rest of the session.
+    let resolveCoverage: (value: never) => void;
+    vi.mocked(subscriberService.getTimeZoneCoverage).mockReturnValue(
+      new Promise((resolve) => {
+        resolveCoverage = resolve as (value: never) => void;
+      })
+    );
+
+    render(<IssueFormPage />);
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /local send/i }));
+    await waitFor(() => {
+      expect(subscriberService.getTimeZoneCoverage).toHaveBeenCalledTimes(1);
+    });
+
+    // Off and back on while the request is still outstanding.
+    fireEvent.click(screen.getByRole('checkbox', { name: /local send/i }));
+    fireEvent.click(screen.getByRole('checkbox', { name: /local send/i }));
+
+    await act(async () => {
+      resolveCoverage!({
+        success: true,
+        data: { totalSubscribers: 200, confirmedTimeZone: 50, peakHourEligible: 120 },
+      } as never);
+    });
+
+    expect(await screen.findByText(/50 of 200 subscribers/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Checking audience coverage/i)).not.toBeInTheDocument();
+    expect(subscriberService.getTimeZoneCoverage).toHaveBeenCalledTimes(1);
+  });
+
   it('reports timezone coverage and who falls back for timezone mode', async () => {
     render(<IssueFormPage />);
 

--- a/dashboard-ui/src/pages/subscribers/SubscribersPage.tsx
+++ b/dashboard-ui/src/pages/subscribers/SubscribersPage.tsx
@@ -29,6 +29,39 @@ const formatDate = (dateString: string, timeZone?: string) =>
     day: 'numeric',
   }, 'en-US');
 
+/**
+ * Short label for a subscriber's detected timezone — the city portion of the
+ * IANA name ("America/Argentina/Buenos_Aires" -> "Buenos Aires"), which is the
+ * part that distinguishes zones at a glance in a narrow column. The full name
+ * stays in the cell's title attribute.
+ */
+const formatZoneLabel = (timeZone: string): string =>
+  (timeZone.split('/').pop() ?? timeZone).replace(/_/g, ' ');
+
+/**
+ * A subscriber's detected timezone, or an em dash when it hasn't been confirmed
+ * yet. Detection needs three consecutive issues of agreeing open/click
+ * geolocation including at least one click, so "not detected" is the norm for a
+ * new or open-only subscriber rather than a fault — the tooltip says so, since
+ * an unexplained dash in a timezone column reads like missing data.
+ */
+const TimeZoneCell: React.FC<{ timeZone?: string | null; className?: string }> = ({
+  timeZone,
+  className = '',
+}) =>
+  timeZone ? (
+    <span className={`text-muted-foreground ${className}`} title={`${timeZone} — detected from engagement activity`}>
+      {formatZoneLabel(timeZone)}
+    </span>
+  ) : (
+    <span
+      className={`text-muted-foreground/60 ${className}`}
+      title="Not detected yet — needs engagement across 3 consecutive issues, including at least one click"
+    >
+      —
+    </span>
+  );
+
 /** Skeleton for the subscriber count metric card (Row 1) */
 const MetricSkeleton: React.FC = () => (
   <Card padding="sm">
@@ -302,6 +335,9 @@ export const SubscribersPage: React.FC = () => {
                   {label.text}
                 </span>
                 <span>{sub.addedAt ? formatDate(sub.addedAt, timeZone) : '—'}</span>
+                {/* Only when detected — a dash per undetected subscriber would
+                    be noise on a line this tight. */}
+                {sub.timeZone && <TimeZoneCell timeZone={sub.timeZone} />}
               </div>
             </div>
           );
@@ -390,6 +426,13 @@ export const SubscribersPage: React.FC = () => {
         className: 'hidden lg:block',
         headerClassName: 'hidden lg:block',
         render: (sub) => <InterestChips interestScores={sub.interestScores} max={2} />,
+      },
+      {
+        key: 'timezone',
+        header: 'Timezone',
+        className: 'hidden lg:block',
+        headerClassName: 'hidden lg:block',
+        render: (sub) => <TimeZoneCell timeZone={sub.timeZone} />,
       },
       {
         key: 'subscribed',

--- a/dashboard-ui/src/pages/subscribers/__tests__/SubscribersPage.test.tsx
+++ b/dashboard-ui/src/pages/subscribers/__tests__/SubscribersPage.test.tsx
@@ -359,4 +359,68 @@ describe('SubscribersPage', () => {
 
     expect(mockNavigate).toHaveBeenCalledWith('/segments/seg-1');
   });
+
+  // --- Detected timezone column (local send) ---
+  describe('detected timezone column', () => {
+    const renderWithSubscribers = async (
+      subscribers: { email: string; timeZone?: string | null }[]
+    ) => {
+      vi.mocked(subscriberService.getCount).mockResolvedValue({
+        success: true,
+        data: { totalSubscribers: subscribers.length },
+      });
+      vi.mocked(subscriberService.getTrends).mockResolvedValue({
+        success: true,
+        data: mockTrendsData,
+      });
+      vi.mocked(segmentService.listSegments).mockResolvedValue({
+        success: true,
+        data: { segments: [] },
+      });
+      vi.mocked(subscriberService.getList).mockResolvedValue({
+        success: true,
+        data: {
+          total: subscribers.length,
+          subscribers: subscribers.map((sub) => ({
+            addedAt: '2025-01-01T00:00:00Z',
+            lastEngagedIssue: 5,
+            ...sub,
+          })),
+        },
+      });
+
+      renderPage();
+      await waitFor(() => {
+        expect(screen.getByText(subscribers[0].email)).toBeInTheDocument();
+      });
+    };
+
+    it('shows the city portion of a detected zone, with the full name as a tooltip', async () => {
+      await renderWithSubscribers([{ email: 'reader@example.com', timeZone: 'America/Chicago' }]);
+
+      const cell = screen.getByText('Chicago');
+      expect(cell).toBeInTheDocument();
+      expect(cell).toHaveAttribute('title', expect.stringContaining('America/Chicago'));
+    });
+
+    it('renders multi-segment zone names readably', async () => {
+      await renderWithSubscribers([
+        { email: 'reader@example.com', timeZone: 'America/Argentina/Buenos_Aires' },
+      ]);
+
+      // Underscores are display noise, and the trailing segment is the part that
+      // distinguishes zones at a glance.
+      expect(screen.getByText('Buenos Aires')).toBeInTheDocument();
+    });
+
+    it('explains an undetected zone rather than showing a bare dash', async () => {
+      await renderWithSubscribers([{ email: 'quiet@example.com', timeZone: null }]);
+
+      const dash = screen
+        .getAllByText('—')
+        .find((el) => el.getAttribute('title')?.includes('Not detected yet'));
+      expect(dash).toBeDefined();
+      expect(dash).toHaveAttribute('title', expect.stringContaining('3 consecutive issues'));
+    });
+  });
 });

--- a/dashboard-ui/src/services/subscriberService.ts
+++ b/dashboard-ui/src/services/subscriberService.ts
@@ -1,6 +1,6 @@
 import { apiClient } from './api';
 import { validateSubscriberCountResponse, validateSubscriberTrendsResponse } from '@/utils/dataValidation';
-import type { ApiResponse, SubscriberCountResponse, SubscriberTrendsResponse, SubscriberListResponse, SubscriberDetail } from '@/types';
+import type { ApiResponse, SubscriberCountResponse, SubscriberTrendsResponse, SubscriberListResponse, SubscriberDetail, TimeZoneCoverage } from '@/types';
 
 export class SubscriberService {
   /**
@@ -41,6 +41,14 @@ export class SubscriberService {
 
   async getList(): Promise<ApiResponse<SubscriberListResponse>> {
     return apiClient.get<SubscriberListResponse>('/subscribers');
+  }
+
+  /**
+   * How much of the audience each local-send mode can actually place. Read by
+   * the issue form so enabling local send isn't a blind flip.
+   */
+  async getTimeZoneCoverage(): Promise<ApiResponse<TimeZoneCoverage>> {
+    return apiClient.get<TimeZoneCoverage>('/subscribers/timezone-coverage');
   }
 
   /**

--- a/dashboard-ui/src/types/subscribers.ts
+++ b/dashboard-ui/src/types/subscribers.ts
@@ -55,6 +55,20 @@ export interface SubscriberListResponse {
   total: number;
 }
 
+/**
+ * Local-send readiness, returned by GET /subscribers/timezone-coverage. Each
+ * count is the audience one `localSend.mode` can place in a real group; the
+ * remainder falls back to the issue's default-timezone send time. The two are
+ * independent — a subscriber may qualify for either, both, or neither.
+ */
+export interface TimeZoneCoverage {
+  totalSubscribers: number;
+  /** Subscribers with a confirmed IANA timezone (mode: 'timezone'). */
+  confirmedTimeZone: number;
+  /** Subscribers with enough logged opens to have a peak hour (mode: 'peak-hour'). */
+  peakHourEligible: number;
+}
+
 /** A single behavioral activity entry (an open or a click), newest-first. */
 export interface ActivityEntry {
   type: 'open' | 'click';

--- a/functions/src/api/controllers/subscribers.rs
+++ b/functions/src/api/controllers/subscribers.rs
@@ -1,5 +1,6 @@
 use aws_sdk_dynamodb::types::AttributeValue;
 use aws_smithy_types::error::display::DisplayErrorContext;
+use chrono_tz::Tz;
 use lambda_http::{Body, Error, Request, RequestExt, Response};
 use newsletter::admin::{auth, aws_clients, error::AppError, response};
 use percent_encoding::percent_decode_str;
@@ -60,6 +61,35 @@ struct SubscriberTrendsResponse {
     points: Vec<SubscriberTrendPoint>,
     summary: SubscriberTrendSummary,
 }
+
+/// How ready the audience is for a local send, in the two currencies the
+/// feature actually spends: confirmed timezones and open-hour histograms.
+///
+/// Both counts answer "how many subscribers will land in a real group rather
+/// than the `__default__` fallback", one per `localSend.mode`. Neither is
+/// derivable from the subscriber list the dashboard already loads —
+/// `openHourTotal` is only on the single-subscriber detail response — so this
+/// is its own endpoint rather than a widening of `/subscribers`.
+#[derive(Serialize, Debug, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
+struct TimeZoneCoverageResponse {
+    total_subscribers: i64,
+    /// Subscribers with a confirmed, parseable IANA `timeZone`. These are the
+    /// ones `mode: "timezone"` can place; everyone else sends at the default
+    /// zone's wall-clock time.
+    confirmed_time_zone: i64,
+    /// Subscribers whose open-hour histogram has reached the minimum sample
+    /// count, i.e. the ones `mode: "peak-hour"` can place.
+    peak_hour_eligible: i64,
+}
+
+/// Minimum recorded opens before a subscriber's open-hour histogram is trusted
+/// for a peak-hour send.
+///
+/// Mirrors `PEAK_HOUR_MIN_SAMPLES` in `functions/utils/local-send.mjs`, which is
+/// what the send path actually enforces. If that changes, change this too or the
+/// dashboard will promise a placement the fan-out won't make.
+const PEAK_HOUR_MIN_SAMPLES: i64 = 5;
 
 #[derive(Serialize, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -241,6 +271,14 @@ pub async fn get_subscriber_trends(event: Request) -> Result<Response<Body>, Err
     }
 }
 
+/// GET /subscribers/timezone-coverage
+pub async fn get_timezone_coverage(event: Request) -> Result<Response<Body>, Error> {
+    match handle_get_timezone_coverage(event).await {
+        Ok(resp) => Ok(resp),
+        Err(e) => Ok(response::format_error_response(&e)),
+    }
+}
+
 // ── Internal handlers ──────────────────────────────────────────────────
 
 async fn handle_get_audience_health(event: Request) -> Result<Response<Body>, AppError> {
@@ -305,6 +343,20 @@ async fn handle_get_subscriber_trends(event: Request) -> Result<Response<Body>, 
     let summary = calculate_trend_summary(&points);
 
     response::format_response(200, SubscriberTrendsResponse { points, summary })
+}
+
+async fn handle_get_timezone_coverage(event: Request) -> Result<Response<Body>, AppError> {
+    let user_context = auth::get_user_context(&event)?;
+    let tenant_id = user_context
+        .tenant_id
+        .ok_or_else(|| AppError::Forbidden("Tenant access required".to_string()))?;
+
+    let subscribers_table = get_subscribers_table_name()?;
+    let ddb_client = aws_clients::get_dynamodb_client().await;
+
+    let coverage = query_timezone_coverage(ddb_client, &subscribers_table, &tenant_id).await?;
+
+    response::format_response(200, coverage)
 }
 
 async fn handle_get_sunset_candidates(event: Request) -> Result<Response<Body>, AppError> {
@@ -998,6 +1050,83 @@ async fn query_all_subscribers(
     Ok(subscribers)
 }
 
+/// Whether a subscriber record carries a timezone the send path would actually
+/// group on.
+///
+/// The parse is not ceremony: `local-send.mjs` re-validates every stored zone
+/// through `Intl` at fan-out time and drops anything unparseable into
+/// `__default__`. Counting a malformed zone as covered here would overstate
+/// readiness for exactly the subscribers the fan-out is about to give up on.
+fn has_confirmed_time_zone(item: &HashMap<String, AttributeValue>) -> bool {
+    item.get("timeZone")
+        .and_then(|v| v.as_s().ok())
+        .map(|zone| zone.parse::<Tz>().is_ok())
+        .unwrap_or(false)
+}
+
+/// Whether a subscriber has logged enough opens for peak-hour placement.
+fn is_peak_hour_eligible(item: &HashMap<String, AttributeValue>) -> bool {
+    item.get("openHourTotal")
+        .and_then(|v| v.as_n().ok())
+        .and_then(|n| n.parse::<i64>().ok())
+        .map(|total| total >= PEAK_HOUR_MIN_SAMPLES)
+        .unwrap_or(false)
+}
+
+/// Count how much of a tenant's list each local-send mode can actually place.
+///
+/// Walks the same tenant partition as `query_all_subscribers` but accumulates
+/// three counters instead of materializing the list — the answer is three
+/// integers, and a tenant with a large list should not pay to build a Vec of
+/// every subscriber to get them.
+async fn query_timezone_coverage(
+    ddb_client: &aws_sdk_dynamodb::Client,
+    table_name: &str,
+    tenant_id: &str,
+) -> Result<TimeZoneCoverageResponse, AppError> {
+    let mut coverage = TimeZoneCoverageResponse::default();
+    let mut exclusive_start_key = None;
+
+    loop {
+        let mut query = ddb_client
+            .query()
+            .table_name(table_name)
+            .key_condition_expression("tenantId = :tid")
+            .expression_attribute_values(":tid", AttributeValue::S(tenant_id.to_string()));
+
+        if let Some(start_key) = exclusive_start_key.take() {
+            query = query.set_exclusive_start_key(Some(start_key));
+        }
+
+        let result = query.send().await?;
+
+        for item in result.items() {
+            // Segment infrastructure rows share this partition — see
+            // `is_subscriber_record`.
+            if !is_subscriber_record(item) {
+                continue;
+            }
+
+            coverage.total_subscribers += 1;
+            if has_confirmed_time_zone(item) {
+                coverage.confirmed_time_zone += 1;
+            }
+            if is_peak_hour_eligible(item) {
+                coverage.peak_hour_eligible += 1;
+            }
+        }
+
+        match result.last_evaluated_key() {
+            Some(key) if !key.is_empty() => {
+                exclusive_start_key = Some(key.clone());
+            }
+            _ => break,
+        }
+    }
+
+    Ok(coverage)
+}
+
 /// Query all subscribers for a tenant and filter for sunset candidates.
 ///
 /// A subscriber is considered dormant if their lastEngagedIssue is below the cutoff:
@@ -1587,6 +1716,150 @@ mod tests {
         // recentActivity is an empty array; openHourTotal defaults to 0.
         assert_eq!(json["recentActivity"], serde_json::json!([]));
         assert_eq!(json["openHourTotal"], 0);
+    }
+
+    /// A subscriber item carrying just the two fields local-send coverage reads.
+    fn make_coverage_item(
+        email: &str,
+        time_zone: Option<&str>,
+        open_hour_total: Option<i64>,
+    ) -> HashMap<String, AttributeValue> {
+        let mut item = HashMap::new();
+        item.insert("email".to_string(), AttributeValue::S(email.to_string()));
+        if let Some(tz) = time_zone {
+            item.insert("timeZone".to_string(), AttributeValue::S(tz.to_string()));
+        }
+        if let Some(total) = open_hour_total {
+            item.insert(
+                "openHourTotal".to_string(),
+                AttributeValue::N(total.to_string()),
+            );
+        }
+        item
+    }
+
+    #[test]
+    fn test_has_confirmed_time_zone_accepts_iana_names() {
+        assert!(has_confirmed_time_zone(&make_coverage_item(
+            "a@example.com",
+            Some("America/Chicago"),
+            None
+        )));
+        assert!(has_confirmed_time_zone(&make_coverage_item(
+            "b@example.com",
+            Some("UTC"),
+            None
+        )));
+    }
+
+    #[test]
+    fn test_has_confirmed_time_zone_rejects_absent_and_unparseable() {
+        // Never confirmed — the common case until 3 agreeing observations land.
+        assert!(!has_confirmed_time_zone(&make_coverage_item(
+            "a@example.com",
+            None,
+            None
+        )));
+        // The send path re-validates through Intl and would drop these into
+        // __default__, so coverage must not count them.
+        assert!(!has_confirmed_time_zone(&make_coverage_item(
+            "b@example.com",
+            Some(""),
+            None
+        )));
+        assert!(!has_confirmed_time_zone(&make_coverage_item(
+            "c@example.com",
+            Some("CST"),
+            None
+        )));
+        assert!(!has_confirmed_time_zone(&make_coverage_item(
+            "d@example.com",
+            Some("Not/AZone"),
+            None
+        )));
+    }
+
+    #[test]
+    fn test_is_peak_hour_eligible_matches_send_path_threshold() {
+        // The boundary is the one local-send.mjs enforces: >= 5 opens.
+        assert!(!is_peak_hour_eligible(&make_coverage_item(
+            "a@example.com",
+            None,
+            None
+        )));
+        assert!(!is_peak_hour_eligible(&make_coverage_item(
+            "b@example.com",
+            None,
+            Some(0)
+        )));
+        assert!(!is_peak_hour_eligible(&make_coverage_item(
+            "c@example.com",
+            None,
+            Some(PEAK_HOUR_MIN_SAMPLES - 1)
+        )));
+        assert!(is_peak_hour_eligible(&make_coverage_item(
+            "d@example.com",
+            None,
+            Some(PEAK_HOUR_MIN_SAMPLES)
+        )));
+        assert!(is_peak_hour_eligible(&make_coverage_item(
+            "e@example.com",
+            None,
+            Some(50)
+        )));
+    }
+
+    #[test]
+    fn test_timezone_coverage_counts_are_independent() {
+        // The two modes place different subscribers: a clicker can have a
+        // confirmed zone with few opens, and a heavy opener who never clicks can
+        // never confirm a zone. Neither count implies the other.
+        let items = vec![
+            make_coverage_item("both@example.com", Some("America/Chicago"), Some(12)),
+            make_coverage_item("tz-only@example.com", Some("Europe/Berlin"), Some(2)),
+            make_coverage_item("opens-only@example.com", None, Some(9)),
+            make_coverage_item("neither@example.com", None, None),
+        ];
+
+        let mut coverage = TimeZoneCoverageResponse::default();
+        for item in &items {
+            if !is_subscriber_record(item) {
+                continue;
+            }
+            coverage.total_subscribers += 1;
+            if has_confirmed_time_zone(item) {
+                coverage.confirmed_time_zone += 1;
+            }
+            if is_peak_hour_eligible(item) {
+                coverage.peak_hour_eligible += 1;
+            }
+        }
+
+        assert_eq!(coverage.total_subscribers, 4);
+        assert_eq!(coverage.confirmed_time_zone, 2);
+        assert_eq!(coverage.peak_hour_eligible, 2);
+    }
+
+    #[test]
+    fn test_timezone_coverage_skips_segment_rows() {
+        // Segment infrastructure rows share the tenant partition and must not
+        // inflate the denominator.
+        let segment_row = make_coverage_item("SEGMENT#abc", Some("America/Chicago"), Some(20));
+        assert!(!is_subscriber_record(&segment_row));
+    }
+
+    #[test]
+    fn test_timezone_coverage_serializes_camel_case() {
+        let json = serde_json::to_value(TimeZoneCoverageResponse {
+            total_subscribers: 100,
+            confirmed_time_zone: 41,
+            peak_hour_eligible: 58,
+        })
+        .unwrap();
+
+        assert_eq!(json["totalSubscribers"], 100);
+        assert_eq!(json["confirmedTimeZone"], 41);
+        assert_eq!(json["peakHourEligible"], 58);
     }
 
     #[test]

--- a/functions/src/api/router.rs
+++ b/functions/src/api/router.rs
@@ -154,9 +154,13 @@ pub async fn route_request(event: Request) -> Result<Response<Body>, Error> {
         (&Method::GET, "/subscribers/trends") => subscribers::get_subscriber_trends(event).await,
         (&Method::GET, "/subscribers") => subscribers::list_subscribers(event).await,
         (&Method::GET, "/subscribers/health") => subscribers::get_audience_health(event).await,
-        // NOTE: the exact at-risk match must come before the generic
-        // /subscribers/{email} prefix route, or "at-risk" is parsed as an email.
+        // NOTE: the exact at-risk and timezone-coverage matches must come before
+        // the generic /subscribers/{email} prefix route, or the literal segment
+        // is parsed as an email.
         (&Method::GET, "/subscribers/at-risk") => churn::get_at_risk_subscribers(event).await,
+        (&Method::GET, "/subscribers/timezone-coverage") => {
+            subscribers::get_timezone_coverage(event).await
+        }
         (&Method::GET, path) if path.starts_with("/subscribers/") => {
             let email = extract_path_param(path, "/subscribers/");
             subscribers::get_subscriber(event, email).await
@@ -424,6 +428,7 @@ fn is_valid_api_path(path: &str) -> bool {
         || path == "/subscribers/count"
         || path == "/subscribers/trends"
         || path == "/subscribers/health"
+        || path == "/subscribers/timezone-coverage"
         || path.starts_with("/subscribers/")
         // Segments paths
         || path == "/segments"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2444,6 +2444,46 @@ paths:
         "500":
           $ref: "#/components/responses/UnknownError"
 
+  /subscribers/timezone-coverage:
+    get:
+      summary: Get local-send readiness for the audience
+      description: >-
+        Counts how many subscribers each local-send mode can actually place in a
+        real group rather than the default fallback. `confirmedTimeZone` is the
+        audience `mode: "timezone"` can place — subscribers whose IANA timezone
+        has been confirmed from open/click geolocation across 3 consecutive
+        issues (including at least one click). `peakHourEligible` is the audience
+        `mode: "peak-hour"` can place — subscribers whose open-hour histogram has
+        reached the minimum sample count. The two counts are independent: a
+        subscriber may qualify for either, both, or neither.
+      tags:
+        - Subscribers
+      responses:
+        "200":
+          description: Local-send coverage counts
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  totalSubscribers:
+                    type: integer
+                    description: Total subscribers on the list
+                  confirmedTimeZone:
+                    type: integer
+                    description: Subscribers with a confirmed, parseable IANA timezone
+                  peakHourEligible:
+                    type: integer
+                    description: Subscribers with enough logged opens for peak-hour placement
+                required:
+                  - totalSubscribers
+                  - confirmedTimeZone
+                  - peakHourEligible
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/UnknownError"
+
   /subscribers/at-risk:
     get:
       summary: Get subscribers at risk of churning, with reasons


### PR DESCRIPTION
Timezone detection has been feeding the subscriber record for a while, but
the dashboard only ever showed it one subscriber at a time, in the profile
modal. The list already received `timeZone` on every row and dropped it, and
nothing anywhere answered the question that actually decides whether local
send is worth enabling: how much of the list can it place?

Two additions:

- A Timezone column on the subscriber list (lg and up; the mobile layout
  gets it on the secondary line, and only when detected — a dash per
  undetected subscriber is noise on a line that tight). Shows the trailing
  segment of the IANA name, which is the part that distinguishes zones at a
  glance, with the full name in the title. An undetected zone explains
  itself rather than rendering a bare dash: detection needs three
  consecutive issues of agreeing geolocation including at least one click,
  so "not yet" is the norm for a new or open-only subscriber, not a fault.

- GET /subscribers/timezone-coverage, and a readiness bar in the issue
  form's local-send box that reads from it. The two counts track the two
  modes: `confirmedTimeZone` is what `mode: "timezone"` can place,
  `peakHourEligible` (openHourTotal >= 5) is what `mode: "peak-hour"` can.
  They are independent — a clicker can have a confirmed zone and few opens,
  and a heavy opener who never clicks can never confirm a zone — so the
  figure switches with the selected mode, and names how many fall back to
  the default zone's send time.

The endpoint counts rather than materializing the list, and validates each
stored zone through chrono-tz because local-send.mjs re-validates through
Intl at fan-out and drops what won't parse; counting those as covered would
overstate readiness for exactly the subscribers the fan-out is about to give
up on. PEAK_HOUR_MIN_SAMPLES is duplicated from local-send.mjs with a note
on both sides, since the dashboard must not promise a placement the send
path won't make.

Coverage is advisory: it loads on first interest rather than on every issue
form open (the query walks the whole tenant partition), and a failed lookup
hides the bar without blocking the toggle.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HpY3L9SfzUTyvDpqKZeTnB