### PR TITLE
fix(issues): apply the default send time to a serialized bare date, and let a scheduled send be moved

### DIFF
--- a/__tests__/state-machines/stage-issue-definition.test.mjs
+++ b/__tests__/state-machines/stage-issue-definition.test.mjs
@@ -15,7 +15,11 @@ const definitionPath = fileURLToPath(new URL('../../state-machines/stage-issue.a
 const templatePath = fileURLToPath(new URL('../../template.yaml', import.meta.url));
 
 const definition = JSON.parse(readFileSync(definitionPath, 'utf8'));
-const templateText = readFileSync(templatePath, 'utf8');
+// Newlines are normalized because the template is read as *text*: the resource
+// scan below matches whole lines exactly, and a Windows checkout (git's
+// core.autocrlf) leaves a trailing \r on every one of them, which fails every
+// such match and takes the whole suite down before a single test runs.
+const templateText = readFileSync(templatePath, 'utf8').replace(/\r\n/g, '\n');
 
 const STATE_MACHINE_RESOURCE = 'StageIssueStateMachine';
 

--- a/dashboard-ui/src/components/issues/RescheduleIssueDialog.tsx
+++ b/dashboard-ui/src/components/issues/RescheduleIssueDialog.tsx
@@ -1,0 +1,271 @@
+import React, { useMemo, useState } from 'react';
+import { Clock } from 'lucide-react';
+import {
+  Modal,
+  ModalHeader,
+  ModalTitle,
+  ModalDescription,
+  ModalContent,
+  ModalFooter
+} from '@/components/ui/Modal';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { cn } from '@/utils/cn';
+import { useTenantDateFormat, useTenantSettings } from '@/contexts/SettingsContext';
+import { padSendTime } from '@/services/settingsService';
+import {
+  combineDateAndTimeInTimeZone,
+  formatDateTimeInTimeZone,
+  toDatetimeLocalInTimeZone
+} from '@/utils/dateFormatting';
+import type { Issue } from '@/types/issues';
+
+/**
+ * How the new send time is chosen.
+ *
+ * `default` sends the API a bare `YYYY-MM-DD` and lets it apply the tenant's
+ * default send time — the same resolution a date-only schedule gets on create.
+ * That is deliberate rather than a shortcut: resolving the day here and posting
+ * an instant would make the dashboard a second implementation of a rule the API
+ * owns, and the two would drift across a DST boundary.
+ */
+type ScheduleMode = 'default' | 'custom';
+
+export interface RescheduleIssueDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  /** The scheduled issue being moved. */
+  issue: Pick<Issue, 'issueNumber' | 'subject' | 'scheduledAt'>;
+  /**
+   * Performs the reschedule. Receives exactly what should go to the API: a
+   * bare date in `default` mode, an RFC3339 instant in `custom` mode. Rejects
+   * to keep the dialog open with the error shown.
+   */
+  onSubmit: (scheduledAt: string) => Promise<void>;
+}
+
+/**
+ * Moves an already-scheduled issue to a different send time.
+ *
+ * The dialog leads with the default-send-time option because that is the
+ * common repair: an issue scheduled from a bare date that never picked up the
+ * tenant's configured time — most visibly one that landed at midnight UTC,
+ * which reads as the previous evening anywhere west of it.
+ */
+export const RescheduleIssueDialog: React.FC<RescheduleIssueDialogProps> = ({
+  isOpen,
+  onClose,
+  issue,
+  onSubmit
+}) => {
+  const { timeZone, formatDateTime } = useTenantDateFormat();
+  const { defaultSendTime } = useTenantSettings();
+
+  // The modal unmounts its children when closed, so these initialisers run
+  // fresh on every open and the form always starts from the current schedule.
+  const current = toDatetimeLocalInTimeZone(issue.scheduledAt, timeZone);
+  const [mode, setMode] = useState<ScheduleMode>('default');
+  const [date, setDate] = useState(current.slice(0, 10));
+  const [time, setTime] = useState(current.slice(11, 16) || padSendTime(defaultSendTime));
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const sendTime = mode === 'default' ? padSendTime(defaultSendTime) : time;
+
+  /**
+   * What the chosen day and time come out as. In `default` mode this mirrors
+   * what the API will resolve rather than deciding it — the resolvers agree by
+   * construction (see `combineDateAndTimeInTimeZone`), and the response is
+   * still the value the page adopts.
+   */
+  const preview = useMemo(() => {
+    if (!date || !sendTime) return null;
+
+    const instant = combineDateAndTimeInTimeZone(date, sendTime, timeZone);
+    if (!instant) return null;
+
+    return {
+      instant,
+      inTenantZone: formatDateTimeInTimeZone(instant, timeZone),
+      inUtc: formatDateTimeInTimeZone(instant, 'UTC'),
+      isPast: new Date(instant).getTime() <= Date.now()
+    };
+  }, [date, sendTime, timeZone]);
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+
+    if (!date) {
+      setError('Pick a date for this issue to send.');
+      return;
+    }
+    if (mode === 'custom' && !time) {
+      setError('Pick a time of day for this issue to send.');
+      return;
+    }
+    if (!preview) {
+      setError("That date and time isn't a valid send time.");
+      return;
+    }
+    if (preview.isPast) {
+      setError('Pick a time in the future — a send cannot be moved into the past.');
+      return;
+    }
+
+    setError(null);
+    setIsSubmitting(true);
+
+    try {
+      // The bare date is the payload in default mode: the API applies the
+      // tenant's default send time to it, which is the whole point of the
+      // option.
+      await onSubmit(mode === 'default' ? date : preview.instant);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to move the send time.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleClose = () => {
+    if (!isSubmitting) onClose();
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleClose} size="md">
+      <form onSubmit={handleSubmit}>
+        <ModalHeader onClose={handleClose}>
+          <ModalTitle>Change send time</ModalTitle>
+          <ModalDescription>
+            Issue #{issue.issueNumber} is currently scheduled for{' '}
+            {formatDateTime(issue.scheduledAt)}.
+          </ModalDescription>
+        </ModalHeader>
+
+        <ModalContent>
+          <div className="space-y-4">
+            <fieldset>
+              <legend className="field-label mb-2">Send time</legend>
+              <div className="space-y-2">
+                <ModeOption
+                  id="reschedule-mode-default"
+                  checked={mode === 'default'}
+                  onSelect={() => setMode('default')}
+                  disabled={isSubmitting}
+                  title="Use my default send time"
+                  description={`Your newsletter default is ${padSendTime(defaultSendTime)} in ${timeZone}. The exact instant is worked out when you save.`}
+                />
+                <ModeOption
+                  id="reschedule-mode-custom"
+                  checked={mode === 'custom'}
+                  onSelect={() => setMode('custom')}
+                  disabled={isSubmitting}
+                  title="Pick a specific time"
+                  description="Choose the time of day yourself, in your newsletter timezone."
+                />
+              </div>
+            </fieldset>
+
+            <div className={cn('grid gap-4', mode === 'custom' ? 'sm:grid-cols-2' : 'sm:max-w-xs')}>
+              <Input
+                label="Date"
+                type="date"
+                value={date}
+                onChange={(event) => setDate(event.target.value)}
+                disabled={isSubmitting}
+              />
+              {mode === 'custom' && (
+                <Input
+                  label="Time of day"
+                  type="time"
+                  value={time}
+                  onChange={(event) => setTime(event.target.value)}
+                  disabled={isSubmitting}
+                />
+              )}
+            </div>
+
+            {preview && (
+              <div className="rounded-lg border border-border bg-surface p-4">
+                <p className="text-sm font-medium text-foreground flex items-center gap-2">
+                  <Clock className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+                  This issue would send at
+                </p>
+                <p className="text-sm text-muted-foreground mt-1">{preview.inTenantZone}</p>
+                <p className="text-xs text-muted-foreground mt-0.5">{preview.inUtc}</p>
+              </div>
+            )}
+
+            {error && (
+              <p role="alert" className="text-sm text-error-600">
+                {error}
+              </p>
+            )}
+
+            <p className="text-xs text-muted-foreground">
+              A send can only be moved while it is still waiting. Once the issue starts going out,
+              unscheduling is the only way to stop it.
+            </p>
+          </div>
+        </ModalContent>
+
+        <ModalFooter>
+          <Button type="button" variant="outline" onClick={handleClose} disabled={isSubmitting}>
+            Cancel
+          </Button>
+          <Button type="submit" disabled={isSubmitting}>
+            {isSubmitting ? 'Moving…' : 'Change send time'}
+          </Button>
+        </ModalFooter>
+      </form>
+    </Modal>
+  );
+};
+
+interface ModeOptionProps {
+  id: string;
+  checked: boolean;
+  onSelect: () => void;
+  disabled: boolean;
+  title: string;
+  description: string;
+}
+
+/** One choice, as a card: radio, its label, and what choosing it means. */
+const ModeOption: React.FC<ModeOptionProps> = ({
+  id,
+  checked,
+  onSelect,
+  disabled,
+  title,
+  description
+}) => (
+  <div
+    className={cn(
+      'flex gap-3 items-start p-3 rounded-lg border transition-colors',
+      checked
+        ? 'border-primary-500 bg-primary-50 dark:bg-primary-900/20'
+        : 'border-border hover:bg-surface',
+      disabled && 'opacity-60'
+    )}
+  >
+    <input
+      id={id}
+      type="radio"
+      name="reschedule-mode"
+      className="mt-1"
+      checked={checked}
+      onChange={onSelect}
+      disabled={disabled}
+      aria-describedby={`${id}-description`}
+    />
+    <div>
+      <label htmlFor={id} className="block text-sm font-medium text-foreground cursor-pointer">
+        {title}
+      </label>
+      <p id={`${id}-description`} className="text-xs text-muted-foreground mt-0.5">
+        {description}
+      </p>
+    </div>
+  </div>
+);

--- a/dashboard-ui/src/components/issues/__tests__/RescheduleIssueDialog.test.tsx
+++ b/dashboard-ui/src/components/issues/__tests__/RescheduleIssueDialog.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { RescheduleIssueDialog } from '../RescheduleIssueDialog';
+import type { Issue } from '@/types/issues';
+
+// The tenant is in Chicago at 09:00, so a bare date and a resolved instant are
+// visibly different values — which is the distinction these tests are about.
+vi.mock('@/contexts/SettingsContext', async () => {
+  const actual = await vi.importActual<typeof import('@/contexts/SettingsContext')>(
+    '@/contexts/SettingsContext'
+  );
+  const settings = { timezone: 'America/Chicago', defaultSendTime: '09:00' };
+
+  return {
+    ...actual,
+    useTenantSettings: () => settings,
+    useTenantDateFormat: () => ({
+      timeZone: settings.timezone,
+      formatDate: (value: string) => value,
+      formatLongDate: (value: string) => value,
+      formatTime: (value: string) => value,
+      formatDateTime: (value: string) => value,
+      timeZoneLabel: () => 'CDT'
+    })
+  };
+});
+
+/** Far enough out that these never collide with the "must be future" guard. */
+const SCHEDULED_AT = '2099-08-03T00:00:00.000Z';
+
+const issue = {
+  issueNumber: 42,
+  subject: 'Issue 42',
+  scheduledAt: SCHEDULED_AT
+} as Pick<Issue, 'issueNumber' | 'subject' | 'scheduledAt'>;
+
+const renderDialog = (onSubmit = vi.fn().mockResolvedValue(undefined)) => {
+  render(
+    <RescheduleIssueDialog isOpen onClose={vi.fn()} issue={issue} onSubmit={onSubmit} />
+  );
+  return onSubmit;
+};
+
+const submit = () => fireEvent.click(screen.getByRole('button', { name: /change send time/i }));
+
+describe('RescheduleIssueDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('opens on the tenant default and sends a bare date so the API resolves it', async () => {
+    const onSubmit = renderDialog();
+
+    // The stored instant is midnight UTC, which is the previous evening in
+    // Chicago — the date field shows the day the tenant sees.
+    expect(screen.getByLabelText('Date')).toHaveValue('2099-08-02');
+    // No time input in default mode: the send time is the tenant's setting.
+    expect(screen.queryByLabelText('Time of day')).not.toBeInTheDocument();
+
+    submit();
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith('2099-08-02'));
+  });
+
+  it('previews the instant a date-only send would land on', () => {
+    renderDialog();
+
+    // 09:00 CDT is 14:00Z — the resolution the API will perform, shown before
+    // the operator commits to it.
+    expect(screen.getByText(/Aug 2, 2099, 9:00\s?AM CDT/)).toBeInTheDocument();
+    expect(screen.getByText(/Aug 2, 2099, 2:00\s?PM UTC/)).toBeInTheDocument();
+  });
+
+  it('sends a resolved instant when a specific time is picked', async () => {
+    const onSubmit = renderDialog();
+
+    fireEvent.click(screen.getByLabelText(/Pick a specific time/i));
+    fireEvent.change(screen.getByLabelText('Date'), { target: { value: '2099-08-05' } });
+    fireEvent.change(screen.getByLabelText('Time of day'), { target: { value: '18:30' } });
+
+    submit();
+
+    // 18:30 CDT is 23:30Z. A specific time is the caller being specific, so it
+    // goes to the API as an instant rather than a date to be resolved.
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith('2099-08-05T23:30:00.000Z')
+    );
+  });
+
+  it('refuses a send time in the past', async () => {
+    const onSubmit = renderDialog();
+
+    fireEvent.change(screen.getByLabelText('Date'), { target: { value: '2020-01-01' } });
+    submit();
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/future/i);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('keeps the dialog open and shows why when the API refuses', async () => {
+    const onSubmit = vi
+      .fn()
+      .mockRejectedValue(new Error('Issue 42 is already being prepared to send'));
+    renderDialog(onSubmit);
+
+    submit();
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/already being prepared/i);
+  });
+});

