### PR TITLE
fix(monthly-report): mail the report to an address that exists

### DIFF
--- a/functions/__tests__/monthly-report-job.test.mjs
+++ b/functions/__tests__/monthly-report-job.test.mjs
@@ -1,6 +1,6 @@
 import { jest } from '@jest/globals';
 
-const { getReportingWindow } = await import('../monthly-report-job.mjs');
+const { getReportingWindow, tenantRecordEmail, buildExecutionName } = await import('../monthly-report-job.mjs');
 
 describe('monthly-report-job getReportingWindow', () => {
   test('targets the previous month when run on the 1st', () => {
@@ -17,5 +17,44 @@ describe('monthly-report-job getReportingWindow', () => {
     expect(w.monthLabel).toBe('December 2025');
     expect(w.periodStart).toBe('2025-12-01T00:00:00.000Z');
     expect(w.periodEnd).toBe('2026-01-01T00:00:00.000Z');
+  });
+});
+
+describe('monthly-report-job tenantRecordEmail', () => {
+  test('rejects the SES setup map tenant-finalization writes to `email`', () => {
+    const record = { pk: 'tenant-a', email: { tenantArn: 'arn:aws:ses:...', contactList: 'tenant-a' } };
+    expect(tenantRecordEmail(record)).toBeNull();
+  });
+
+  test('rejects a record with no email at all', () => {
+    expect(tenantRecordEmail({ pk: 'tenant-a' })).toBeNull();
+    expect(tenantRecordEmail(undefined)).toBeNull();
+  });
+
+  test('accepts a real address left by the external Add/Update Tenant event', () => {
+    expect(tenantRecordEmail({ pk: 'tenant-a', email: 'owner@example.com' })).toBe('owner@example.com');
+    expect(tenantRecordEmail({ pk: 'tenant-a', email: '  owner@example.com  ' })).toBe('owner@example.com');
+  });
+
+  test('rejects a string that is not an address', () => {
+    expect(tenantRecordEmail({ pk: 'tenant-a', email: 'not-an-address' })).toBeNull();
+  });
+});
+
+describe('monthly-report-job buildExecutionName', () => {
+  test('keeps a normal tenant id intact', () => {
+    expect(buildExecutionName('ready-set-cloud', '2026-07', 1754049600000))
+      .toBe('ready-set-cloud-2026-07-1754049600000');
+  });
+
+  test('replaces characters Step Functions will not take', () => {
+    expect(buildExecutionName('tenant a/b', '2026-07', 1754049600000))
+      .toBe('tenant_a_b-2026-07-1754049600000');
+  });
+
+  test('stays within the 80 character cap for a long tenant id', () => {
+    const name = buildExecutionName('t'.repeat(120), '2026-07', 1754049600000);
+    expect(name.length).toBe(80);
+    expect(name.endsWith('-2026-07-1754049600000')).toBe(true);
   });
 });

--- a/functions/monthly-report-job.mjs
+++ b/functions/monthly-report-job.mjs
@@ -1,12 +1,18 @@
 import { DynamoDBClient, QueryCommand } from '@aws-sdk/client-dynamodb';
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
 import { SFNClient, StartExecutionCommand } from '@aws-sdk/client-sfn';
+import { CognitoIdentityProviderClient, ListUsersCommand } from '@aws-sdk/client-cognito-identity-provider';
 
 const ddb = new DynamoDBClient();
 const sfn = new SFNClient();
+const cognito = new CognitoIdentityProviderClient();
 
 const TABLE_NAME = process.env.TABLE_NAME;
 const STATE_MACHINE_ARN = process.env.STATE_MACHINE_ARN;
+const USER_POOL_ID = process.env.USER_POOL_ID;
+
+// Step Functions rejects an execution name longer than this.
+const EXECUTION_NAME_MAX_LENGTH = 80;
 
 /**
  * Compute the reporting window for the month prior to `now`.
@@ -30,6 +36,11 @@ export const getReportingWindow = (now = new Date()) => {
 /**
  * List all tenant records via GSI1 (GSI1PK = "tenant"), projecting the fields
  * needed to fan out a per-tenant report run. Using the index avoids a table Scan.
+ *
+ * NOTE: a tenant record only appears here once it carries GSI1PK="tenant". Both
+ * onboarding paths set it, but records that predate the key need
+ * `scripts/backfill-tenant-gsi.mjs` run once against the table or they are
+ * invisible to this job.
  */
 const getAllTenants = async () => {
   const tenants = [];
@@ -41,20 +52,81 @@ const getAllTenants = async () => {
       IndexName: 'GSI1',
       KeyConditionExpression: 'GSI1PK = :gsi1pk',
       ExpressionAttributeValues: marshall({ ':gsi1pk': 'tenant' }),
-      ProjectionExpression: 'pk, email',
+      ProjectionExpression: 'pk, email, createdBy',
       ...(lastKey && { ExclusiveStartKey: lastKey })
     }));
 
     if (result.Items) {
       for (const item of result.Items) {
         const record = unmarshall(item);
-        tenants.push({ id: record.pk, email: record.email });
+        tenants.push({ id: record.pk, email: record.email, createdBy: record.createdBy });
       }
     }
     lastKey = result.LastEvaluatedKey;
   } while (lastKey);
 
   return tenants;
