### PR TITLE
Make suspected-bot flags legible and countable

### DIFF
--- a/dashboard-ui/src/components/subscribers/SubscriberProfileModal.tsx
+++ b/dashboard-ui/src/components/subscribers/SubscriberProfileModal.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Sparkles, MailOpen, MousePointerClick } from 'lucide-react';
+import { Sparkles, MailOpen, MousePointerClick, Bot } from 'lucide-react';
 import { Modal, ModalHeader, ModalTitle, ModalDescription, ModalContent } from '@/components/ui/Modal';
 import {
   getSortedInterestProfile,
@@ -7,6 +7,7 @@ import {
   AUTO_SEGMENT_THRESHOLD,
 } from '@/utils/interestProfile';
 import { getEngagementStatus } from '@/utils/engagement';
+import { describeBotFlags, hasStrongBotSignal } from './botFlags';
 import { subscriberService } from '@/services/subscriberService';
 import type { SubscriberListItem, SubscriberDetail, ActivityEntry } from '@/types';
 import { useTenantDateFormat } from '@/contexts/SettingsContext';
@@ -122,6 +123,8 @@ export const SubscriberProfileModal: React.FC<SubscriberProfileModalProps> = ({
   const profile = getSortedInterestProfile(subscriber.interestScores);
   const autoSegmentTopics = profile.filter((entry) => entry.score >= AUTO_SEGMENT_THRESHOLD);
   const recentActivity = detail?.recentActivity ?? [];
+  const botReasons = describeBotFlags(subscriber.botFlags);
+  const strongBotSignal = hasStrongBotSignal(subscriber.botFlags);
 
   return (
     <Modal isOpen={!!subscriber} onClose={onClose} size="md">
@@ -132,6 +135,32 @@ export const SubscriberProfileModal: React.FC<SubscriberProfileModalProps> = ({
         <ModalDescription>{subscriber.email}</ModalDescription>
       </ModalHeader>
       <ModalContent className="space-y-6">
+        {/* Why this subscriber is flagged — only present when something fired.
+            This is what the "Suspected" chip on the list opens to. */}
+        {botReasons.length > 0 && (
+          <section className="rounded-lg border border-orange-200 bg-orange-50 p-3 dark:border-orange-900 dark:bg-orange-900/10">
+            <h3 className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-orange-800 dark:text-orange-300 mb-2">
+              <Bot className="w-3.5 h-3.5" aria-hidden="true" />
+              {strongBotSignal ? 'Likely automated signup' : 'Possibly automated signup'}
+            </h3>
+            <ul className="space-y-2">
+              {botReasons.map((reason) => (
+                <li key={reason.key}>
+                  <p className="text-sm font-medium text-foreground">{reason.label}</p>
+                  <p className="text-xs text-muted-foreground leading-snug">{reason.description}</p>
+                </li>
+              ))}
+            </ul>
+            <p className="text-xs text-muted-foreground mt-3 leading-snug">
+              {strongBotSignal
+                ? 'These signals fired when the address signed up. Nothing here is blocked automatically except honeypot hits — the rest are recorded for review.'
+                : 'Every signal here is circumstantial on its own. Treat this as worth a look rather than a verdict.'}
+              {' '}Engagement is not a counter-argument: mail-security scanners fetch tracked
+              links automatically, which counts as engagement on this list.
+            </p>
+          </section>
+        )}
+
         {/* Engagement */}
         <section>
           <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">

--- a/dashboard-ui/src/components/subscribers/__tests__/SubscriberProfileModal.test.tsx
+++ b/dashboard-ui/src/components/subscribers/__tests__/SubscriberProfileModal.test.tsx
@@ -184,4 +184,66 @@ describe('SubscriberProfileModal', () => {
     // The email is still shown (as the secondary description line).
     expect(screen.getByText('reader@example.com')).toBeInTheDocument();
   });
+
+  it('says nothing about bot signals for an unflagged subscriber', () => {
+    render(
+      <SubscriberProfileModal subscriber={base} latestIssueNumber={20} onClose={() => {}} />
+    );
+    expect(screen.queryByText(/automated signup/i)).not.toBeInTheDocument();
+  });
+
+  it('explains each flag that fired, strongest first', () => {
+    render(
+      <SubscriberProfileModal
+        subscriber={{
+          ...base,
+          suspectedBot: true,
+          botFlags: {
+            honeypotTriggered: true,
+            disposableDomain: false,
+            suspiciousUserAgent: true,
+            fastSubmission: false,
+            suspiciousEmailPattern: false,
+          },
+        }}
+        latestIssueNumber={20}
+        onClose={() => {}}
+      />
+    );
+
+    expect(screen.getByText('Likely automated signup')).toBeInTheDocument();
+
+    const reasons = screen.getAllByRole('listitem').map((li) => li.textContent ?? '');
+    const honeypotIndex = reasons.findIndex((t) => t.includes('Honeypot triggered'));
+    const uaIndex = reasons.findIndex((t) => t.includes('Suspicious user agent'));
+    expect(honeypotIndex).toBeGreaterThanOrEqual(0);
+    expect(uaIndex).toBeGreaterThan(honeypotIndex);
+
+    // Flags that did not fire are not listed.
+    expect(screen.queryByText('Disposable email domain')).not.toBeInTheDocument();
+    expect(screen.queryByText('Fast form submission')).not.toBeInTheDocument();
+  });
+
+  it('hedges the wording when only circumstantial signals fired', () => {
+    render(
+      <SubscriberProfileModal
+        subscriber={{
+          ...base,
+          suspectedBot: true,
+          botFlags: {
+            honeypotTriggered: false,
+            disposableDomain: false,
+            suspiciousUserAgent: true,
+            fastSubmission: true,
+            suspiciousEmailPattern: false,
+          },
+        }}
+        latestIssueNumber={20}
+        onClose={() => {}}
+      />
+    );
+
+    expect(screen.getByText('Possibly automated signup')).toBeInTheDocument();
+    expect(screen.getByText(/circumstantial on its own/)).toBeInTheDocument();
+  });
 });

--- a/dashboard-ui/src/components/subscribers/botFlags.ts
+++ b/dashboard-ui/src/components/subscribers/botFlags.ts
@@ -1,0 +1,97 @@
+import type { BotFlags } from '@/types';
+
+/**
+ * How much weight a single signal deserves on its own.
+ *
+ * `strong` signals are ones a real subscriber essentially cannot trip by
+ * accident. `weak` ones are circumstantial — they correlate with automation but
+ * have mundane explanations too, so a subscriber carrying only weak signals is
+ * a candidate for review, not a verdict.
+ */
+export type BotSignalStrength = 'strong' | 'weak';
+
+export interface BotFlagReason {
+  key: keyof BotFlags;
+  label: string;
+  /** What the signal actually measures, and how it can misfire. */
+  description: string;
+  strength: BotSignalStrength;
+}
+
+/**
+ * The five signup signals, in descending order of how much they should move
+ * your judgement. Order is fixed rather than derived so the reasons list reads
+ * the same way every time.
+ *
+ * Kept in sync with `functions/utils/bot-protection.mjs` (detection) and
+ * `functions/src/api/controllers/subscribers.rs` (the `suspectedBot` OR).
+ */
+const REASONS: readonly BotFlagReason[] = [
+  {
+    key: 'honeypotTriggered',
+    label: 'Honeypot triggered',
+    description:
+      'The signup form has a decoy field that is invisible to a person. This submission filled it in, which a human browser will not do. The strongest signal here.',
+    strength: 'strong',
+  },
+  {
+    key: 'disposableDomain',
+    label: 'Disposable email domain',
+    description:
+      'The address is on a known throwaway-mailbox provider. Occasionally a privacy-conscious reader, but far more often a signup that will never be read.',
+    strength: 'strong',
+  },
+  {
+    key: 'suspiciousEmailPattern',
+    label: 'Suspicious email pattern',
+    description:
+      'A Gmail address with three or more dots in the local part. Gmail ignores those dots, so one mailbox can generate unlimited distinct-looking addresses from the same inbox.',
+    strength: 'weak',
+  },
+  {
+    key: 'fastSubmission',
+    label: 'Fast form submission',
+    description:
+      'The form was submitted less than 1.5 seconds after it rendered. Scripts fill forms instantly; people rarely do. Autofill can occasionally trip this.',
+    strength: 'weak',
+  },
+  {
+    key: 'suspiciousUserAgent',
+    label: 'Suspicious user agent',
+    description:
+      'The browser identified itself with a scripting or crawler signature, or sent no user agent at all. Note that signups made server-side or through the API also land here, so this one produces false positives.',
+    strength: 'weak',
+  },
+];
+
+/**
+ * The reasons a subscriber carries the "Suspected" chip, strongest first.
+ *
+ * Returns an empty array when nothing is flagged, so callers can treat length
+ * as the question of whether there is anything to explain.
+ */
+export const describeBotFlags = (flags?: BotFlags): BotFlagReason[] => {
+  if (!flags) return [];
+  return REASONS.filter((reason) => flags[reason.key]);
+};
+
+/**
+ * One-line summary for the chip's hover tooltip. The full descriptions live in
+ * the profile modal — this is only meant to say why the chip is there.
+ */
+export const summarizeBotFlags = (flags?: BotFlags): string => {
+  const reasons = describeBotFlags(flags);
+  if (reasons.length === 0) {
+    return 'One or more bot detection flags were triggered. Click for detail.';
+  }
+  return `Flagged for: ${reasons.map((r) => r.label).join(', ')}. Click for detail.`;
+};
+
+/**
+ * Whether any flag is one a real subscriber essentially cannot trip. Drives the
+ * "likely" vs "possible" wording in the profile modal — a subscriber carrying
+ * only weak signals is genuinely ambiguous and should not be described as if it
+ * were settled.
+ */
+export const hasStrongBotSignal = (flags?: BotFlags): boolean =>
+  describeBotFlags(flags).some((reason) => reason.strength === 'strong');

--- a/dashboard-ui/src/pages/subscribers/SubscribersPage.tsx
+++ b/dashboard-ui/src/pages/subscribers/SubscribersPage.tsx
@@ -14,6 +14,7 @@ import { SubscriberGrowthChart } from '@/components/SubscriberGrowthChart';
 import { AudienceHealthWidget } from '@/components/AudienceHealthWidget';
 import { InterestChips } from '@/components/subscribers/InterestChips';
 import { SubscriberProfileModal } from '@/components/subscribers/SubscriberProfileModal';
+import { summarizeBotFlags } from '@/components/subscribers/botFlags';
 import { subscriberService } from '@/services/subscriberService';
 import { segmentService } from '@/services/segmentService';
 import { useMediaQuery } from '@/hooks/useMediaQuery';
@@ -143,6 +144,7 @@ export const SubscribersPage: React.FC = () => {
   const [subscriberListError, setSubscriberListError] = useState<string | null>(null);
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('desc');
   const [selectedSubscriber, setSelectedSubscriber] = useState<SubscriberListItem | null>(null);
+  const [suspectedOnly, setSuspectedOnly] = useState(false);
 
   // Create segment modal state
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
@@ -232,13 +234,40 @@ export const SubscribersPage: React.FC = () => {
     ? Number(trendsData.points[0].issueNumber)
     : 0;
 
+  const suspectedCount = useMemo(
+    () => subscriberList.filter((sub) => sub.suspectedBot).length,
+    [subscriberList]
+  );
+
+  /**
+   * Share of the 30 most recent signups that are flagged. Growth questions are
+   * about the recent intake, and a lifetime percentage is dominated by history
+   * — a clean list of 5,000 would hide a week where every new signup tripped a
+   * flag. Undefined below a floor of 10, where the ratio is too noisy to mean
+   * anything.
+   */
+  const recentSuspectedRate = useMemo(() => {
+    const RECENT_WINDOW = 30;
+    const MIN_FOR_A_RATE = 10;
+    const recent = [...subscriberList]
+      .filter((sub) => sub.addedAt)
+      .sort((a, b) => new Date(b.addedAt!).getTime() - new Date(a.addedAt!).getTime())
+      .slice(0, RECENT_WINDOW);
+    if (recent.length < MIN_FOR_A_RATE) return null;
+    const flagged = recent.filter((sub) => sub.suspectedBot).length;
+    return { flagged, of: recent.length, percent: Math.round((flagged / recent.length) * 100) };
+  }, [subscriberList]);
+
   const sortedSubscribers = useMemo(() => {
-    return [...subscriberList].sort((a, b) => {
+    const visible = suspectedOnly
+      ? subscriberList.filter((sub) => sub.suspectedBot)
+      : subscriberList;
+    return [...visible].sort((a, b) => {
       const aTime = a.addedAt ? new Date(a.addedAt).getTime() : 0;
       const bTime = b.addedAt ? new Date(b.addedAt).getTime() : 0;
       return sortDirection === 'asc' ? aTime - bTime : bTime - aTime;
     });
-  }, [subscriberList, sortDirection]);
+  }, [subscriberList, sortDirection, suspectedOnly]);
 
   const toggleSortDirection = useCallback(() => {
     setSortDirection((prev) => (prev === 'asc' ? 'desc' : 'asc'));
@@ -277,26 +306,23 @@ export const SubscribersPage: React.FC = () => {
     [latestIssueNumber]
   );
 
+  // The chip opens the profile modal rather than an inline popover: the table
+  // body scrolls with `overflow: auto`, so anything anchored inside a row gets
+  // clipped, and a native `title` tooltip never appears on touch at all. The
+  // modal is also where there is room to say what each signal actually means.
   const renderBotBadge = useCallback((sub: SubscriberListItem): React.ReactNode => {
     if (!sub.suspectedBot) return null;
-    const reasons: string[] = [];
-    if (sub.botFlags?.honeypotTriggered) reasons.push('Honeypot triggered');
-    if (sub.botFlags?.disposableDomain) reasons.push('Disposable email domain');
-    if (sub.botFlags?.suspiciousUserAgent) reasons.push('Suspicious user agent');
-    if (sub.botFlags?.fastSubmission) reasons.push('Fast form submission');
-    if (sub.botFlags?.suspiciousEmailPattern) reasons.push('Suspicious email pattern (dot-trick)');
-    const tooltip = reasons.length > 0
-      ? `Flagged for: ${reasons.join(', ')}`
-      : 'One or more bot detection flags were triggered';
     return (
-      <span
-        className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-orange-100 text-orange-800 dark:bg-orange-900/20 dark:text-orange-400 cursor-help"
-        role="status"
-        title={tooltip}
+      <button
+        type="button"
+        onClick={() => setSelectedSubscriber(sub)}
+        className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-orange-100 text-orange-800 dark:bg-orange-900/20 dark:text-orange-400 hover:bg-orange-200 dark:hover:bg-orange-900/40 focus:outline-none focus:ring-2 focus:ring-ring transition-colors"
+        title={summarizeBotFlags(sub.botFlags)}
+        aria-label={`Why ${sub.email} is flagged as a suspected bot`}
       >
         <Bot className="w-3 h-3" aria-hidden="true" />
         Suspected
-      </span>
+      </button>
     );
   }, []);
 
@@ -647,22 +673,56 @@ export const SubscribersPage: React.FC = () => {
           <h3 className="text-lg font-semibold text-foreground mb-4">Subscribers</h3>
           <SectionError message={subscriberListError} onRetry={loadSubscriberList} />
         </Card>
-      ) : sortedSubscribers.length === 0 ? (
+      ) : subscriberList.length === 0 ? (
         <Card padding="md">
           <h3 className="text-lg font-semibold text-foreground mb-4">Subscribers</h3>
           <p className="text-sm text-muted-foreground">No subscribers yet.</p>
         </Card>
       ) : (
         <Card padding="md">
-          <h3 className="text-lg font-semibold text-foreground mb-4">Subscribers</h3>
-          <VirtualTable<SubscriberListItem>
-            items={sortedSubscribers}
-            getKey={(sub) => sub.email}
-            ariaLabel="Subscribers list"
-            rowHeight={isMobile ? 60 : 44}
-            maxHeight={440}
-            columns={isMobile ? mobileSubscriberColumns : subscriberColumns}
-          />
+          <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
+            <h3 className="text-lg font-semibold text-foreground">Subscribers</h3>
+            {suspectedCount > 0 && (
+              <div className="flex flex-wrap items-center gap-3">
+                {/* The lifetime count answers "how much junk is on the list";
+                    the recent rate answers "is this week different", which is
+                    the one a growth spike actually turns on. */}
+                {recentSuspectedRate && (
+                  <span className="text-xs text-muted-foreground">
+                    {recentSuspectedRate.flagged} of the last {recentSuspectedRate.of} signups
+                    {' '}({recentSuspectedRate.percent}%)
+                  </span>
+                )}
+                <button
+                  type="button"
+                  onClick={() => setSuspectedOnly((prev) => !prev)}
+                  aria-pressed={suspectedOnly}
+                  className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium border transition-colors focus:outline-none focus:ring-2 focus:ring-ring ${
+                    suspectedOnly
+                      ? 'bg-orange-100 text-orange-800 border-orange-300 dark:bg-orange-900/30 dark:text-orange-300 dark:border-orange-800'
+                      : 'bg-transparent text-muted-foreground border-border hover:bg-muted'
+                  }`}
+                >
+                  <Bot className="w-3.5 h-3.5" aria-hidden="true" />
+                  Suspected ({suspectedCount.toLocaleString()})
+                </button>
+              </div>
+            )}
+          </div>
+          {sortedSubscribers.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No subscribers match this filter.
+            </p>
+          ) : (
+            <VirtualTable<SubscriberListItem>
+              items={sortedSubscribers}
+              getKey={(sub) => sub.email}
+              ariaLabel="Subscribers list"
+              rowHeight={isMobile ? 60 : 44}
+              maxHeight={440}
+              columns={isMobile ? mobileSubscriberColumns : subscriberColumns}
+            />
+          )}
         </Card>
       )}
 

--- a/dashboard-ui/src/pages/subscribers/__tests__/SubscribersPage.test.tsx
+++ b/dashboard-ui/src/pages/subscribers/__tests__/SubscribersPage.test.tsx
@@ -423,4 +423,145 @@ describe('SubscribersPage', () => {
       expect(dash).toHaveAttribute('title', expect.stringContaining('3 consecutive issues'));
     });
   });
+
+  // --- Suspected-bot surfacing ---
+  describe('suspected bot flags', () => {
+    type BotSub = {
+      email: string;
+      addedAt?: string;
+      suspectedBot?: boolean;
+      botFlags?: {
+        honeypotTriggered: boolean;
+        disposableDomain: boolean;
+        suspiciousUserAgent: boolean;
+        fastSubmission: boolean;
+        suspiciousEmailPattern: boolean;
+      };
+    };
+
+    const flags = (overrides: Partial<BotSub['botFlags'] & object> = {}) => ({
+      honeypotTriggered: false,
+      disposableDomain: false,
+      suspiciousUserAgent: false,
+      fastSubmission: false,
+      suspiciousEmailPattern: false,
+      ...overrides,
+    });
+
+    const renderWithBotSubscribers = async (subscribers: BotSub[]) => {
+      vi.mocked(subscriberService.getCount).mockResolvedValue({
+        success: true,
+        data: { totalSubscribers: subscribers.length },
+      });
+      vi.mocked(subscriberService.getTrends).mockResolvedValue({
+        success: true,
+        data: mockTrendsData,
+      });
+      vi.mocked(segmentService.listSegments).mockResolvedValue({
+        success: true,
+        data: { segments: [] },
+      });
+      vi.mocked(subscriberService.getList).mockResolvedValue({
+        success: true,
+        data: {
+          total: subscribers.length,
+          subscribers: subscribers.map((sub) => ({
+            addedAt: '2025-01-01T00:00:00Z',
+            lastEngagedIssue: 5,
+            ...sub,
+          })),
+        },
+      });
+
+      renderPage();
+      await waitFor(() => {
+        expect(screen.getByText(subscribers[0].email)).toBeInTheDocument();
+      });
+    };
+
+    it('renders the Suspected chip as a button that opens the profile', async () => {
+      await renderWithBotSubscribers([
+        {
+          email: 'bot@example.com',
+          suspectedBot: true,
+          botFlags: flags({ honeypotTriggered: true }),
+        },
+      ]);
+
+      // A native title tooltip never fires on touch, so the chip has to be a
+      // real control rather than a decorated span.
+      const chip = screen.getByRole('button', {
+        name: /Why bot@example.com is flagged as a suspected bot/,
+      });
+      expect(chip).toHaveAttribute('title', expect.stringContaining('Honeypot triggered'));
+
+      fireEvent.click(chip);
+
+      await waitFor(() => {
+        expect(screen.getByText('Likely automated signup')).toBeInTheDocument();
+      });
+    });
+
+    it('does not render a chip for an unflagged subscriber', async () => {
+      await renderWithBotSubscribers([{ email: 'reader@example.com', suspectedBot: false }]);
+
+      expect(
+        screen.queryByRole('button', { name: /flagged as a suspected bot/ })
+      ).not.toBeInTheDocument();
+    });
+
+    it('counts flagged subscribers and filters the list down to them', async () => {
+      await renderWithBotSubscribers([
+        { email: 'bot@example.com', suspectedBot: true, botFlags: flags({ fastSubmission: true }) },
+        { email: 'spam@example.com', suspectedBot: true, botFlags: flags({ disposableDomain: true }) },
+        { email: 'reader@example.com', suspectedBot: false },
+      ]);
+
+      const toggle = screen.getByRole('button', { name: /Suspected \(2\)/ });
+      expect(toggle).toHaveAttribute('aria-pressed', 'false');
+      expect(screen.getByText('reader@example.com')).toBeInTheDocument();
+
+      fireEvent.click(toggle);
+
+      await waitFor(() => {
+        expect(screen.queryByText('reader@example.com')).not.toBeInTheDocument();
+      });
+      expect(screen.getByText('bot@example.com')).toBeInTheDocument();
+      expect(screen.getByText('spam@example.com')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /Suspected \(2\)/ })
+      ).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    it('hides the count entirely when nothing is flagged', async () => {
+      await renderWithBotSubscribers([{ email: 'reader@example.com', suspectedBot: false }]);
+
+      expect(screen.queryByRole('button', { name: /Suspected \(/ })).not.toBeInTheDocument();
+    });
+
+    it('reports the flagged share of recent signups once there are enough to be meaningful', async () => {
+      // 12 signups, 3 flagged — above the 10-signup floor for a rate.
+      const subs: BotSub[] = Array.from({ length: 12 }, (_, i) => ({
+        email: `sub${i}@example.com`,
+        addedAt: `2025-01-${String(i + 1).padStart(2, '0')}T00:00:00Z`,
+        suspectedBot: i < 3,
+        botFlags: i < 3 ? flags({ fastSubmission: true }) : undefined,
+      }));
+      await renderWithBotSubscribers(subs);
+
+      expect(screen.getByText(/3 of the last 12 signups/)).toBeInTheDocument();
+      expect(screen.getByText(/\(25%\)/)).toBeInTheDocument();
+    });
+
+    it('omits the rate when the sample is too small to mean anything', async () => {
+      await renderWithBotSubscribers([
+        { email: 'bot@example.com', suspectedBot: true, botFlags: flags({ fastSubmission: true }) },
+        { email: 'reader@example.com', suspectedBot: false },
+      ]);
+
+      expect(screen.queryByText(/of the last/)).not.toBeInTheDocument();
+      // The absolute count still shows.
+      expect(screen.getByRole('button', { name: /Suspected \(1\)/ })).toBeInTheDocument();
+    });
+  });
 });

--- a/functions/__tests__/export-subscribers.test.mjs
+++ b/functions/__tests__/export-subscribers.test.mjs
@@ -124,4 +124,45 @@ describe('export-subscribers', () => {
       engagementCount: null,
     });
   });
+
+  it('excludes the segments feature bookkeeping rows sharing the partition', async () => {
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        { tenantId: { S: 'tenant1' }, email: { S: 'real@example.com' } },
+        // Every shape the segments feature writes under this tenant partition,
+        // all overloading the `email` sort key.
+        { tenantId: { S: 'tenant1' }, email: { S: 'SEGMENT#abc123' } },
+        { tenantId: { S: 'tenant1' }, email: { S: 'SEGMENT#abc123#MEMBER#member@example.com' } },
+        { tenantId: { S: 'tenant1' }, email: { S: 'SEGMENT_NAME#vip subscribers' } },
+        { tenantId: { S: 'tenant1' }, email: { S: 'SEGMENT_JOB#job-1' } },
+      ],
+    });
+    s3Send.mockResolvedValueOnce({});
+
+    await handler({ tenant: 'tenant1' });
+
+    const report = JSON.parse(s3Send.mock.calls[0][0].Body);
+
+    // Bookkeeping keys in `addresses` would read as deliverable recipients.
+    expect(report.addresses).toEqual(['real@example.com']);
+    expect(report.total).toBe(1);
+    expect(report.subscribers).toHaveLength(1);
+  });
+
+  it('skips records with no email rather than exporting a hole', async () => {
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        { tenantId: { S: 'tenant1' }, email: { S: 'real@example.com' } },
+        { tenantId: { S: 'tenant1' } },
+      ],
+    });
+    s3Send.mockResolvedValueOnce({});
+
+    await handler({ tenant: 'tenant1' });
+
+    const report = JSON.parse(s3Send.mock.calls[0][0].Body);
+
+    expect(report.addresses).toEqual(['real@example.com']);
+    expect(report.total).toBe(1);
+  });
 });

--- a/functions/__tests__/publicapi-subscriber-schema.test.mjs
+++ b/functions/__tests__/publicapi-subscriber-schema.test.mjs
@@ -1,0 +1,60 @@
+import { readFile } from 'fs/promises';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SPEC_PATH = join(__dirname, '..', '..', 'publicapi.yaml');
+
+/**
+ * Pull one schema's block out of components.schemas by indentation, so the
+ * assertions below cannot accidentally read a neighbouring schema's fields.
+ */
+const extractSchemaBlock = (spec, schemaName) => {
+  const lines = spec.split('\n');
+  const startIndex = lines.findIndex((line) => line === `    ${schemaName}:`);
+  if (startIndex === -1) throw new Error(`Schema ${schemaName} not found in publicapi.yaml`);
+
+  const block = [];
+  for (const line of lines.slice(startIndex + 1)) {
+    // A non-blank line back at the schema's own indent starts the next schema.
+    if (line.trim() !== '' && !line.startsWith('      ')) break;
+    block.push(line);
+  }
+  return block.join('\n');
+};
+
+describe('publicapi Subscriber schema', () => {
+  let subscriberBlock;
+
+  beforeAll(async () => {
+    const spec = await readFile(SPEC_PATH, 'utf-8');
+    subscriberBlock = extractSchemaBlock(spec, 'Subscriber');
+  });
+
+  /**
+   * POST /{tenant}/subscribers runs the "Validate All" request validator, which
+   * enables validateRequestBody. Any constraint declared here is enforced by API
+   * Gateway *before* add-subscriber.mjs runs, so a maxLength on a name turns the
+   * handler's truncation into a 400 the reader cannot work around — including
+   * for names that would have fitted once whitespace was collapsed.
+   *
+   * The cap belongs in sanitizeName, which truncates. This is a deployment-only
+   * failure mode, invisible to every other test in the suite.
+   */
+  it('declares no length constraint on names, which would reject instead of truncate', () => {
+    expect(subscriberBlock).toContain('firstName:');
+    expect(subscriberBlock).toContain('lastName:');
+
+    // Matched as a YAML key, not as a word — the schema's own description
+    // explains why the constraint is absent, and a substring check would
+    // trip over that explanation.
+    const declaredKeys = subscriberBlock
+      .split('\n')
+      .filter((line) => /^\s*maxLength\s*:/.test(line));
+    expect(declaredKeys).toEqual([]);
+  });
+
+  it('still constrains email, where rejecting is the intended behavior', () => {
+    expect(subscriberBlock).toContain('minLength: 4');
+  });
+});

--- a/functions/__tests__/scanner-clicks.test.mjs
+++ b/functions/__tests__/scanner-clicks.test.mjs
@@ -1,0 +1,211 @@
+import {
+  classifyScannerClicks,
+  DEFAULT_MIN_DISTINCT_LINKS,
+  DEFAULT_WINDOW_SECONDS
+} from '../utils/scanner-clicks.mjs';
+
+const BASE = Date.parse('2025-03-01T12:00:00Z');
+
+/** Build a click event `offsetSeconds` after the base instant. */
+const click = (hash, linkUrl, offsetSeconds, sk = `click#${hash}#${linkUrl}#${offsetSeconds}`) => ({
+  sk,
+  subscriberEmailHash: hash,
+  linkUrl,
+  timestamp: new Date(BASE + offsetSeconds * 1000).toISOString()
+});
+
+/** A scanner-shaped sweep: every link at once, from one subscriber. */
+const sweep = (hash, linkCount, startOffset = 0) =>
+  Array.from({ length: linkCount }, (_, i) =>
+    click(hash, `https://example.com/a${i}`, startOffset + i)
+  );
+
+describe('classifyScannerClicks', () => {
+  describe('sweep detection', () => {
+    it('flags a burst across many distinct links from one subscriber', () => {
+      const { summary, scannerClickIds } = classifyScannerClicks(sweep('reader-a', 6));
+
+      expect(summary.scannerClicks).toBe(6);
+      expect(summary.humanClicks).toBe(0);
+      expect(summary.scannerSubscribers).toBe(1);
+      expect(scannerClickIds.size).toBe(6);
+    });
+
+    it('leaves a reader clicking a few links alone', () => {
+      const clicks = [
+        click('reader-a', 'https://example.com/one', 0),
+        click('reader-a', 'https://example.com/two', 30),
+        click('reader-a', 'https://example.com/three', 90)
+      ];
+
+      const { summary } = classifyScannerClicks(clicks);
+
+      expect(summary.scannerClicks).toBe(0);
+      expect(summary.humanClicks).toBe(3);
+      expect(summary.scannerRate).toBe(0);
+    });
+
+    it('leaves links spread beyond the window alone even when there are many', () => {
+      // Eight distinct links, but paced well apart — a reader working through
+      // an issue, not a sweep.
+      const clicks = Array.from({ length: 8 }, (_, i) =>
+        click('reader-a', `https://example.com/a${i}`, i * (DEFAULT_WINDOW_SECONDS + 10))
+      );
+
+      const { summary } = classifyScannerClicks(clicks);
+
+      expect(summary.scannerClicks).toBe(0);
+      expect(summary.humanClicks).toBe(8);
+    });
+
+    it('does not fire one link short of the threshold', () => {
+      const { summary } = classifyScannerClicks(sweep('reader-a', DEFAULT_MIN_DISTINCT_LINKS - 1));
+      expect(summary.scannerClicks).toBe(0);
+    });
+
+    it('fires exactly at the threshold', () => {
+      const { summary } = classifyScannerClicks(sweep('reader-a', DEFAULT_MIN_DISTINCT_LINKS));
+      expect(summary.scannerClicks).toBe(DEFAULT_MIN_DISTINCT_LINKS);
+    });
+
+    it('does not pool separate subscribers into one burst', () => {
+      // Six clicks in six seconds, but one link each from six people — a
+      // popular link at send time, not a sweep.
+      const clicks = Array.from({ length: 6 }, (_, i) =>
+        click(`reader-${i}`, `https://example.com/a${i}`, i)
+      );
+
+      const { summary } = classifyScannerClicks(clicks);
+
+      expect(summary.scannerClicks).toBe(0);
+      expect(summary.humanClicks).toBe(6);
+    });
+
+    it('counts repeat hits inside a burst as part of the sweep', () => {
+      const clicks = [
+        ...sweep('reader-a', 4),
+        // Same URL again, still inside the window — part of the same pass.
+        click('reader-a', 'https://example.com/a0', 5, 'click#repeat')
+      ];
+
+      const { summary } = classifyScannerClicks(clicks);
+
+      expect(summary.scannerClicks).toBe(5);
+    });
+
+    it('flags only the sweeping subscriber when both kinds are present', () => {
+      const clicks = [
+        ...sweep('scanner', 5),
+        click('reader-a', 'https://example.com/one', 200),
+        click('reader-a', 'https://example.com/two', 400)
+      ];
+
+      const { summary } = classifyScannerClicks(clicks);
+
+      expect(summary.scannerClicks).toBe(5);
+      expect(summary.humanClicks).toBe(2);
+      expect(summary.scannerSubscribers).toBe(1);
+      expect(summary.scannerRate).toBe(71.4);
+    });
+
+    it('flags a later burst even after quiet earlier activity', () => {
+      const clicks = [
+        click('reader-a', 'https://example.com/one', 0),
+        click('reader-a', 'https://example.com/two', 3600),
+        ...sweep('reader-a', 5, 7200)
+      ];
+
+      const { summary } = classifyScannerClicks(clicks);
+
+      expect(summary.scannerClicks).toBe(5);
+      expect(summary.humanClicks).toBe(2);
+    });
+  });
+
+  describe('unattributable clicks', () => {
+    it('neither classifies nor discards clicks with no subscriber id', () => {
+      const clicks = [
+        ...sweep('unknown', 6).map((c) => ({ ...c, subscriberEmailHash: 'unknown' })),
+        click('reader-a', 'https://example.com/one', 0)
+      ];
+
+      const { summary } = classifyScannerClicks(clicks);
+
+      expect(summary.unattributedClicks).toBe(6);
+      expect(summary.scannerClicks).toBe(0);
+      expect(summary.humanClicks).toBe(1);
+      // The rate is over what could be classified, not the raw total.
+      expect(summary.scannerRate).toBe(0);
+    });
+
+    it('treats a missing hash the same as an explicit unknown', () => {
+      const clicks = [{ sk: 'click#1', linkUrl: 'https://example.com/one', timestamp: new Date(BASE).toISOString() }];
+      const { summary } = classifyScannerClicks(clicks);
+      expect(summary.unattributedClicks).toBe(1);
+    });
+
+    it('sets no rate when nothing could be attributed', () => {
+      const clicks = sweep('unknown', 3).map((c) => ({ ...c, subscriberEmailHash: 'unknown' }));
+      const { summary } = classifyScannerClicks(clicks);
+
+      // Null rather than 0 — "no data" and "no scanners" are different answers.
+      expect(summary.scannerRate).toBeNull();
+    });
+
+    it('sets aside events with an unusable timestamp rather than guessing', () => {
+      const clicks = sweep('reader-a', 5).map((c) => ({ ...c, timestamp: 'not-a-date' }));
+      const { summary } = classifyScannerClicks(clicks);
+
+      expect(summary.unattributedClicks).toBe(5);
+      expect(summary.scannerClicks).toBe(0);
+    });
+  });
+
+  describe('edges and configuration', () => {
+    it('handles an empty or missing click list', () => {
+      for (const input of [[], null, undefined]) {
+        const { summary } = classifyScannerClicks(input);
+        expect(summary.totalClicks).toBe(0);
+        expect(summary.scannerClicks).toBe(0);
+        expect(summary.scannerRate).toBeNull();
+      }
+    });
+
+    it('honours overridden thresholds and reports them back', () => {
+      const clicks = sweep('reader-a', 3);
+
+      const strict = classifyScannerClicks(clicks, { minDistinctLinks: 3 });
+      expect(strict.summary.scannerClicks).toBe(3);
+      expect(strict.summary.thresholds).toEqual({ minDistinctLinks: 3, windowSeconds: DEFAULT_WINDOW_SECONDS });
+
+      const lenient = classifyScannerClicks(clicks, { minDistinctLinks: 10 });
+      expect(lenient.summary.scannerClicks).toBe(0);
+    });
+
+    it('respects a narrowed window', () => {
+      const clicks = [
+        click('reader-a', 'https://example.com/a', 0),
+        click('reader-a', 'https://example.com/b', 20),
+        click('reader-a', 'https://example.com/c', 40),
+        click('reader-a', 'https://example.com/d', 55)
+      ];
+
+      expect(classifyScannerClicks(clicks).summary.scannerClicks).toBe(4);
+      expect(classifyScannerClicks(clicks, { windowSeconds: 10 }).summary.scannerClicks).toBe(0);
+    });
+
+    it('always accounts for every click exactly once', () => {
+      const clicks = [
+        ...sweep('scanner', 5),
+        click('reader-a', 'https://example.com/one', 100),
+        ...sweep('unknown', 2).map((c) => ({ ...c, subscriberEmailHash: 'unknown' }))
+      ];
+
+      const { summary } = classifyScannerClicks(clicks);
+
+      expect(summary.scannerClicks + summary.humanClicks + summary.unattributedClicks).toBe(
+        summary.totalClicks
+      );
+    });
+  });
+});

--- a/functions/__tests__/subscriber-name.test.mjs
+++ b/functions/__tests__/subscriber-name.test.mjs
@@ -1,0 +1,85 @@
+import { sanitizeName, MAX_NAME_LENGTH } from '../utils/subscriber-name.mjs';
+
+/** Build a string from a code point, keeping literal control chars out of source. */
+const ch = (codePoint) => String.fromCodePoint(codePoint);
+
+describe('sanitizeName', () => {
+  describe('absent or unusable input', () => {
+    it('returns null for anything that is not a string', () => {
+      for (const value of [undefined, null, 42, true, {}, [], { toString: () => 'Ada' }]) {
+        expect(sanitizeName(value)).toBeNull();
+      }
+    });
+
+    it('returns null for a string with nothing visible in it', () => {
+      expect(sanitizeName('')).toBeNull();
+      expect(sanitizeName('   ')).toBeNull();
+      expect(sanitizeName(ch(0x200b) + ch(0x200b))).toBeNull();
+      expect(sanitizeName(ch(0x09) + ch(0x0a))).toBeNull();
+    });
+  });
+
+  describe('normalization', () => {
+    it('trims and collapses whitespace', () => {
+      expect(sanitizeName('  Ada   Lovelace  ')).toBe('Ada Lovelace');
+    });
+
+    it('turns line breaks and tabs into a single space rather than joining words', () => {
+      expect(sanitizeName('Ada' + ch(0x0a) + 'Lovelace')).toBe('Ada Lovelace');
+      expect(sanitizeName('Ada' + ch(0x09) + 'Lovelace')).toBe('Ada Lovelace');
+      expect(sanitizeName('Ada' + ch(0x0d) + ch(0x0a) + 'Lovelace')).toBe('Ada Lovelace');
+    });
+
+    it('removes control characters outright', () => {
+      expect(sanitizeName('Ada' + ch(0x00) + ' Lovelace')).toBe('Ada Lovelace');
+      expect(sanitizeName('Ada' + ch(0x1b) + ' Lovelace')).toBe('Ada Lovelace');
+      expect(sanitizeName('Ada' + ch(0x7f) + ' Lovelace')).toBe('Ada Lovelace');
+    });
+
+    it('removes zero-width characters used to disguise a word', () => {
+      // "ad<zero-width space>min" displays as "admin" but stores as something
+      // that evades an equality check.
+      expect(sanitizeName('ad' + ch(0x200b) + 'min')).toBe('admin');
+      expect(sanitizeName('a' + ch(0xfeff) + 'b')).toBe('ab');
+    });
+
+    it('removes bidirectional overrides', () => {
+      expect(sanitizeName('Ada' + ch(0x202e) + 'Lovelace')).toBe('AdaLovelace');
+    });
+
+    it('leaves ordinary international names untouched', () => {
+      for (const name of ['José', 'Ægir', 'Łukasz', '田中', 'Разумовский', "O'Brien", 'Anne-Marie']) {
+        expect(sanitizeName(name)).toBe(name);
+      }
+    });
+  });
+
+  describe('length', () => {
+    it('truncates rather than rejecting', () => {
+      const long = 'A'.repeat(MAX_NAME_LENGTH + 30);
+      expect(sanitizeName(long)).toHaveLength(MAX_NAME_LENGTH);
+    });
+
+    it('keeps a name exactly at the cap', () => {
+      const exact = 'A'.repeat(MAX_NAME_LENGTH);
+      expect(sanitizeName(exact)).toBe(exact);
+    });
+
+    it('counts code points, not UTF-16 units, so astral characters stay whole', () => {
+      const emoji = '👩';
+      const result = sanitizeName(emoji.repeat(MAX_NAME_LENGTH + 10));
+
+      expect([...result]).toHaveLength(MAX_NAME_LENGTH);
+      // Emoji are surrogate *pairs*, which are fine; what a mid-code-point
+      // slice would leave behind is an unpaired half.
+      const loneSurrogate = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/;
+      expect(result).not.toMatch(loneSurrogate);
+    });
+
+    it('measures length after cleaning, not before', () => {
+      // Padding with spaces must not consume the budget for real characters.
+      const padded = '  ' + 'A'.repeat(MAX_NAME_LENGTH) + '  ';
+      expect(sanitizeName(padded)).toHaveLength(MAX_NAME_LENGTH);
+    });
+  });
+});

--- a/functions/aggregate-issue-analytics.mjs
+++ b/functions/aggregate-issue-analytics.mjs
@@ -2,6 +2,7 @@ import { DynamoDBClient, QueryCommand, UpdateItemCommand, GetItemCommand } from 
 import { EventBridgeClient, PutEventsCommand } from '@aws-sdk/client-eventbridge';
 import { unmarshall, marshall } from '@aws-sdk/util-dynamodb';
 import { decrypt, getTenant } from './utils/helpers.mjs';
+import { classifyScannerClicks } from './utils/scanner-clicks.mjs';
 
 const ddb = new DynamoDBClient();
 const eventBridge = new EventBridgeClient();
@@ -64,6 +65,10 @@ export const handler = async (event) => {
       timingMetrics: calculateTimingMetrics(events.opens, events.clicks),
       engagementType: await calculateEngagementType(events.clicks, ddb, tenantId),
       trafficSource: calculateTrafficSource(events.clicks),
+      // Reported alongside the raw counters, never subtracted from them. The
+      // anomaly check below reads `clicks` and treats scanner traffic as the
+      // floor that separates a dead click path from a quiet week.
+      clickQuality: classifyScannerClicks(events.clicks).summary,
       bounceReasons: calculateBounceReasons(events.bounces),
       complaintDetails: formatComplaintDetails(events.complaints),
       ...(abTestSummary && { abTest: abTestSummary })

--- a/functions/process-campaign-click.mjs
+++ b/functions/process-campaign-click.mjs
@@ -2,6 +2,7 @@ import { DynamoDBClient, UpdateItemCommand, PutItemCommand } from '@aws-sdk/clie
 import { marshall } from '@aws-sdk/util-dynamodb';
 import { ulid } from 'ulid';
 import zlib from 'zlib';
+import { detectDevice } from './utils/detect-device.mjs';
 
 const ddb = new DynamoDBClient();
 const TABLE = process.env.TABLE_NAME;
@@ -72,6 +73,8 @@ async function recordClickEvent({ code, occurredAt, src, raw }) {
       src,
       destinationUrl: raw.u || null,
       subscriberHash: raw.s || null,
+      // 'unknown' for clicks logged before the redirect captured a user agent.
+      device: detectDevice(raw.ua),
       ttl: Math.floor(Date.now() / 1000) + CLICK_TTL_SECONDS,
     }, { removeUndefinedValues: true }),
   }));

--- a/functions/process-link-click.mjs
+++ b/functions/process-link-click.mjs
@@ -226,7 +226,10 @@ const captureClickEvent = async (msg, eventTimestamp, statsCache) => {
 
   const countryData = ip ? await lookupCountry(ip) : null;
 
-  const device = detectDevice(null);
+  // The redirect function logs a truncated user agent. Before it did, every
+  // web click resolved to 'unknown' and the device breakdown covered opens
+  // only — older events therefore stay 'unknown' rather than being backfilled.
+  const device = detectDevice(msg.ua);
   const country = countryData?.countryCode || 'unknown';
 
   const clickEvent = {

--- a/functions/subscribers/add-subscriber.mjs
+++ b/functions/subscribers/add-subscriber.mjs
@@ -18,6 +18,7 @@ import {
   emitBotProtectionLog,
   disposableDomainSet
 } from '../utils/bot-protection.mjs';
+import { sanitizeName } from '../utils/subscriber-name.mjs';
 import { checkRateLimit } from '../utils/rate-limiter.mjs';
 import { createLogger } from '../utils/structured-logger.mjs';
 import { getMostRecentPublishedIssue, incrementIssueCounter } from '../utils/issue-attribution.mjs';
@@ -54,6 +55,11 @@ export const handler = async (event) => {
 
     // Step 2: Normalize email
     const normalizedEmail = normalizeEmail(contact.email);
+
+    // Names are free-form and unauthenticated — normalize once here so the
+    // stored record and the SUBSCRIBER_ADDED event carry the same value.
+    contact.firstName = sanitizeName(contact.firstName);
+    contact.lastName = sanitizeName(contact.lastName);
 
     // Step 3: Extract request metadata
     const { sourceIp, userAgent, unknownIp } = extractRequestMetadata(event);

--- a/functions/subscribers/export-subscribers.mjs
+++ b/functions/subscribers/export-subscribers.mjs
@@ -2,6 +2,7 @@ import { DynamoDBClient, QueryCommand } from "@aws-sdk/client-dynamodb";
 import { marshall, unmarshall } from "@aws-sdk/util-dynamodb";
 import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
 import { getTenant, sendWithRetry } from "../utils/helpers.mjs";
+import { isSubscriberRecord } from "../utils/subscriber-record.mjs";
 
 const ddb = new DynamoDBClient();
 const s3 = new S3Client();
@@ -36,6 +37,11 @@ export const handler = async (event) => {
       if (response.Items?.length) {
         for (const item of response.Items) {
           const record = unmarshall(item);
+          // The tenant partition also holds the segments feature's bookkeeping
+          // rows. Without this they land in `addresses` looking like real
+          // recipients.
+          if (!isSubscriberRecord(record)) continue;
+
           emailAddresses.push(record.email);
           subscribers.push({
             email: record.email,

--- a/functions/subscribers/import-subscriber-list.mjs
+++ b/functions/subscribers/import-subscriber-list.mjs
@@ -1,6 +1,7 @@
 import { DynamoDBClient, UpdateItemCommand, BatchWriteItemCommand, QueryCommand } from "@aws-sdk/client-dynamodb";
 import { marshall } from "@aws-sdk/util-dynamodb";
 import { getTenant, formatResponse, throttle, sendWithRetry } from "../utils/helpers.mjs";
+import { sanitizeName } from "../utils/subscriber-name.mjs";
 
 const ddb = new DynamoDBClient();
 
@@ -69,12 +70,15 @@ export const handler = async (event) => {
 const addSubscriber = async (tenantId, contact) => {
   const addedAt = new Date().toISOString();
 
+  const firstName = sanitizeName(contact.firstName);
+  const lastName = sanitizeName(contact.lastName);
+
   const subscriberItem = {
     tenantId,
     email: contact.address.toLowerCase(), // Normalize email to lowercase
     addedAt,
-    ...(contact.firstName && { firstName: contact.firstName }),
-    ...(contact.lastName && { lastName: contact.lastName })
+    ...(firstName && { firstName }),
+    ...(lastName && { lastName })
   };
 
   const requestItems = {

--- a/functions/utils/scanner-clicks.mjs
+++ b/functions/utils/scanner-clicks.mjs
@@ -1,0 +1,179 @@
+/**
+ * Identifies clicks that came from automated link scanners rather than readers.
+ *
+ * Corporate mail security (Outlook SafeLinks, Proofpoint, Mimecast, Barracuda)
+ * fetches every link in a message to check it before the recipient ever sees
+ * the mail. Those fetches arrive on the same tracking URLs a reader would use,
+ * carrying the same encrypted subscriber id, so they land in the click stream
+ * indistinguishable from engagement at the level of a single event.
+ *
+ * What separates them is shape, not any one field: a scanner touches *many
+ * distinct links in one burst*, because it is walking the message rather than
+ * reading it. That is the only signal used here.
+ *
+ * Deliberately NOT used:
+ *
+ *   - User agent. Two of the three click paths never capture one — the
+ *     CloudFront redirect functions log only the destination, source and IP —
+ *     so a UA rule would silently apply to email clicks alone and quietly miss
+ *     everything else. Shape is available on every path.
+ *   - Time since publish. Scanners are fast, but so is an engaged reader on a
+ *     morning send, and delivery is spread over minutes while `publishedAt` is
+ *     a single instant. Speed alone convicts real readers.
+ *
+ * This module only classifies. It never mutates counters: callers record the
+ * split alongside the raw totals, because the raw numbers are load-bearing
+ * elsewhere (`describeCounterAnomaly` relies on scanner clicks putting a floor
+ * under a healthy issue's click count) and because a heuristic you cannot
+ * check against the unfiltered figure is a heuristic you cannot tune.
+ */
+
+/**
+ * Distinct links one subscriber must touch inside the window before the burst
+ * reads as a sweep.
+ *
+ * Four is deliberately above the two-or-three a curious reader might open in
+ * quick succession from a link roundup, and well below the "every link in the
+ * issue" a scanner takes. Raising it trades recall for precision.
+ */
+export const DEFAULT_MIN_DISTINCT_LINKS = 4;
+
+/**
+ * Width of the burst window, in seconds. Scanners typically finish a message in
+ * under ten seconds; a minute is generous enough to absorb retries and queuing
+ * without swallowing a reader working through an issue over a coffee.
+ */
+export const DEFAULT_WINDOW_SECONDS = 60;
+
+/** Sort key value used for click events with no identifiable subscriber. */
+const UNATTRIBUTED = 'unknown';
+
+const toEpochSeconds = (timestamp) => {
+  const parsed = Date.parse(timestamp);
+  return Number.isNaN(parsed) ? null : Math.floor(parsed / 1000);
+};
+
+/**
+ * Find the clicks belonging to sweep bursts within one subscriber's timeline.
+ *
+ * Walks a window over the subscriber's clicks in time order. Whenever a window
+ * holds at least `minDistinctLinks` distinct URLs, every click in it is part of
+ * a sweep — including repeats of a URL already counted, since they arrived
+ * inside the same automated pass.
+ *
+ * @param {object[]} clicks - One subscriber's clicks, ascending by time
+ * @param {number} minDistinctLinks
+ * @param {number} windowSeconds
+ * @returns {Set<string>} `sk` values of clicks inside a burst
+ */
+const findBurstClicks = (clicks, minDistinctLinks, windowSeconds) => {
+  const flagged = new Set();
+  if (clicks.length < minDistinctLinks) return flagged;
+
+  let start = 0;
+  for (let end = 0; end < clicks.length; end++) {
+    // Shrink from the left until the window is within range of the new click.
+    while (clicks[end].at - clicks[start].at > windowSeconds) {
+      start++;
+    }
+
+    const distinct = new Set();
+    for (let i = start; i <= end; i++) {
+      distinct.add(clicks[i].linkUrl);
+    }
+
+    if (distinct.size >= minDistinctLinks) {
+      for (let i = start; i <= end; i++) {
+        flagged.add(clicks[i].sk);
+      }
+    }
+  }
+
+  return flagged;
+};
+
+/**
+ * Split an issue's click events into scanner-driven and reader-driven.
+ *
+ * Clicks with no subscriber attribution (`subscriberEmailHash` of "unknown" —
+ * the web-version redirect path, where no encrypted id rides along) cannot be
+ * grouped into a timeline and are reported separately rather than guessed at.
+ * Counting them as human would overstate engagement; counting them as scanner
+ * would condemn ordinary web readers.
+ *
+ * @param {object[]} clickEvents - Raw click events for one issue
+ * @param {object} [options]
+ * @param {number} [options.minDistinctLinks]
+ * @param {number} [options.windowSeconds]
+ * @returns {{ scannerClickIds: Set<string>, summary: object }}
+ */
+export function classifyScannerClicks(clickEvents, options = {}) {
+  const minDistinctLinks = options.minDistinctLinks ?? DEFAULT_MIN_DISTINCT_LINKS;
+  const windowSeconds = options.windowSeconds ?? DEFAULT_WINDOW_SECONDS;
+
+  const bySubscriber = new Map();
+  let unattributed = 0;
+
+  for (const click of clickEvents ?? []) {
+    const hash = click?.subscriberEmailHash;
+    if (!hash || hash === UNATTRIBUTED) {
+      unattributed++;
+      continue;
+    }
+
+    const at = toEpochSeconds(click.timestamp);
+    // An event we cannot place in time cannot be placed in a burst either.
+    if (at === null) {
+      unattributed++;
+      continue;
+    }
+
+    if (!bySubscriber.has(hash)) bySubscriber.set(hash, []);
+    bySubscriber.get(hash).push({
+      sk: click.sk,
+      at,
+      linkUrl: click.linkUrl ?? UNATTRIBUTED
+    });
+  }
+
+  const scannerClickIds = new Set();
+  const scannerSubscribers = new Set();
+
+  for (const [hash, clicks] of bySubscriber) {
+    clicks.sort((a, b) => a.at - b.at);
+    const burst = findBurstClicks(clicks, minDistinctLinks, windowSeconds);
+    if (burst.size > 0) {
+      scannerSubscribers.add(hash);
+      for (const sk of burst) scannerClickIds.add(sk);
+    }
+  }
+
+  const total = clickEvents?.length ?? 0;
+  const scanner = scannerClickIds.size;
+  const attributed = total - unattributed;
+  const human = attributed - scanner;
+
+  return {
+    scannerClickIds,
+    summary: {
+      totalClicks: total,
+      /** Clicks inside a sweep burst — almost certainly a link scanner. */
+      scannerClicks: scanner,
+      /** Attributed clicks that were not part of a sweep. */
+      humanClicks: human,
+      /**
+       * Clicks with no subscriber id (web-version traffic) or no usable
+       * timestamp. Neither classified nor discarded.
+       */
+      unattributedClicks: unattributed,
+      /**
+       * Scanner share of the clicks that could be classified at all. Null when
+       * nothing was attributable, since 0% and "no data" are different answers.
+       */
+      scannerRate: attributed > 0 ? Math.round((scanner / attributed) * 1000) / 10 : null,
+      /** Distinct subscribers whose clicks included at least one sweep. */
+      scannerSubscribers: scannerSubscribers.size,
+      thresholds: { minDistinctLinks, windowSeconds }
+    }
+  };
+}

--- a/functions/utils/subscriber-name.mjs
+++ b/functions/utils/subscriber-name.mjs
@@ -1,0 +1,81 @@
+/**
+ * Normalization for subscriber-supplied names.
+ *
+ * The public signup endpoint is unauthenticated and validates only the email
+ * address, so `firstName` and `lastName` arrive as arbitrary JSON: any type,
+ * any length. Whatever lands in the record is later rendered into the welcome
+ * email and the dashboard subscriber list.
+ */
+
+/**
+ * Longest name kept, in characters.
+ *
+ * Matches the cap the authenticated profile endpoint already declares
+ * (`openapi.yaml`, maxLength 50) so the two paths agree on what a name is.
+ */
+export const MAX_NAME_LENGTH = 50;
+
+/**
+ * Code point ranges stripped before storage, as [first, last] inclusive pairs.
+ *
+ * Expressed as numbers rather than a character class because the literal
+ * characters are invisible in a source file, which makes the intent of the
+ * pattern impossible to review.
+ *
+ *   C0 controls and DEL, C1 controls  — render as nothing or as layout damage
+ *   zero-width and directional marks  — invisible, and can reorder display
+ *   line/paragraph separators, bidi   — can make stored text display as
+ *   overrides, invisible operators      something other than what it is
+ *   byte order mark                   — stray from copy-paste
+ */
+const STRIPPED_RANGES = [
+  // Tab through carriage return (0x09-0x0d) are deliberately absent: they are
+  // whitespace, and a name submitted across two lines reads correctly once the
+  // collapse below turns them into a single space. Removing them outright
+  // would run the words together.
+  [0x0000, 0x0008],
+  [0x000e, 0x001f],
+  [0x007f, 0x009f],
+  [0x200b, 0x200f],
+  [0x2028, 0x202e],
+  [0x2060, 0x206f],
+  [0xfeff, 0xfeff]
+];
+
+const isStripped = (codePoint) =>
+  STRIPPED_RANGES.some(([first, last]) => codePoint >= first && codePoint <= last);
+
+/**
+ * Reduce a submitted name to something safe to store and display, or null if
+ * there is nothing usable left.
+ *
+ * Over-length names are truncated rather than rejected. The profile endpoint
+ * returns a 400 for the same input, and the inconsistency is deliberate: that
+ * endpoint is a logged-in user editing their own record who can see the error
+ * and fix it, whereas this one is a public signup where the reader is the
+ * person who loses out if a long name costs them the subscription. Capping the
+ * stored value gets the unbounded write under control without that cost.
+ *
+ * @param {*} value - Raw value from the request body, any type
+ * @returns {string|null} Normalized name, or null when absent/unusable
+ */
+export function sanitizeName(value) {
+  // Anything non-string (object, array, number, null) is not a name. Silently
+  // dropping it is right for a field that was always optional.
+  if (typeof value !== 'string') return null;
+
+  // Iterating the string spreads it into whole code points, so an astral
+  // character is never split into a lone surrogate half.
+  const kept = [...value].filter((char) => !isStripped(char.codePointAt(0)));
+
+  const cleaned = kept
+    .join('')
+    // Collapse runs of whitespace so a name padded out to the cap cannot push
+    // the visible part out of a list column.
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  if (cleaned.length === 0) return null;
+
+  return [...cleaned].slice(0, MAX_NAME_LENGTH).join('');
+}

--- a/functions/utils/subscriber-record.mjs
+++ b/functions/utils/subscriber-record.mjs
@@ -1,0 +1,32 @@
+/**
+ * Telling real subscribers apart from the segment bookkeeping that shares
+ * their table.
+ *
+ * The segments feature stores its records in the subscribers table under the
+ * same tenant partition, overloading the `email` sort key:
+ *
+ *   SEGMENT#<segmentId>                    the segment itself
+ *   SEGMENT#<segmentId>#MEMBER#<email>     a membership row
+ *   SEGMENT_NAME#<lowercased name>         the name-uniqueness guard
+ *   SEGMENT_JOB#<jobId>                    an in-flight rebuild job
+ *
+ * Every one of them begins with `SEGMENT`, so a single prefix check covers the
+ * set. A tenant query returns them interleaved with subscribers, and any caller
+ * that forgets to exclude them treats bookkeeping keys as sendable addresses.
+ */
+
+/** Sort-key prefix owned by the segments feature. */
+const SEGMENT_KEY_PREFIX = 'SEGMENT';
+
+/**
+ * Whether a raw record from the subscribers table is an actual subscriber.
+ *
+ * A record with no `email` is not one either: the attribute is this table's
+ * sort key, so its absence means the item is not shaped like anything the
+ * subscriber paths can use.
+ *
+ * @param {object} record - Unmarshalled item from the subscribers table
+ * @returns {boolean}
+ */
+export const isSubscriberRecord = (record) =>
+  typeof record?.email === 'string' && !record.email.startsWith(SEGMENT_KEY_PREFIX);

--- a/functions/utils/subscriber.mjs
+++ b/functions/utils/subscriber.mjs
@@ -1,5 +1,6 @@
 import { DynamoDBClient, PutItemCommand, QueryCommand, DeleteItemCommand, UpdateItemCommand, GetItemCommand } from '@aws-sdk/client-dynamodb';
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
+import { isSubscriberRecord } from './subscriber-record.mjs';
 
 const ddb = new DynamoDBClient();
 
@@ -53,12 +54,11 @@ export const listSubscribers = async (tenantId, options = {}) => {
     const response = await ddb.send(new QueryCommand(queryParams));
 
     // Unmarshall items and extract subscriber data. The segments feature stores
-    // its records (SEGMENT#, SEGMENT_NAME#, SEGMENT_JOB#, and member rows)
-    // under the same tenant partition with the sort key overloading `email`;
-    // those must never be treated as sendable subscribers.
+    // its records under the same tenant partition with the sort key overloading
+    // `email`; those must never be treated as sendable subscribers.
     const subscribers = (response.Items || [])
       .map(item => unmarshall(item))
-      .filter(subscriber => subscriber.email && !subscriber.email.startsWith('SEGMENT'))
+      .filter(isSubscriberRecord)
       .map(subscriber => ({
         email: subscriber.email,
         firstName: subscriber.firstName || null,

--- a/publicapi.yaml
+++ b/publicapi.yaml
@@ -468,8 +468,16 @@ components:
           minLength: 4
         firstName:
           type: string
+          maxLength: 50
+          description: >-
+            Optional. Normalized before storage: surrounding and repeated
+            whitespace is collapsed, invisible and control characters are
+            removed, and anything longer than 50 characters is truncated rather
+            than rejected so an unusual name never costs a signup.
         lastName:
           type: string
+          maxLength: 50
+          description: Optional. Normalized on the same terms as firstName.
         website:
           type: string
           description: Honeypot field — should be empty for legitimate signups

--- a/publicapi.yaml
+++ b/publicapi.yaml
@@ -468,15 +468,18 @@ components:
           minLength: 4
         firstName:
           type: string
-          maxLength: 50
           description: >-
             Optional. Normalized before storage: surrounding and repeated
             whitespace is collapsed, invisible and control characters are
-            removed, and anything longer than 50 characters is truncated rather
-            than rejected so an unusual name never costs a signup.
+            removed, and anything still longer than 50 characters is truncated.
+            Deliberately carries no maxLength — this route runs the "Validate
+            All" request validator, so a schema constraint would make API
+            Gateway reject the signup with a 400 before the handler could
+            truncate it, including names that would have come in under the cap
+            once whitespace was collapsed. The cap is enforced in
+            add-subscriber.mjs, where overflowing it costs the reader nothing.
         lastName:
           type: string
-          maxLength: 50
           description: Optional. Normalized on the same terms as firstName.
         website:
           type: string

--- a/scripts/backfill-click-quality.mjs
+++ b/scripts/backfill-click-quality.mjs
@@ -1,0 +1,189 @@
+/**
+ * Backfill: classify past issues' click events into scanner vs reader traffic
+ * and record the split on each issue's stored analytics.
+ *
+ * Reads the raw `click#` events already retained per issue (90-day TTL) and
+ * writes `analytics.clickQuality`. Raw counters are never touched — this only
+ * adds the derived split, so an issue that already has analytics keeps every
+ * number it had.
+ *
+ * Usage:
+ *   node scripts/backfill-click-quality.mjs --table TABLE_NAME --tenant TENANT_ID [--dry-run]
+ *
+ * Options:
+ *   --table     DynamoDB issues/stats table name (required)
+ *   --tenant    Tenant to backfill (required)
+ *   --issue     Single issue number; omit to do every issue found
+ *   --dry-run   Print the split without writing
+ *
+ * Safe to re-run — the classification is derived fresh from the events each
+ * time, so a re-run after a threshold change simply overwrites with the new
+ * answer.
+ */
+
+import { DynamoDBClient, QueryCommand, UpdateItemCommand } from '@aws-sdk/client-dynamodb';
+import { unmarshall, marshall } from '@aws-sdk/util-dynamodb';
+import { classifyScannerClicks } from '../functions/utils/scanner-clicks.mjs';
+
+// ── Parse CLI args ─────────────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const args = { table: null, tenant: null, issue: null, dryRun: false };
+  for (let i = 2; i < argv.length; i++) {
+    if (argv[i] === '--table' && argv[i + 1]) { args.table = argv[++i]; }
+    else if (argv[i] === '--tenant' && argv[i + 1]) { args.tenant = argv[++i]; }
+    else if (argv[i] === '--issue' && argv[i + 1]) { args.issue = argv[++i]; }
+    else if (argv[i] === '--dry-run') { args.dryRun = true; }
+  }
+  return args;
+}
+
+const args = parseArgs(process.argv);
+
+if (!args.table || !args.tenant) {
+  console.error('Usage: node scripts/backfill-click-quality.mjs --table TABLE_NAME --tenant TENANT_ID [--issue N] [--dry-run]');
+  process.exit(1);
+}
+
+const ddb = new DynamoDBClient();
+
+// ── Issue discovery ────────────────────────────────────────────────────
+
+/**
+ * Issue numbers to process. With --issue this is just that one; otherwise the
+ * partition keys are discovered from the stats records the tenant already has.
+ *
+ * There is no index over issues, so discovery walks stats rows via a scan-free
+ * query per candidate. Instead of guessing a range, the caller passes --issue
+ * for a spot check and omits it for a full sweep, which walks upward from 1
+ * until it hits a run of missing issues.
+ */
+async function discoverIssueNumbers() {
+  if (args.issue) return [args.issue];
+
+  const found = [];
+  let consecutiveMisses = 0;
+  const STOP_AFTER_CONSECUTIVE_MISSES = 25;
+
+  for (let n = 1; consecutiveMisses < STOP_AFTER_CONSECUTIVE_MISSES; n++) {
+    const result = await ddb.send(new QueryCommand({
+      TableName: args.table,
+      KeyConditionExpression: 'pk = :pk AND sk = :sk',
+      ExpressionAttributeValues: marshall({ ':pk': `${args.tenant}#${n}`, ':sk': 'stats' }),
+      ProjectionExpression: 'pk'
+    }));
+
+    if (result.Items?.length) {
+      found.push(String(n));
+      consecutiveMisses = 0;
+    } else {
+      consecutiveMisses++;
+    }
+  }
+
+  return found;
+}
+
+// ── Event loading ──────────────────────────────────────────────────────
+
+async function loadClickEvents(issueNumber) {
+  const pk = `${args.tenant}#${issueNumber}`;
+  const clicks = [];
+  let exclusiveStartKey;
+
+  do {
+    const result = await ddb.send(new QueryCommand({
+      TableName: args.table,
+      KeyConditionExpression: 'pk = :pk AND begins_with(sk, :prefix)',
+      ExpressionAttributeValues: marshall({ ':pk': pk, ':prefix': 'click#' }),
+      ExpressionAttributeNames: { '#ts': 'timestamp' },
+      ProjectionExpression: 'sk, subscriberEmailHash, linkUrl, #ts',
+      ExclusiveStartKey: exclusiveStartKey
+    }));
+
+    for (const raw of result.Items || []) {
+      clicks.push(unmarshall(raw));
+    }
+    exclusiveStartKey = result.LastEvaluatedKey;
+  } while (exclusiveStartKey);
+
+  return clicks;
+}
+
+// ── Backfill ───────────────────────────────────────────────────────────
+
+async function backfill() {
+  const mode = args.dryRun ? 'DRY RUN' : 'LIVE';
+  console.log(`[${mode}] Classifying click traffic`);
+  console.log(`  Table:  ${args.table}`);
+  console.log(`  Tenant: ${args.tenant}\n`);
+
+  const issueNumbers = await discoverIssueNumbers();
+  if (issueNumbers.length === 0) {
+    console.log('No issues found for this tenant.');
+    return;
+  }
+
+  let processed = 0;
+  let skipped = 0;
+  let totalScanner = 0;
+  let totalClassified = 0;
+
+  for (const issueNumber of issueNumbers) {
+    const clicks = await loadClickEvents(issueNumber);
+
+    // Events age out on a 90-day TTL, so older issues legitimately have none
+    // left to classify. Writing a zeroed split for those would read as "no
+    // scanner traffic" rather than "no evidence either way".
+    if (clicks.length === 0) {
+      skipped++;
+      continue;
+    }
+
+    const { summary } = classifyScannerClicks(clicks);
+
+    const line = `  issue #${issueNumber}: ${summary.scannerClicks} scanner / ${summary.humanClicks} reader`
+      + ` / ${summary.unattributedClicks} unattributed`
+      + (summary.scannerRate === null ? '' : ` (${summary.scannerRate}% scanner)`);
+
+    if (!args.dryRun) {
+      try {
+        await ddb.send(new UpdateItemCommand({
+          TableName: args.table,
+          Key: marshall({ pk: `${args.tenant}#${issueNumber}`, sk: 'stats' }),
+          UpdateExpression: 'SET analytics.clickQuality = :quality',
+          // Only touch issues that already have an analytics blob; creating one
+          // here would half-populate a record the aggregator owns.
+          ConditionExpression: 'attribute_exists(analytics)',
+          ExpressionAttributeValues: marshall({ ':quality': summary })
+        }));
+      } catch (err) {
+        if (err.name !== 'ConditionalCheckFailedException') throw err;
+        console.log(`  [no analytics record] issue #${issueNumber} — skipped`);
+        skipped++;
+        continue;
+      }
+    }
+
+    // Counted only once the issue is actually accounted for, so the totals
+    // below match the lines printed above them.
+    processed++;
+    totalScanner += summary.scannerClicks;
+    totalClassified += summary.scannerClicks + summary.humanClicks;
+    console.log(args.dryRun ? `  [would write]${line}` : line);
+  }
+
+  const overallRate = totalClassified > 0
+    ? `${Math.round((totalScanner / totalClassified) * 1000) / 10}%`
+    : 'n/a';
+
+  console.log(`\n[${mode}] Complete:`);
+  console.log(`  Issues classified:   ${processed}`);
+  console.log(`  Issues skipped:      ${skipped} (no retained click events, or no analytics record)`);
+  console.log(`  Scanner share:       ${overallRate} of classifiable clicks`);
+}
+
+backfill().catch((err) => {
+  console.error('Backfill failed:', err);
+  process.exit(1);
+});

--- a/scripts/backfill-click-quality.mjs
+++ b/scripts/backfill-click-quality.mjs
@@ -50,38 +50,48 @@ const ddb = new DynamoDBClient();
 // ── Issue discovery ────────────────────────────────────────────────────
 
 /**
- * Issue numbers to process. With --issue this is just that one; otherwise the
- * partition keys are discovered from the stats records the tenant already has.
+ * Issue numbers to process. With --issue this is just that one; otherwise every
+ * issue the tenant has a stats record for.
  *
- * There is no index over issues, so discovery walks stats rows via a scan-free
- * query per candidate. Instead of guessing a range, the caller passes --issue
- * for a spot check and omits it for a full sweep, which walks upward from 1
- * until it hits a run of missing issues.
+ * Stats records carry GSI1PK = `{tenantId}#issue`, so the set is a single index
+ * query. Probing issue numbers upward from 1 instead would quietly skip work
+ * whenever a tenant's numbering starts high or leaves a gap — issue numbers are
+ * caller-supplied, so neither is unusual.
+ *
+ * The issue number comes off the record's own `pk` rather than GSI1SK, since
+ * the sort key is zero-padded in places and `pk` is what the update below has
+ * to match anyway.
  */
 async function discoverIssueNumbers() {
   if (args.issue) return [args.issue];
 
   const found = [];
-  let consecutiveMisses = 0;
-  const STOP_AFTER_CONSECUTIVE_MISSES = 25;
+  let exclusiveStartKey;
 
-  for (let n = 1; consecutiveMisses < STOP_AFTER_CONSECUTIVE_MISSES; n++) {
+  do {
     const result = await ddb.send(new QueryCommand({
       TableName: args.table,
-      KeyConditionExpression: 'pk = :pk AND sk = :sk',
-      ExpressionAttributeValues: marshall({ ':pk': `${args.tenant}#${n}`, ':sk': 'stats' }),
-      ProjectionExpression: 'pk'
+      IndexName: 'GSI1',
+      KeyConditionExpression: 'GSI1PK = :gsi1pk',
+      FilterExpression: 'sk = :stats',
+      ExpressionAttributeValues: marshall({
+        ':gsi1pk': `${args.tenant}#issue`,
+        ':stats': 'stats'
+      }),
+      ProjectionExpression: 'pk',
+      ExclusiveStartKey: exclusiveStartKey
     }));
 
-    if (result.Items?.length) {
-      found.push(String(n));
-      consecutiveMisses = 0;
-    } else {
-      consecutiveMisses++;
+    for (const raw of result.Items || []) {
+      const { pk } = unmarshall(raw);
+      const issueNumber = typeof pk === 'string' ? pk.split('#')[1] : null;
+      if (issueNumber) found.push(issueNumber);
     }
-  }
 
-  return found;
+    exclusiveStartKey = result.LastEvaluatedKey;
+  } while (exclusiveStartKey);
+
+  return found.sort((a, b) => Number(a) - Number(b));
 }
 
 // ── Event loading ──────────────────────────────────────────────────────

--- a/template.yaml
+++ b/template.yaml
@@ -2874,7 +2874,11 @@ Resources:
           }
 
           // Loop guard: don't redirect back to the tracker host
-          var hostHdr = headers.host && headers.host[0] && headers.host[0].value || '';
+          // CloudFront Functions expose headers as { host: { value } }, with no
+          // array index — the [0] this used to carry is the Lambda@Edge shape,
+          // and it made hostHdr always empty, so the loop guard below never
+          // fired.
+          var hostHdr = (headers.host && headers.host.value) || '';
           var destHost = ''; try { destHost = dest.split('/')[2].toLowerCase(); } catch(e) { return fallback('bad_url'); }
           if (hostHdr && destHost === hostHdr.toLowerCase()) return fallback('loop_to_tracker');
 
@@ -2959,7 +2963,9 @@ Resources:
 
           if (!dest || !/^https?:\/\//i.test(dest)) return fallback('bad_dest');
 
-          const hostHdr = (headers.host && headers.host[0] && headers.host[0].value) || '';
+          // Same correction as the generic redirect: CloudFront Functions have
+          // no array index on headers, so this guard never fired.
+          const hostHdr = (headers.host && headers.host.value) || '';
           let destHost = '';
           try { destHost = dest.split('/')[2].toLowerCase(); } catch(e) { return fallback('bad_url'); }
           if (hostHdr && destHost === hostHdr.toLowerCase()) return fallback('loop_to_tracker');

--- a/template.yaml
+++ b/template.yaml
@@ -2835,6 +2835,12 @@ Resources:
           // Reliable in CloudFront Functions:
           var ip  = (event.viewer && event.viewer.ip) || null;
 
+          // Truncated because the log line is the whole tracking payload and a
+          // long UA would crowd out the fields that matter; 256 is well past
+          // where the device and client are identifiable.
+          var uaHdr = headers['user-agent'] && headers['user-agent'].value;
+          var ua = uaHdr ? String(uaHdr).slice(0, 256) : null;
+
           function redirect(to){
             return {
               statusCode: 302,
@@ -2875,7 +2881,7 @@ Resources:
           if (dest.length > 2048) return fallback('url_too_long');
 
           // SUCCESS: log minimal fields only, then redirect
-          try { console.log(JSON.stringify({ cid: cid || null, u: dest, src, ip, s })); } catch(_) {}
+          try { console.log(JSON.stringify({ cid: cid || null, u: dest, src, ip, s, ua })); } catch(_) {}
           return redirect(dest);
         }
       FunctionConfig:
@@ -2910,6 +2916,12 @@ Resources:
           const srcOverride = get('src');
           const s = get('s') || null;
           const ip = (event.viewer && event.viewer.ip) || null;
+
+          // Truncated for the same reason as the generic redirect: the log line
+          // is the tracking payload, and 256 characters is well past where the
+          // device and client are identifiable.
+          const uaHdr = headers['user-agent'] && headers['user-agent'].value;
+          const ua = uaHdr ? String(uaHdr).slice(0, 256) : null;
 
           function redirect(to){
             return {
@@ -2954,7 +2966,7 @@ Resources:
 
           if (dest.length > 2048) return fallback('url_too_long');
 
-          try { console.log(JSON.stringify({ code, u: dest, src, ip, s })); } catch(_) {}
+          try { console.log(JSON.stringify({ code, u: dest, src, ip, s, ua })); } catch(_) {}
           return redirect(dest);
         }
       FunctionConfig:


### PR DESCRIPTION
The "Suspected" chip was a span with a native title tooltip and no click
handler, so it explained itself only on hover-and-wait and said nothing at
all on touch. It also gave no way to ask the question the flags exist to
answer: how much of recent growth is automated.

- The chip is now a button that opens the profile modal, where there is room
  to say what each signal measures and how it can misfire. An inline popover
  was the obvious alternative, but the table body scrolls with overflow:auto
  and would clip it.
- The profile modal gains a flags section listing only the signals that
  fired, strongest first, and hedges its heading when everything that fired
  is circumstantial. It also notes that engagement is not a counter-argument,
  since link scanners generate engagement on their own.
- The list header gains a flagged count and a filter, plus the flagged share
  of the last 30 signups. A lifetime percentage is dominated by history; the
  recent rate is the one a growth spike actually turns on.

Signal descriptions move to a shared module so the chip tooltip and the modal
cannot drift apart.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014C6YLPQLVwrCopLsyyaMQR