--- a/dashboard-ui/src/components/issues/index.ts
+++ b/dashboard-ui/src/components/issues/index.ts
@@ -19,6 +19,9 @@ export type { TemplateJsonEditorProps } from './TemplateJsonEditor';
 export { DeleteIssueDialog } from './DeleteIssueDialog';
 export type { DeleteIssueDialogProps } from './DeleteIssueDialog';
 
+export { RescheduleIssueDialog } from './RescheduleIssueDialog';
+export type { RescheduleIssueDialogProps } from './RescheduleIssueDialog';
+
 export { IssuesEmptyState } from './IssuesEmptyState';
 export type { IssuesEmptyStateProps } from './IssuesEmptyState';
 

--- a/dashboard-ui/src/pages/issues/IssueDetailPage.tsx
+++ b/dashboard-ui/src/pages/issues/IssueDetailPage.tsx
@@ -9,6 +9,7 @@ import { cn } from '../../utils/cn';
 import { IssueStatusBadge } from '../../components/issues/IssueStatusBadge';
 import { MarkdownPreview } from '../../components/issues/MarkdownPreview';
 import { DeleteIssueDialog } from '../../components/issues/DeleteIssueDialog';
+import { RescheduleIssueDialog } from '../../components/issues/RescheduleIssueDialog';
 import { SubscriberMetricsPanel } from '../../components/issues/SubscriberMetricsPanel';
 import { AbTestResults } from '../../components/issues/AbTestResults';
 import { SendProgressCard } from '../../components/issues/SendProgressCard';