+};
+
+/**
+ * The tenant record's `email` attribute is not reliably an address. The
+ * self-serve path (tenant-finalization.asl.json, "UpdateTenantRecord") writes it
+ * as a map of the tenant's SES setup - `{ tenantArn, contactList }` - and the
+ * brand-onboarding path (create_tenant_with_brand_data in brand.rs) never writes
+ * it at all. Only the external "Add/Update Tenant" event can leave a real address
+ * there. Handing the map straight through as `to.email` is why no monthly report
+ * has ever landed in an inbox: send-email-v2 queries the subscribers table with
+ * it as the sort key, which is typed S, and the send dies before SES sees it.
+ *
+ * @returns {string|null} the address if this record already carries one
+ */
+export const tenantRecordEmail = (record) => {
+  const value = record?.email;
+  return typeof value === 'string' && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value.trim())
+    ? value.trim()
+    : null;
+};
+
+/**
+ * Resolve the tenant owner's address from Cognito by the `createdBy` sub, the
+ * same lookup `find_user_email_by_sub` (profile.rs) does. The address lives on
+ * the Cognito user, not in DynamoDB - every other path that mails a tenant gets
+ * it off the caller's token, which a scheduled job has no equivalent of.
+ */
+const findOwnerEmail = async (sub) => {
+  if (!sub || !USER_POOL_ID) return null;
+
+  const result = await cognito.send(new ListUsersCommand({
+    UserPoolId: USER_POOL_ID,
+    Filter: `sub = "${sub}"`,
+    Limit: 1
+  }));
+
+  const attributes = result.Users?.[0]?.Attributes ?? [];
+  return attributes.find((attr) => attr.Name === 'email')?.Value ?? null;
+};
+
+/**
+ * The address this tenant's report should be mailed to, or null when there is
+ * none to be found. A null is not fatal: compile-monthly-report still persists
+ * the report for the dashboard and skips only the email.
+ */
+const resolveRecipient = async (tenant, cache) => {
+  const onRecord = tenantRecordEmail(tenant);
+  if (onRecord) return onRecord;
+
+  const sub = tenant.createdBy;
+  if (!sub) return null;
+  if (cache.has(sub)) return cache.get(sub);
+
+  try {
+    const email = await findOwnerEmail(sub);
+    cache.set(sub, email);
+    return email;
+  } catch (error) {
+    console.error(`[MONTHLY-REPORT-JOB] Cognito lookup failed for ${tenant.id}:`, error.message);
+    return null;
+  }
 };
 
 /**
@@ -105,7 +177,9 @@ export const handler = async () => {
 
   let started = 0;
   let skipped = 0;
+  let withoutRecipient = 0;
   const failures = [];
+  const emailBySub = new Map();
 
   for (const tenant of tenants) {
     try {
@@ -115,11 +189,19 @@ export const handler = async () => {
         continue;
       }
 
+      // Resolved here rather than in getAllTenants so the Cognito lookup only
+      // runs for the tenants that actually get a report.
+      const email = await resolveRecipient(tenant, emailBySub);
+      if (!email) {
+        withoutRecipient++;
+        console.warn(`[MONTHLY-REPORT-JOB] No owner address for tenant ${tenant.id}; its report will be persisted but not emailed`);
+      }
+
       await sfn.send(new StartExecutionCommand({
         stateMachineArn: STATE_MACHINE_ARN,
-        name: `${sanitizeName(tenant.id)}-${window.month}-${Date.now()}`,
+        name: buildExecutionName(tenant.id, window.month),
         input: JSON.stringify({
-          tenant: { id: tenant.id, email: tenant.email },
+          tenant: { id: tenant.id, email },
           month: window.month,
           monthLabel: window.monthLabel,
           periodStart: window.periodStart,
@@ -138,10 +220,29 @@ export const handler = async () => {
     tenants: tenants.length,
     started,
     skipped,
+    withoutRecipient,
     failed: failures.length
   });
 
-  return { month: window.month, tenants: tenants.length, started, skipped, failed: failures.length };
+  return {
+    month: window.month,
+    tenants: tenants.length,
+    started,
+    skipped,
+    withoutRecipient,
+    failed: failures.length
+  };
 };
 
-const sanitizeName = (value) => String(value).replace(/[^a-zA-Z0-9-_]/g, '_').slice(0, 60);
+const sanitizeName = (value, maxLength) => String(value).replace(/[^a-zA-Z0-9-_]/g, '_').slice(0, maxLength);
+
+/**
+ * Build the execution name, keeping it inside Step Functions' 80 character cap.
+ * The month and timestamp suffix is fixed width, so the tenant id absorbs the
+ * trim - a tenant id long enough to overflow used to fail its StartExecution
+ * outright, and only for that tenant.
+ */
+export const buildExecutionName = (tenantId, month, now = Date.now()) => {
+  const suffix = `-${month}-${now}`;
+  return `${sanitizeName(tenantId, EXECUTION_NAME_MAX_LENGTH - suffix.length)}${suffix}`;
+};