@@ -123,6 +124,7 @@ export const IssueDetailPage: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [rescheduleDialogOpen, setRescheduleDialogOpen] = useState(false);
   const [selectedLinkId, setSelectedLinkId] = useState<string | null>(null);
   const [isAnalyticsRebuilding, setIsAnalyticsRebuilding] = useState(false);
   const [isMarkingPublished, setIsMarkingPublished] = useState(false);
@@ -552,6 +554,44 @@ export const IssueDetailPage: React.FC = () => {
   );
   const canMarkAsPublished = useMemo(() => issue?.status === 'in progress' || issue?.status === 'failed', [issue?.status]);
 
+  /**
+   * A scheduled issue is the only one with a send time to move. The API
+   * refuses once the publish workflow has started, which the page can't see
+   * from here — so the button stays offered and the dialog surfaces that
+   * refusal rather than the page guessing at it.
+   */
+  const canReschedule = useMemo(
+    () => issue?.status === 'scheduled' && !!issue?.scheduledAt,
+    [issue?.status, issue?.scheduledAt]
+  );
+
+  /**
+   * Moves the send time of a scheduled issue.
+   *
+   * The value handed over is whatever the dialog decided — a bare date when
+   * the tenant's default send time should apply, an instant otherwise — and
+   * the response, not the request, is what the page adopts: only the API knows
+   * what a bare date resolves to.
+   */
+  const handleReschedule = useCallback(async (scheduledAt: string) => {
+    if (!id) return;
+
+    const response = await issuesService.rescheduleIssue(id, scheduledAt);
+
+    if (!response.success || !response.data) {
+      throw new Error(response.error || 'Could not move the send time.');
+    }
+
+    const resolved = response.data.scheduledAt;
+    setIssue((current) => (current ? { ...current, scheduledAt: resolved } : current));
+    setRescheduleDialogOpen(false);
+    addToast({
+      type: 'success',
+      title: 'Send time updated',
+      message: `This issue now sends ${formatDate(resolved)}.`,
+    });
+  }, [id, addToast, formatDate]);
+
   // The content heatmap overlays click data on the rendered markdown, so it only
   // applies to markdown issues that have per-link analytics.
   const canShowHeatmap = useMemo(
@@ -829,6 +869,18 @@ export const IssueDetailPage: React.FC = () => {
                     <RefreshCw className="h-4 w-4 mr-2" />
                     <span className="hidden sm:inline">{isAnalyticsRebuilding ? 'Queuing…' : 'Refresh insights'}</span>
                     <span className="sm:hidden">{isAnalyticsRebuilding ? 'Queuing…' : 'Refresh'}</span>
+                  </Button>
+                )}
+                {canReschedule && (
+                  <Button
+                    onClick={() => setRescheduleDialogOpen(true)}
+                    variant="outline"
+                    size="sm"
+                    aria-label="Change this issue's send time"
+                    className="hover:bg-primary-50 hover:border-primary-300 dark:hover:bg-primary-900/20 transition-colors min-h-[44px] min-w-[44px]"
+                  >
+                    <Clock className="h-4 w-4 mr-2" />
+                    <span className="hidden sm:inline">Change send time</span>
                   </Button>
                 )}
                 {isDraft && (
@@ -1322,6 +1374,16 @@ export const IssueDetailPage: React.FC = () => {
         </Card>
 
       </main>
+
+      {/* Reschedule Dialog */}
+      {canReschedule && issue && (
+        <RescheduleIssueDialog
+          isOpen={rescheduleDialogOpen}
+          onClose={() => setRescheduleDialogOpen(false)}
+          issue={issue}
+          onSubmit={handleReschedule}
+        />
+      )}
 
       {/* Delete Confirmation Dialog */}
       <DeleteIssueDialog

--- a/dashboard-ui/src/services/issuesService.ts
+++ b/dashboard-ui/src/services/issuesService.ts
@@ -7,6 +7,8 @@ import type {
   TrendsData,
   CreateIssueRequest,
   UpdateIssueRequest,
+  RescheduleIssueRequest,
+  RescheduleIssueResponse,
   ListIssuesParams,
   VariantId,
   AbHistoryResponse,
@@ -127,6 +129,29 @@ class IssuesService {
    */
   async updateIssue(issueId: string, data: UpdateIssueRequest): Promise<ApiResponse<Issue>> {
     return apiClient.put(`/issues/${issueId}`, data);
+  }
+
+  /**
+   * Moves a scheduled issue's send time.
+   *
+   * Separate from {@link updateIssue} because the API treats it separately: a
+   * scheduled issue refuses content edits, but its send time can still move
+   * until the publish workflow starts. Passing a bare `YYYY-MM-DD` resolves the
+   * day against the tenant's default send time server-side, which is how an
+   * issue scheduled without one gets corrected.
+   *
+   * @param issueId - Unique identifier of the issue to reschedule
+   * @param scheduledAt - RFC3339 instant, or a date-only `YYYY-MM-DD` value
+   * @returns Promise resolving to the resolved send instant
+   * @throws {Error} 409 Conflict if the send has already started
+   */
+  async rescheduleIssue(
+    issueId: string,
+    scheduledAt: string
+  ): Promise<ApiResponse<RescheduleIssueResponse>> {
+    return apiClient.put<RescheduleIssueResponse>(`/issues/${issueId}/schedule`, {
+      scheduledAt
+    } satisfies RescheduleIssueRequest);
   }
 
   /**

--- a/dashboard-ui/src/types/issues.ts
+++ b/dashboard-ui/src/types/issues.ts
@@ -316,6 +316,26 @@ export interface UpdateIssueRequest {
   contentAssembly?: ContentAssembly | null;
 }
 
+/**
+ * A new send time for an issue that is already scheduled.
+ *
+ * `scheduledAt` takes the same forms the create endpoint accepts, and the
+ * difference between them is the point: a full timestamp names an instant,
+ * while a bare `YYYY-MM-DD` asks the API to anchor the day to the tenant's
+ * default send time and timezone.
+ */
+export interface RescheduleIssueRequest {
+  scheduledAt: string;
+}
+
+/** What a reschedule reports back — chiefly the resolved instant. */
+export interface RescheduleIssueResponse {
+  id: string;
+  issueNumber: number;
+  status: IssueStatus;
+  scheduledAt: string;
+}
+
 export interface ListIssuesParams {
   limit?: number;
   nextToken?: string;

--- a/dashboard-ui/vitest.config.ts
+++ b/dashboard-ui/vitest.config.ts
@@ -9,6 +9,14 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: ['./src/test/setup.ts'],
+    env: {
+      // The dashboard renders instants in the tenant's zone, and falls back to
+      // the *browser's* zone until settings load — so any test that asserts on
+      // a rendered time is really asserting against the machine's timezone.
+      // Pinning it here is what makes those tests mean the same thing on a
+      // developer's laptop as they do in CI, which runs in UTC.
+      TZ: 'UTC',
+    },
   },
   resolve: {
     alias: {

--- a/functions/__tests__/tenant-settings.test.mjs
+++ b/functions/__tests__/tenant-settings.test.mjs
@@ -24,6 +24,19 @@ describe('tenant-settings', () => {
       expect(isDateOnly(new Date('2026-08-01T12:00:00.000Z'))).toBe(false);
       expect(isDateOnly(new Date('nope'))).toBe(false);
     });
+
+    it('recognizes that Date once it has been serialized back to a string', () => {
+      // How a bare frontmatter date reaches `sendAt`: through JSON, as a
+      // string. Read literally it is a midnight send, a day early west of UTC.
+      expect(isDateOnly('2026-08-01T00:00:00.000Z')).toBe(true);
+      expect(isDateOnly('2026-08-01T00:00:00Z')).toBe(true);
+      expect(isDateOnly('2026-08-01T00:00:00+00:00')).toBe(true);
+    });
+
+    it('leaves a midnight the caller actually chose alone', () => {
+      expect(isDateOnly('2026-08-01T00:00:00-05:00')).toBe(false);
+      expect(isDateOnly('2026-08-01T00:00:01Z')).toBe(false);
+    });
   });
 
   describe('resolveSendInstant', () => {
@@ -54,6 +67,15 @@ describe('tenant-settings', () => {
     it('resolves the UTC-midnight Date form the same way', () => {
       const resolved = resolveSendInstant(
         new Date('2026-08-01T00:00:00.000Z'),
+        settings({ timezone: 'America/Chicago', defaultSendTime: '09:00' })
+      );
+
+      expect(resolved.toISOString()).toBe('2026-08-01T14:00:00.000Z');
+    });
+
+    it('resolves the serialized UTC-midnight string the same way', () => {
+      const resolved = resolveSendInstant(
+        '2026-08-01T00:00:00.000Z',
         settings({ timezone: 'America/Chicago', defaultSendTime: '09:00' })
       );
 

--- a/functions/src/api/controllers/issues.rs
+++ b/functions/src/api/controllers/issues.rs
@@ -139,6 +139,25 @@ pub struct UpdateIssueRequest {
     content_type: Option<String>,
 }
 
+/// Request body for moving a scheduled issue's send time.
+#[derive(Deserialize)]
+pub struct RescheduleIssueRequest {
+    #[serde(rename = "scheduledAt")]
+    scheduled_at: String,
+}
+
+/// What a reschedule reports back: the resolved instant, which is the point of
+/// the call when the caller sent a bare date.
+#[derive(Serialize)]
+pub struct RescheduleIssueResponse {
+    id: String,
+    #[serde(rename = "issueNumber")]
+    issue_number: i32,
+    status: String,
+    #[serde(rename = "scheduledAt")]
+    scheduled_at: String,
+}
+
 // Request body for declaring an A/B test winner.
 #[derive(Deserialize)]
 pub struct DeclareWinnerRequest {
@@ -464,6 +483,16 @@ pub async fn update_issue(
     issue_id: Option<String>,
 ) -> Result<Response<Body>, Error> {
     match handle_update_issue(event, issue_id).await {
+        Ok(response) => Ok(response),
+        Err(e) => Ok(response::format_error_response(&e)),
+    }
+}
+
+pub async fn reschedule_issue(
+    event: Request,
+    issue_id: Option<String>,
+) -> Result<Response<Body>, Error> {
+    match handle_reschedule_issue(event, issue_id).await {
         Ok(response) => Ok(response),
         Err(e) => Ok(response::format_error_response(&e)),
     }
@@ -2189,6 +2218,93 @@ async fn handle_update_issue(
     response::format_response(200, updated)
 }
 
+/// Moves a scheduled issue's send to a different instant.
+///
+/// Separate from `PUT /issues/{id}` on purpose. That endpoint edits a draft's
+/// content and refuses a `scheduled` issue outright, because an edit whose
+/// window has closed (the workflow reads the record at send instant − lead
+/// time) would silently not be in the issue. Moving the send is the one change
+/// a scheduled issue *can* accept, and it has to do something the content
+/// update never does: re-point the Scheduler entry.
+///
+/// A bare `YYYY-MM-DD` resolves against the tenant's default send time, exactly
+/// as it does on create — which is what makes this the fix for an issue whose
+/// stored instant came from a date that never got that treatment.
+async fn handle_reschedule_issue(
+    event: Request,
+    issue_id: Option<String>,
+) -> Result<Response<Body>, AppError> {
+    let user_context = auth::get_user_context(&event)?;
+    let tenant_id = user_context
+        .tenant_id
+        .ok_or_else(|| AppError::Unauthorized("Tenant access required".to_string()))?;
+
+    let issue_id =
+        issue_id.ok_or_else(|| AppError::BadRequest("Issue ID is required".to_string()))?;
+
+    let body: RescheduleIssueRequest = serde_json::from_slice(event.body())
+        .map_err(|e| AppError::BadRequest(format!("Invalid JSON: {}", e)))?;
+
+    // The issue is checked before the new time is resolved so an issue that
+    // cannot be rescheduled says so, rather than complaining about a date that
+    // was never going to be used.
+    let existing = get_issue_by_id(&tenant_id, &issue_id).await?;
+
+    if existing.status != "scheduled" {
+        return Err(AppError::BadRequest(format!(
+            "Cannot reschedule an issue with status '{}'. Only scheduled issues have a send time \
+             to move",
+            existing.status
+        )));
+    }
+
+    // The workflow has started, so the send is past the point this can move:
+    // the content is frozen, the Scheduler entry is gone, and the wait that
+    // remains belongs to the execution. Unscheduling is the only way out, and
+    // it is the honest thing to point at.
+    if existing.execution_arn.is_some() {
+        return Err(AppError::Conflict(format!(
+            "Issue {} is already being prepared to send and can no longer be moved. Unschedule it \
+             to stop the send.",
+            existing.issue_number
+        )));
+    }
+
+    let requested = body.scheduled_at.trim();
+    let tenant_settings = load_settings_if_needed(&tenant_id, Some(requested), false).await;
+    let scheduled_at = resolve_reschedule_at(requested, &tenant_settings)?;
+
+    reschedule_issue_send(
+        &IssueScheduleInput {
+            tenant_id: &tenant_id,
+            tenant_email: user_context.email.as_str(),
+            issue_number: existing.issue_number,
+            scheduled_at: Some(&scheduled_at),
+            template_id: existing.template_id.as_deref(),
+            content_type: &normalize_content_type(existing.content_type.as_deref()),
+        },
+        &scheduled_at,
+    )
+    .await?;
+
+    // Deliberately after the send has moved. Either order can fail halfway and
+    // both heal on a retry, but only this one leaves the issue sending when the
+    // caller asked; the other leaves a record promising a time the send won't
+    // honour.
+    update_issue_scheduled_at(&tenant_id, existing.issue_number, &scheduled_at).await?;
+
+    let response = RescheduleIssueResponse {
+        id: existing.issue_number.to_string(),
+        issue_number: existing.issue_number,
+        status: "scheduled".to_string(),
+        scheduled_at,
+    };
+
+    publish_event(&tenant_id, "ISSUE_UPDATED", &response).await?;
+
+    response::format_response(200, response)
+}
+
 async fn handle_delete_issue(
     event: Request,
     issue_id: Option<String>,
@@ -3516,10 +3632,11 @@ async fn load_settings_if_needed(
 /// issue. `None` means "send immediately" — an absent value, `"now"`, or a
 /// time that has already passed.
 ///
-/// A date-only value (`YYYY-MM-DD`) carries no time of day, so rather than
-/// rejecting it or guessing midnight UTC, it is anchored to the tenant's
-/// configured default send time, read as wall-clock time in the tenant's
-/// timezone (see [`super::settings`]).
+/// A date-only value carries no time of day, so rather than rejecting it or
+/// guessing midnight UTC, it is anchored to the tenant's configured default
+/// send time, read as wall-clock time in the tenant's timezone. That covers
+/// both a bare `YYYY-MM-DD` and the exactly-midnight-UTC timestamp a
+/// serialized bare date arrives as (see [`super::settings::date_only_day`]).
 fn resolve_scheduled_at(
     value: Option<&str>,
     settings: &TenantSettings,
@@ -3548,6 +3665,24 @@ fn resolve_scheduled_at(
     }
 
     Ok(Some(parsed.to_rfc3339()))
+}
+
+/// The instant a reschedule names, resolved the same way a create's
+/// `scheduledAt` is — a bare date (in either spelling) picks up the tenant's
+/// default send time.
+///
+/// The one difference is what "no instant" means. [`resolve_scheduled_at`]
+/// answers `None` for an empty value, `"now"`, and a time that has already
+/// passed, all of which mean "send immediately" on create. None of them mean
+/// that here: nobody moving a scheduled send is asking for it to go out this
+/// second, so they are rejected rather than acted on.
+fn resolve_reschedule_at(requested: &str, settings: &TenantSettings) -> Result<String, AppError> {
+    resolve_scheduled_at(Some(requested), settings)?.ok_or_else(|| {
+        AppError::BadRequest(
+            "scheduledAt must be a future time. To send now, unschedule the issue and publish it."
+                .to_string(),
+        )
+    })
 }
 
 /// Hashes everything that determines what a create request does, so a reused
@@ -3943,24 +4078,14 @@ async fn schedule_issue_send(
         .create_schedule()
         .name(&schedule_name)
         .group_name("newsletter")
-        .schedule_expression(format!("at({})", fire_at.format("%Y-%m-%dT%H:%M:%S")))
+        .schedule_expression(issue_send_schedule_expression(fire_at))
         .action_after_completion(aws_sdk_scheduler::types::ActionAfterCompletion::Delete)
-        .flexible_time_window(
-            aws_sdk_scheduler::types::FlexibleTimeWindow::builder()
-                .mode(aws_sdk_scheduler::types::FlexibleTimeWindowMode::Off)
-                .build()
-                .map_err(|e| {
-                    AppError::InternalError(format!("Failed to build time window: {}", e))
-                })?,
-        )
-        .target(
-            aws_sdk_scheduler::types::Target::builder()
-                .arn(&state_machine_arn)
-                .role_arn(&role_arn)
-                .input(execution_input.to_string())
-                .build()
-                .map_err(|e| AppError::InternalError(format!("Failed to build target: {}", e)))?,
-        )
+        .flexible_time_window(issue_send_time_window()?)
+        .target(issue_send_target(
+            &state_machine_arn,
+            &role_arn,
+            execution_input,
+        )?)
         .send()
         .await
         .map_err(|err| {
@@ -4010,6 +4135,171 @@ async fn schedule_issue_send(
 
         return Err(status_error);
     }
+
+    Ok(())
+}
+
+/// The `at()` expression Scheduler stores. Second granularity, no zone suffix —
+/// Scheduler reads it as UTC, which is the zone `fire_at` is already in.
+fn issue_send_schedule_expression(fire_at: chrono::DateTime<chrono::Utc>) -> String {
+    format!("at({})", fire_at.format("%Y-%m-%dT%H:%M:%S"))
+}
+
+/// A send fires at its instant or not at all, so the flexible window is off.
+fn issue_send_time_window() -> Result<aws_sdk_scheduler::types::FlexibleTimeWindow, AppError> {
+    aws_sdk_scheduler::types::FlexibleTimeWindow::builder()
+        .mode(aws_sdk_scheduler::types::FlexibleTimeWindowMode::Off)
+        .build()
+        .map_err(|e| AppError::InternalError(format!("Failed to build time window: {}", e)))
+}
+
+fn issue_send_target(
+    state_machine_arn: &str,
+    role_arn: &str,
+    execution_input: &serde_json::Value,
+) -> Result<aws_sdk_scheduler::types::Target, AppError> {
+    aws_sdk_scheduler::types::Target::builder()
+        .arn(state_machine_arn)
+        .role_arn(role_arn)
+        .input(execution_input.to_string())
+        .build()
+        .map_err(|e| AppError::InternalError(format!("Failed to build target: {}", e)))
+}
+
+/// Moves an already-scheduled issue's send to a new instant.
+///
+/// The entry is *replaced*, not deleted and recreated. `UpdateSchedule` is a
+/// full overwrite of a schedule that keeps existing, so there is no moment
+/// where the issue says `scheduled` with nothing behind it — which a failed
+/// `CreateSchedule` after a successful `DeleteSchedule` would leave, and which
+/// nothing is watching for.
+///
+/// The target input is rewritten along with the fire time, so the execution's
+/// `sendAt` is the new instant. The two must move together: the entry decides
+/// when the workflow starts, `sendAt` decides when the issue goes out, and a
+/// stale `sendAt` sends at the old time from a workflow that started at the new
+/// one.
+async fn reschedule_issue_send(
+    input: &IssueScheduleInput<'_>,
+    scheduled_at: &str,
+) -> Result<(), AppError> {
+    let execution_input = build_execution_input(input);
+
+    let send_instant = chrono::DateTime::parse_from_rfc3339(scheduled_at)
+        .map_err(|_| {
+            AppError::InternalError(format!("Unparseable scheduled send time: {scheduled_at}"))
+        })?
+        .with_timezone(&chrono::Utc);
+
+    let now = chrono::Utc::now();
+    let fire_at = issue_send_fire_at(send_instant, issue_send_lead_time(), now);
+
+    // Moved to inside the lead time, so the workflow is already due. Same
+    // branch the create path takes for a short-notice schedule: cancel the
+    // entry and start the execution here, since Scheduler cannot be asked for a
+    // fire time that has effectively passed. The issue still goes out at its
+    // own instant — the workflow carries `sendAt` and the send path holds it.
+    if is_due_now(fire_at, now) {
+        delete_issue_send_schedule(input.tenant_id, input.issue_number).await?;
+        return start_issue_execution(input, &execution_input).await;
+    }
+
+    let scheduler = aws_clients::get_scheduler_client().await;
+    let state_machine_arn = std::env::var("STATE_MACHINE_ARN")
+        .map_err(|_| AppError::InternalError("STATE_MACHINE_ARN not set".to_string()))?;
+    let role_arn = std::env::var("ISSUE_SEND_SCHEDULER_ROLE_ARN").map_err(|_| {
+        AppError::InternalError("ISSUE_SEND_SCHEDULER_ROLE_ARN not set".to_string())
+    })?;
+    let schedule_name = build_issue_send_schedule_name(input.tenant_id, input.issue_number);
+
+    scheduler
+        .update_schedule()
+        .name(&schedule_name)
+        .group_name("newsletter")
+        .schedule_expression(issue_send_schedule_expression(fire_at))
+        .action_after_completion(aws_sdk_scheduler::types::ActionAfterCompletion::Delete)
+        .flexible_time_window(issue_send_time_window()?)
+        .target(issue_send_target(
+            &state_machine_arn,
+            &role_arn,
+            &execution_input,
+        )?)
+        .send()
+        .await
+        .map_err(|err| {
+            // A `scheduled` record whose entry has gone missing is the one case
+            // this can't fix: the entry deletes itself when it fires, so
+            // not-found here means the send already started (or was cancelled
+            // out from under the record) and there is nothing left to move.
+            // Recreating one would send the issue a second time.
+            let is_not_found = err
+                .as_service_error()
+                .is_some_and(|service_err| service_err.is_resource_not_found_exception());
+
+            if is_not_found {
+                return AppError::Conflict(format!(
+                    "Issue {} no longer has a pending send to move. It may already be on its way \
+                     out; reload the issue to see where it is.",
+                    input.issue_number
+                ));
+            }
+
+            AppError::AwsError(format!("Failed to move the scheduled send: {}", err))
+        })?;
+
+    Ok(())
+}
+
+/// Writes a rescheduled issue's new send instant to its record.
+///
+/// Conditional on the record still saying `scheduled`: the publish workflow
+/// claims the issue by moving it off that status, so the condition is what
+/// keeps a reschedule from rewriting the send time of an issue that started
+/// going out while this request was in flight.
+async fn update_issue_scheduled_at(
+    tenant_id: &str,
+    issue_number: i32,
+    scheduled_at: &str,
+) -> Result<(), AppError> {
+    let ddb_client = aws_clients::get_dynamodb_client().await;
+    let table_name = std::env::var("TABLE_NAME")
+        .map_err(|_| AppError::InternalError("TABLE_NAME not set".to_string()))?;
+
+    ddb_client
+        .update_item()
+        .table_name(&table_name)
+        .key(
+            "pk",
+            AttributeValue::S(format!("{tenant_id}#{issue_number}")),
+        )
+        .key("sk", AttributeValue::S("newsletter".to_string()))
+        .update_expression("SET scheduledAt = :scheduledAt, updatedAt = :updatedAt")
+        .condition_expression("attribute_exists(pk) AND #status = :scheduled")
+        .expression_attribute_names("#status", "status")
+        .expression_attribute_values(":scheduledAt", AttributeValue::S(scheduled_at.to_string()))
+        .expression_attribute_values(
+            ":updatedAt",
+            AttributeValue::S(chrono::Utc::now().to_rfc3339()),
+        )
+        .expression_attribute_values(":scheduled", AttributeValue::S("scheduled".to_string()))
+        .send()
+        .await
+        .map_err(|err| {
+            // The send moved but the record didn't. Reporting it as a plain
+            // failure would be a lie in the operator's favour, so say which
+            // half landed — a retry re-points the entry at the same instant and
+            // writes the record, so the fix is to try again.
+            tracing::error!(
+                "Issue {} send was moved to {scheduled_at} but the record still shows the old \
+                 time: {err}",
+                issue_number
+            );
+            AppError::InternalError(format!(
+                "Issue {} is now set to send at {scheduled_at}, but the issue record could not be \
+                 updated to say so. Retry the reschedule.",
+                issue_number
+            ))
+        })?;
 
     Ok(())
 }
@@ -5392,6 +5682,32 @@ Thanks!"#;
     }
 
     #[test]
+    fn test_resolve_scheduled_at_applies_default_send_time_to_a_serialized_bare_date() {
+        // The GitHub Action forwards a frontmatter `date:` as-is, and a bare
+        // date serializes to midnight UTC. Stored verbatim it sends the
+        // evening before for any tenant west of UTC, so it gets the same
+        // treatment as the date it came from.
+        let value = format!("{}-08-01T00:00:00.000Z", future_year());
+        let resolved =
+            resolve_scheduled_at(Some(&value), &tenant_settings("America/Chicago", "09:00"))
+                .unwrap()
+                .expect("a future date should stay scheduled");
+
+        assert_eq!(resolved, format!("{}-08-01T14:00:00+00:00", future_year()));
+    }
+
+    #[test]
+    fn test_resolve_scheduled_at_keeps_a_deliberate_midnight() {
+        // Midnight with a real offset is a time the caller picked.
+        let value = format!("{}-08-01T00:00:00-05:00", future_year());
+        let resolved =
+            resolve_scheduled_at(Some(&value), &tenant_settings("America/Chicago", "09:00"))
+                .unwrap();
+
+        assert_eq!(resolved, Some(value));
+    }
+
+    #[test]
     fn test_resolve_scheduled_at_uses_utc_at_nine_without_configured_settings() {
         let date = format!("{}-08-01", future_year());
         let resolved = resolve_scheduled_at(Some(&date), &TenantSettings::default())
@@ -5411,6 +5727,47 @@ Thanks!"#;
         )
         .unwrap();
         assert_eq!(resolved, None);
+    }
+
+    #[test]
+    fn test_resolve_reschedule_at_applies_the_default_send_time() {
+        let settings = tenant_settings("America/Chicago", "09:00");
+
+        // Both spellings of a bare date, because correcting an issue that was
+        // scheduled from the serialized one is the reason this endpoint exists.
+        for value in [
+            format!("{}-08-01", future_year()),
+            format!("{}-08-01T00:00:00.000Z", future_year()),
+        ] {
+            assert_eq!(
+                resolve_reschedule_at(&value, &settings).unwrap(),
+                format!("{}-08-01T14:00:00+00:00", future_year()),
+                "{value} should resolve to the tenant's default send time"
+            );
+        }
+    }
+
+    #[test]
+    fn test_resolve_reschedule_at_keeps_an_explicit_instant() {
+        let value = format!("{}-08-01T18:30:00+00:00", future_year());
+        assert_eq!(
+            resolve_reschedule_at(&value, &tenant_settings("America/Chicago", "09:00")).unwrap(),
+            value
+        );
+    }
+
+    #[test]
+    fn test_resolve_reschedule_at_refuses_to_mean_now() {
+        // On create these all mean "send immediately". Moving a scheduled send
+        // to "immediately" is never what somebody meant, so they are errors
+        // here rather than a send.
+        let settings = tenant_settings("America/Chicago", "09:00");
+        for value in ["", "   ", "now", "2020-01-01", "2020-01-01T09:00:00Z"] {
+            assert!(
+                resolve_reschedule_at(value, &settings).is_err(),
+                "{value:?} should not be accepted as a new send time"
+            );
+        }
     }
 
     #[test]

--- a/functions/src/api/controllers/settings.rs
+++ b/functions/src/api/controllers/settings.rs
@@ -387,14 +387,43 @@ fn validate_tokens(field: &str, value: &str, allowed: &[&str]) -> Result<(), App
 
 // ── Date-only resolution ───────────────────────────────────────────────
 
-/// True when a schedule value carries a date but no time (`YYYY-MM-DD`) and so
-/// needs the tenant's default send time to become an instant.
-pub(crate) fn is_date_only(value: &str) -> bool {
-    NaiveDate::parse_from_str(value, "%Y-%m-%d").is_ok()
+/// The day a schedule value names when it carries no time of day, and so needs
+/// the tenant's default send time to become an instant.
+///
+/// Two spellings mean the same thing. `YYYY-MM-DD` is what a caller writes by
+/// hand. Exactly midnight UTC (`…T00:00:00Z`) is what a caller *generates*: a
+/// bare date in YAML or JSON has no time component, so every serializer on the
+/// way here turns it into UTC midnight — which is how the GitHub Action
+/// forwards a date-only frontmatter `date:` (see
+/// `docs/github-api-cutover-spec.md` §6.1.6). Reading that as a real midnight
+/// send is the one interpretation nobody wants: it lands the issue on the
+/// previous evening for every tenant west of UTC.
+///
+/// A tenant who genuinely wants midnight can say so unambiguously — a second
+/// past it (`00:00:01Z`), or midnight in their own zone (`00:00:00-05:00`),
+/// which carries a real offset and is left alone.
+pub(crate) fn date_only_day(value: &str) -> Option<NaiveDate> {
+    if let Ok(date) = NaiveDate::parse_from_str(value, "%Y-%m-%d") {
+        return Some(date);
+    }
+
+    let parsed = DateTime::parse_from_rfc3339(value).ok()?;
+    if parsed.offset().local_minus_utc() != 0 {
+        return None;
+    }
+
+    let utc = parsed.with_timezone(&Utc);
+    (utc.time() == NaiveTime::MIN).then(|| utc.date_naive())
 }
 
-/// Turns a bare `YYYY-MM-DD` into an instant: the tenant's default send time
-/// on that date, read as a wall-clock time in the tenant's timezone.
+/// True when a schedule value carries a date but no time of day (see
+/// [`date_only_day`]).
+pub(crate) fn is_date_only(value: &str) -> bool {
+    date_only_day(value).is_some()
+}
+
+/// Turns a date-only value into an instant: the tenant's default send time on
+/// that date, read as a wall-clock time in the tenant's timezone.
 ///
 /// Daylight-saving transitions make that wall-clock time either ambiguous
 /// (it happens twice) or nonexistent (it is skipped). Both are resolved
@@ -405,8 +434,8 @@ pub(crate) fn resolve_date_only(
     value: &str,
     settings: &TenantSettings,
 ) -> Result<DateTime<Utc>, AppError> {
-    let date = NaiveDate::parse_from_str(value, "%Y-%m-%d")
-        .map_err(|_| AppError::BadRequest(format!("'{}' is not a valid date", value)))?;
+    let date = date_only_day(value)
+        .ok_or_else(|| AppError::BadRequest(format!("'{}' is not a valid date", value)))?;
 
     let tz = settings.timezone();
     let naive = date.and_time(settings.send_time());
@@ -826,6 +855,38 @@ mod tests {
         assert!(!is_date_only("2026-08-01T09:00:00-05:00"));
         assert!(!is_date_only("now"));
         assert!(!is_date_only("08/01/2026"));
+    }
+
+    #[test]
+    fn is_date_only_matches_a_serialized_bare_date() {
+        // What a YAML/JSON date becomes on the wire: midnight UTC, in every
+        // spelling a serializer produces.
+        assert!(is_date_only("2026-08-01T00:00:00Z"));
+        assert!(is_date_only("2026-08-01T00:00:00.000Z"));
+        assert!(is_date_only("2026-08-01T00:00:00+00:00"));
+    }
+
+    #[test]
+    fn is_date_only_leaves_a_deliberate_midnight_alone() {
+        // Midnight carrying a real offset is a time the caller chose, not a
+        // date a serializer flattened — and one second past midnight UTC is
+        // the escape hatch for a caller who really does want that instant.
+        assert!(!is_date_only("2026-08-01T00:00:00-05:00"));
+        assert!(!is_date_only("2026-08-01T00:00:01Z"));
+        assert!(!is_date_only("2026-08-01T00:01:00Z"));
+    }
+
+    #[test]
+    fn resolve_date_only_reads_a_serialized_bare_date_as_the_day_it_names() {
+        // The bug this closes: stored as-is, midnight UTC sends on July 31 at
+        // 7pm for a Chicago tenant — the wrong day, half a day early.
+        let resolved = resolve_date_only(
+            "2026-08-01T00:00:00.000Z",
+            &settings("America/Chicago", "09:00"),
+        )
+        .unwrap()
+        .to_rfc3339();
+        assert_eq!(resolved, "2026-08-01T14:00:00+00:00");
     }
 
     #[test]

--- a/functions/src/api/router.rs
+++ b/functions/src/api/router.rs
@@ -101,6 +101,13 @@ pub async fn route_request(event: Request) -> Result<Response<Body>, Error> {
                 .map(|value| value.to_string());
             issues::rebuild_issue_analytics(event, issue_id).await
         }
+        (&Method::PUT, path) if path.starts_with("/issues/") && path.ends_with("/schedule") => {
+            let issue_id = path
+                .strip_prefix("/issues/")
+                .and_then(|value| value.strip_suffix("/schedule"))
+                .map(|value| value.to_string());
+            issues::reschedule_issue(event, issue_id).await
+        }
         (&Method::POST, path) if path.starts_with("/issues/") && path.ends_with("/resend") => {
             let issue_id = path
                 .strip_prefix("/issues/")

--- a/functions/utils/tenant-settings.mjs
+++ b/functions/utils/tenant-settings.mjs
@@ -27,6 +27,14 @@ export const DEFAULT_SEND_TIME = '09:00';
 /** A bare calendar date, with no time of day attached. */
 const DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 
+/**
+ * A bare calendar date that has been through a serializer: midnight UTC is
+ * what a YAML/JSON date becomes once it is a string, and it means "this day",
+ * not "send at midnight". Midnight with a real offset is left alone — that is
+ * a time somebody chose. Kept in step with `date_only_day` in `settings.rs`.
+ */
+const UTC_MIDNIGHT_PATTERN = /^\d{4}-\d{2}-\d{2}T00:00:00(\.0+)?(Z|[+-]00:00)$/i;
+
 const SEND_TIME_PATTERN = /^([01]?\d|2[0-3]):([0-5]\d)$/;
 
 /**
@@ -86,14 +94,19 @@ const nonEmpty = (value) => {
 /**
  * True when a value names a day but no time of day, and therefore needs the
  * tenant's default send time to become an instant. Accepts the `YYYY-MM-DD`
- * string form and a `Date` that is exactly UTC midnight — which is what a YAML
- * parser produces from a bare frontmatter `date:`.
+ * string form, a `Date` that is exactly UTC midnight — which is what a YAML
+ * parser produces from a bare frontmatter `date:` — and that same instant once
+ * it has been serialized back to a string, which is how it reaches the state
+ * machine's `sendAt`.
  */
 export const isDateOnly = (value) => {
   if (value instanceof Date) {
     return !Number.isNaN(value.getTime()) && value.toISOString().endsWith('T00:00:00.000Z');
   }
-  return typeof value === 'string' && DATE_ONLY_PATTERN.test(value.trim());
+  if (typeof value !== 'string') return false;
+
+  const trimmed = value.trim();
+  return DATE_ONLY_PATTERN.test(trimmed) || UTC_MIDNIGHT_PATTERN.test(trimmed);
 };
 
 /** The `YYYY-MM-DD` day a date-only value refers to. */

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1813,6 +1813,76 @@ paths:
         "500":
           $ref: "#/components/responses/UnknownError"
 
+  /issues/{id}/schedule:
+    put:
+      summary: Move a scheduled issue's send time
+      description: >-
+        Reschedules an issue that is already scheduled, re-pointing the send at
+        a new instant. Accepts the same values as scheduledAt on create: an
+        RFC3339 timestamp, or a date-only "YYYY-MM-DD" value that is anchored to
+        the tenant's defaultSendTime and timezone (see GET /settings). Sending a
+        bare date is how an issue whose stored instant never got the default
+        send time applied is corrected.
+
+        Only issues with status "scheduled" can be rescheduled, and only until
+        the publish workflow starts — which happens ISSUE_SEND_LEAD_TIME_MINUTES
+        before the send instant. After that the send can be stopped (by
+        unscheduling) but not moved.
+      tags:
+        - Issues
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The issue ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - scheduledAt
+              properties:
+                scheduledAt:
+                  type: string
+                  description: >-
+                    The new send time. Must resolve to a future instant —
+                    "now", a past timestamp, and a past date are all rejected
+                    rather than sending immediately.
+                  example: "2026-08-01"
+      responses:
+        "200":
+          description: The send was moved
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  issueNumber:
+                    type: integer
+                  status:
+                    type: string
+                    example: scheduled
+                  scheduledAt:
+                    type: string
+                    format: date-time
+                    description: The resolved send instant
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/UnknownError"
+
   /issues/{id}/resend:
     post:
       summary: Resend a published issue
@@ -3750,8 +3820,12 @@ components:
             timestamp, "now", or a date-only "YYYY-MM-DD" value. A date-only
             value has no time of day, so it is anchored to the tenant's
             defaultSendTime read as wall-clock time in the tenant's timezone
-            (see GET /settings). A resolved time that has already passed sends
-            immediately.
+            (see GET /settings). A timestamp at exactly midnight UTC
+            ("2026-08-01T00:00:00Z") is treated as date-only too — that is what
+            a bare date becomes once serialized. To schedule at midnight
+            deliberately, send it with a zone offset
+            ("2026-08-01T00:00:00-05:00") or a second past the hour. A resolved
+            time that has already passed sends immediately.
           example: "2026-08-01"
         action:
           type: string
@@ -4066,7 +4140,9 @@ components:
           description: >-
             When to schedule the issue for publishing. Accepts an RFC3339
             timestamp or a date-only "YYYY-MM-DD" value, which is anchored to
-            the tenant's defaultSendTime and timezone (see GET /settings).
+            the tenant's defaultSendTime and timezone (see GET /settings). A
+            timestamp at exactly midnight UTC counts as date-only; see the
+            create endpoint for how to schedule midnight deliberately.
         metadata:
           type: object
           description: Optional metadata for the issue

--- a/template.yaml
+++ b/template.yaml
@@ -1264,8 +1264,9 @@ Resources:
                 - !Sub "arn:${AWS::Partition}:scheduler:${AWS::Region}:${AWS::AccountId}:schedule/newsletter/draft-ttl-*"
                 # One per scheduled issue, named ISSUE-SEND-<tenant>-<issue>:
                 # it starts the publish workflow at the send instant. The name
-                # is deterministic so CreateSchedule detects a duplicate and
-                # DeleteSchedule can cancel a send.
+                # is deterministic so CreateSchedule detects a duplicate,
+                # UpdateSchedule can move a send, and DeleteSchedule can cancel
+                # one.
                 - !Sub "arn:${AWS::Partition}:scheduler:${AWS::Region}:${AWS::AccountId}:schedule/newsletter/ISSUE-SEND-*"
             - Effect: Allow
               Action:


### PR DESCRIPTION
## What happened

An issue scheduled with only a date showed up in the dashboard as **August 2, 2026 at 7:00 PM CDT** — which is `2026-08-03T00:00:00Z`. The tenant's default send time (9:00 AM CDT) never got applied.

A date-only `scheduledAt` *is* anchored to `defaultSendTime`, but `is_date_only` only recognized the literal `YYYY-MM-DD` spelling. A bare date almost never arrives that way: YAML and JSON have no concept of a date without a time, so every serializer on the path here turns it into midnight UTC. That is exactly how the GitHub Action forwards a frontmatter `date:` — [github-api-cutover-spec.md §6.1.6](docs/github-api-cutover-spec.md) specified midnight UTC as the marker for a date-only value, and the JS resolver already honoured it for the `Date` form. Only the Rust API missed it, so the value parsed as a valid explicit instant and was stored as given: the evening before the intended day, for every tenant west of UTC.

## What changed

**The fix.** `date_only_day` recognizes both spellings. Midnight carrying a real offset (`00:00:00-05:00`) is left alone — that is a time somebody chose — and a second past midnight UTC stays available as an escape hatch. `functions/utils/tenant-settings.mjs` gained the string form so the publish pipeline agrees with the API.

**`PUT /issues/{id}/schedule`.** An issue scheduled before the fix still holds the wrong instant, and there was no way to correct it: `PUT /issues/{id}` refuses a `scheduled` issue outright, and even on a draft it only writes the field — it never re-points the Scheduler entry. So a date change would have written a new time while the send still fired at the old one. The new endpoint resolves a bare date exactly as create does, which makes "send me the date again" the repair.

**Dashboard.** A **Change send time** button on a scheduled issue, opening a dialog that leads with *use my default send time*.

## Notes for a reviewer

- **Midnight UTC is now interpreted, not obeyed.** This is the deliberate trade the spec called for, and the alternative is worse in every real case. Both documented escapes are tested.
- **`UpdateSchedule`, not delete-then-create.** A failed `CreateSchedule` after a successful `DeleteSchedule` leaves a `scheduled` record with nothing behind it and nothing watching for that. `scheduler:UpdateSchedule` was already granted on `ISSUE-SEND-*`, so no IAM change; the API is behind `/{proxy+}`, so no gateway change.
- **Reschedule stops at the lead time.** Once `executionArn` is set the workflow has started, content is frozen and the entry is gone, so the endpoint 409s and points at unscheduling — the honest answer rather than a silent no-op. With `ISSUE_SEND_LEAD_TIME_MINUTES: 1560` that is ~26h before the send.
- **The record write is last, and conditional on the status still being `scheduled`.** Either order can fail halfway and both heal on retry, but only this one leaves the issue sending when the caller asked rather than promising a time the send won't honour.
- **Default mode posts the bare date**, not a resolved instant. The dialog previews what the API will do; it doesn't decide it. Two implementations of that rule would drift at a DST boundary.

## Unrelated test repairs (second commit)

Both predate this branch and fail on any Windows checkout:

- `stage-issue-definition.test.mjs` matches whole lines of `template.yaml` but splits on `\n`; with `core.autocrlf` every line ends `\r`, so it threw at import and **all 46 tests never ran**.
- Three `IssueFormPage` timezone tests assert a schedule renders in UTC before settings load — true only when the browser zone is UTC, since the provider falls back to the viewer's zone. Vitest now pins `TZ=UTC`, matching CI.

Separately, `dashboard-ui` needs `npm ci` — `package.json` and the lockfile pin `@readysetcloud/ui@^0.6.0` while some local installs still have 0.4.1, which predates `PageHero`/`StatTile`/`SegmentedControl` (25 further test failures, no code change needed).

## Testing

- Rust: 587 api-router tests, clippy and `cargo fmt` clean
- Root jest: 94 suites / 1293 tests (was 1 suite failing to load)
- dashboard-ui: 99 files / 1114 tests, including 5 new dialog tests covering the bare-date payload, the explicit-instant payload, the past-time guard and a 409 surfacing in the dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)