--- a/template.yaml
+++ b/template.yaml
@@ -2604,10 +2604,18 @@ Resources:
             - Effect: Allow
               Action: states:StartExecution
               Resource: !Ref MonthlyReportStateMachine
+            # The tenant record does not hold the owner's address - the self-serve
+            # path writes `email` as the tenant's SES setup map and the brand path
+            # omits it. The address is on the Cognito user, found by the record's
+            # `createdBy` sub.
+            - Effect: Allow
+              Action: cognito-idp:ListUsers
+              Resource: !GetAtt NewsletterUserPool.Arn
       Environment:
         Variables:
           AWS_NODEJS_CONNECTION_REUSE_ENABLED: 1
           STATE_MACHINE_ARN: !Ref MonthlyReportStateMachine
+          USER_POOL_ID: !Ref NewsletterUserPool
       Events:
         MonthlySchedule:
           Type: Schedule


### PR DESCRIPTION
The monthly tenant report has never reached an inbox. monthly-report-job
read the recipient off the tenant record's `email` attribute, which is not
an address on either onboarding path:

- tenant-finalization.asl.json ("UpdateTenantRecord") writes `email` as a
  map of the tenant's SES setup, `{ tenantArn, contactList }`
- create_tenant_with_brand_data (brand.rs) never writes `email` at all

So compile-monthly-report either published `to: { email: <map> }` - which
send-email-v2 uses as the subscribers-table sort key, typed S, so the send
fails before SES sees it - or found nothing and logged "email skipped".

Every other path that mails a tenant takes the address off the caller's
token (user_context.email); a scheduled job has no equivalent. Resolve it
the way profile.rs's find_user_email_by_sub does instead: Cognito ListUsers
filtered on the record's `createdBy` sub, with the record's own `email`
still honoured when the external Add/Update Tenant event left a real
address there. A tenant with no resolvable address is no longer fatal - the
report is still built and persisted for the dashboard, the email is skipped,
and the run reports the count.

Also cap the execution name at Step Functions' 80 characters. The old name
could reach 82 for a long tenant id and fail that tenant's StartExecution.

Note for deploys: this job enumerates tenants through GSI1 (GSI1PK="tenant"),
so any tenant record predating that key is invisible to it until
scripts/backfill-tenant-gsi.mjs has been run against the table.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019MF2TaPW44c71cxgHPvorj