### PR TITLE
fix(send): checkpoint the send loop, dedup SES status events, and park failures in a DLQ

### DIFF
--- a/__tests__/handle-email-status.test.mjs
+++ b/__tests__/handle-email-status.test.mjs
@@ -1434,14 +1434,32 @@ describe('handle-email-status', () => {
       await expect(handler(sendEvent('msg-race'))).resolves.toBe(true);
     });
 
-    it('rethrows a cancellation that is not the marker losing its race', async () => {
+    it('rethrows a non-marker conditional failure so a fresh pass can reclassify', async () => {
       ddbSend.mockResolvedValueOnce({ Item: null });
       const cancelled = new Error('Transaction cancelled');
       cancelled.name = 'TransactionCanceledException';
-      cancelled.CancellationReasons = [{ Code: 'None' }, { Code: 'TransactionConflict' }];
-      ddbSend.mockRejectedValueOnce(cancelled);
+      // A conditional failure on an item other than the marker - the
+      // unique-open row is the real case. Retrying in-process would re-submit
+      // the same stale open/reopen classification, so this has to escape and
+      // let a fresh invocation re-read.
+      cancelled.CancellationReasons = [{ Code: 'None' }, { Code: 'ConditionalCheckFailed' }];
+      ddbSend.mockRejectedValue(cancelled);
 
-      await expect(handler(sendEvent('msg-conflict'))).rejects.toThrow('Transaction cancelled');
+      await expect(handler(sendEvent('msg-cond'))).rejects.toThrow('Transaction cancelled');
+    });
+
+    it('rethrows a structural cancellation without burning retries', async () => {
+      ddbSend.mockResolvedValueOnce({ Item: null });
+      const cancelled = new Error('Transaction cancelled');
+      cancelled.name = 'TransactionCanceledException';
+      cancelled.CancellationReasons = [{ Code: 'ValidationError' }];
+      ddbSend.mockRejectedValue(cancelled);
+
+      await expect(handler(sendEvent('msg-invalid'))).rejects.toThrow('Transaction cancelled');
+
+      // Pre-check GetItem + exactly one commit attempt: a malformed request
+      // will never succeed, so retrying it just delays the failure.
+      expect(ddbSend).toHaveBeenCalledTimes(2);
     });
 
     it('writes nothing when the commit fails, so a retry reprocesses cleanly', async () => {

--- a/__tests__/handle-email-status.test.mjs
+++ b/__tests__/handle-email-status.test.mjs
@@ -1314,7 +1314,7 @@ describe('handle-email-status', () => {
       expect(ddbSend).not.toHaveBeenCalled();
     });
 
-    it('should return false on unexpected errors', async () => {
+    it('rethrows unexpected errors so the platform retries the event', async () => {
       // GetItem succeeds, but PutItem (captureOpenEvent) fails
       ddbSend.mockResolvedValueOnce({ Item: null }); // GetItem
       ddbSend.mockRejectedValueOnce(new Error('Unexpected error')); // PutItem fails
@@ -1332,9 +1332,96 @@ describe('handle-email-status', () => {
         }
       };
 
-      const result = await handler(event);
+      await expect(handler(event)).rejects.toThrow('Unexpected error');
+    });
+  });
 
-      expect(result).toBe(false);
+  describe('At-least-once delivery dedup', () => {
+    const sendEvent = (messageId) => ({
+      detail: {
+        eventType: 'Send',
+        mail: {
+          tags: { referenceNumber: ['tenant123_42'] },
+          destination: ['subscriber@example.com'],
+          ...(messageId && { messageId }),
+          timestamp: '2025-01-21T10:30:00.000Z'
+        }
+      }
+    });
+
+    it('skips an event whose processed marker already exists', async () => {
+      ddbSend.mockResolvedValueOnce({ Item: { pk: { S: 'tenant123#42' } } }); // marker GetItem
+
+      const result = await handler(sendEvent('msg-1'));
+
+      expect(result).toBe(true);
+      expect(ddbSend).toHaveBeenCalledTimes(1);
+      const markerCheck = ddbSend.mock.calls[0][0];
+      expect(markerCheck.__type).toBe('GetItem');
+      expect(markerCheck.ConsistentRead).toBe(true);
+      expect(markerCheck.Key.sk.S).toBe('processed#msg-1#send#2025-01-21T10:30:00.000Z');
+    });
+
+    it('writes the processed marker only after the stat update succeeds', async () => {
+      ddbSend.mockResolvedValueOnce({ Item: null }); // marker GetItem
+      ddbSend.mockResolvedValueOnce({}); // stats UpdateItem
+      ddbSend.mockResolvedValueOnce({}); // marker PutItem
+
+      const result = await handler(sendEvent('msg-2'));
+
+      expect(result).toBe(true);
+      expect(ddbSend).toHaveBeenCalledTimes(3);
+      expect(ddbSend.mock.calls[1][0].__type).toBe('UpdateItem');
+      const marker = ddbSend.mock.calls[2][0];
+      expect(marker.__type).toBe('PutItem');
+      expect(marker.Item.sk.S).toBe('processed#msg-2#send#2025-01-21T10:30:00.000Z');
+      expect(marker.Item.ttl.N).toBeDefined();
+    });
+
+    it('leaves no marker when the stat update fails, so a retry reprocesses', async () => {
+      ddbSend.mockResolvedValueOnce({ Item: null }); // marker GetItem
+      ddbSend.mockRejectedValueOnce(new Error('throttled')); // stats UpdateItem
+
+      await expect(handler(sendEvent('msg-3'))).rejects.toThrow('throttled');
+
+      expect(ddbSend).toHaveBeenCalledTimes(2);
+      expect(ddbSend.mock.calls.every(([command]) => command.__type !== 'PutItem')).toBe(true);
+    });
+
+    it('processes events without a messageId, without dedup', async () => {
+      ddbSend.mockResolvedValueOnce({}); // stats UpdateItem
+
+      const result = await handler(sendEvent(undefined));
+
+      expect(result).toBe(true);
+      expect(ddbSend).toHaveBeenCalledTimes(1);
+      expect(ddbSend.mock.calls[0][0].__type).toBe('UpdateItem');
+    });
+
+    it('distinguishes two real clicks on different links from a redelivery', async () => {
+      const clickEvent = (link) => ({
+        detail: {
+          eventType: 'Click',
+          mail: {
+            tags: { referenceNumber: ['tenant123_42'] },
+            destination: ['subscriber@example.com'],
+            messageId: 'msg-4',
+            timestamp: '2025-01-21T10:30:00.000Z'
+          },
+          click: { link, timestamp: '2025-01-21T10:31:00.000Z' }
+        }
+      });
+
+      ddbSend.mockResolvedValue({ Item: null });
+
+      await handler(clickEvent('https://a.example.com'));
+      await handler(clickEvent('https://b.example.com'));
+
+      const markerChecks = ddbSend.mock.calls
+        .map(([command]) => command)
+        .filter((command) => command.__type === 'GetItem' && command.Key?.sk?.S?.startsWith('processed#'));
+      expect(markerChecks).toHaveLength(2);
+      expect(markerChecks[0].Key.sk.S).not.toBe(markerChecks[1].Key.sk.S);
     });
   });
 

--- a/__tests__/handle-email-status.test.mjs
+++ b/__tests__/handle-email-status.test.mjs
@@ -19,6 +19,7 @@ const loadIsolated = async () => {
       PutItemCommand: jest.fn((params) => ({ __type: 'PutItem', ...params })),
       UpdateItemCommand: jest.fn((params) => ({ __type: 'UpdateItem', ...params })),
       GetItemCommand: jest.fn((params) => ({ __type: 'GetItem', ...params })),
+      TransactWriteItemsCommand: jest.fn((params) => ({ __type: 'TransactWriteItems', ...params })),
     }));
 
     jest.unstable_mockModule('@aws-sdk/util-dynamodb', () => ({
@@ -101,6 +102,38 @@ const loadIsolated = async () => {
   });
 };
 
+// Authoritative accounting for an event now commits as ONE TransactWriteItems
+// rather than a sequence of individual writes, so these helpers locate a write
+// by what it targets instead of by call index. That keeps the assertions about
+// behavior and immune to how many reads precede the commit.
+const transactItems = () => {
+  const call = ddbSend.mock.calls
+    .map(([command]) => command)
+    .find((command) => command.__type === 'TransactWriteItems');
+  return call ? call.TransactItems : [];
+};
+
+const puts = () => transactItems().map((item) => item.Put).filter(Boolean);
+const updates = () => transactItems().map((item) => item.Update).filter(Boolean);
+
+const putWithSk = (prefix) => puts().find((put) => put.Item.sk?.S?.startsWith(prefix));
+const statsUpdate = () => updates().find((update) => update.Key.sk.S === 'stats');
+const variantUpdate = () => updates().find((update) => update.Key.sk.S.startsWith('stats#v#'));
+const uniqueOpenPut = () => putWithSk('opens#');
+// The one analytics row for the event (open#/bounce#/complaint#/click#) - a
+// transaction carries at most one, so it needs no prefix to identify it.
+const eventRecordPut = () => puts().find((put) => {
+  const sk = put.Item.sk?.S ?? '';
+  return !sk.startsWith('processed#') && !sk.startsWith('opens#');
+});
+// Enrichment writes stay standalone commands, outside the transaction.
+const standaloneCommands = () => ddbSend.mock.calls
+  .map(([command]) => command)
+  .filter((command) => command.__type !== 'TransactWriteItems');
+const linkClickUpdate = () => standaloneCommands()
+  .find((command) => command.__type === 'UpdateItem' && command.Key?.sk?.S?.startsWith('link#'));
+const markerPut = () => putWithSk('processed#');
+
 describe('handle-email-status', () => {
   beforeEach(async () => {
     jest.resetModules();
@@ -137,10 +170,9 @@ describe('handle-email-status', () => {
       const result = await handler(event);
 
       expect(result).toBe(true);
-      expect(ddbSend).toHaveBeenCalledTimes(4);
+      expect(ddbSend).toHaveBeenCalledTimes(3);
 
-      const trackCall = ddbSend.mock.calls[2][0];
-      expect(trackCall.__type).toBe('PutItem');
+      const trackCall = uniqueOpenPut();
       expect(trackCall.Item.pk.S).toBe('tenant123#issue-456');
       expect(trackCall.Item.sk.S).toBe('opens#subscriber@example.com');
       expect(trackCall.Item.userAgent.S).toBe('Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X)');
@@ -149,8 +181,7 @@ describe('handle-email-status', () => {
       expect(trackCall.Item.createdAt.S).toBeDefined();
       expect(trackCall.Item.ttl.N).toBeDefined();
 
-      const updateCall = ddbSend.mock.calls[3][0];
-      expect(updateCall.__type).toBe('UpdateItem');
+      const updateCall = statsUpdate();
     });
 
     it('should track first open without optional fields', async () => {
@@ -177,7 +208,7 @@ describe('handle-email-status', () => {
 
       expect(result).toBe(true);
 
-      const trackCall = ddbSend.mock.calls[2][0];
+      const trackCall = uniqueOpenPut();
       expect(trackCall.Item.pk.S).toBe('tenant123#issue-456');
       expect(trackCall.Item.sk.S).toBe('opens#subscriber@example.com');
       expect(trackCall.Item.userAgent).toBeUndefined();
@@ -188,13 +219,11 @@ describe('handle-email-status', () => {
 
     it('should detect reopens and increment reopens stat', async () => {
       ddbSend.mockResolvedValueOnce({ Item: null }); // GetItem - no publishedAt
-      ddbSend.mockResolvedValueOnce({});
-
-      const conditionalError = new Error('ConditionalCheckFailedException');
-      conditionalError.name = 'ConditionalCheckFailedException';
-
-      ddbSend.mockRejectedValueOnce(conditionalError);
-      ddbSend.mockResolvedValueOnce({});
+      // An existing opens# row is what makes this a reopen; the classification
+      // is now a read, so the write that claims a first open can ride the
+      // accounting transaction.
+      ddbSend.mockResolvedValueOnce({ Item: { pk: { S: 'tenant123#issue-456' } } });
+      ddbSend.mockResolvedValueOnce({}); // TransactWriteItems
 
       const event = {
         detail: {
@@ -217,11 +246,12 @@ describe('handle-email-status', () => {
       const result = await handler(event);
 
       expect(result).toBe(true);
-      expect(ddbSend).toHaveBeenCalledTimes(4);
+      expect(ddbSend).toHaveBeenCalledTimes(3);
 
-      const updateCall = ddbSend.mock.calls[3][0];
-      expect(updateCall.__type).toBe('UpdateItem');
+      const updateCall = statsUpdate();
       expect(updateCall.ExpressionAttributeNames['#stat']).toBe('reopens');
+      // A reopen must not rewrite the first-open marker.
+      expect(uniqueOpenPut()).toBeUndefined();
     });
   });
 
@@ -258,14 +288,13 @@ describe('handle-email-status', () => {
       const result = await handler(event);
 
       expect(result).toBe(true);
-      expect(ddbSend).toHaveBeenCalledTimes(4);
+      expect(ddbSend).toHaveBeenCalledTimes(3);
 
       // First call is GetItemCommand for publishedAt
       const getCall = ddbSend.mock.calls[0][0];
       expect(getCall.__type).toBe('GetItem');
 
-      const captureCall = ddbSend.mock.calls[1][0];
-      expect(captureCall.__type).toBe('PutItem');
+      const captureCall = eventRecordPut();
       expect(captureCall.Item.pk.S).toBe('tenant123#issue-456');
       expect(captureCall.Item.sk.S).toMatch(/^open#\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z#[a-f0-9]{64}#01HQZX3Y4K5M6N7P8Q9R0S1T2U$/);
       expect(captureCall.Item.eventType.S).toBe('open');
@@ -307,7 +336,7 @@ describe('handle-email-status', () => {
 
       expect(result).toBe(true);
 
-      const captureCall = ddbSend.mock.calls[1][0];
+      const captureCall = eventRecordPut();
       expect(captureCall.Item.timeToOpen.N).toBe('1800');
     });
 
@@ -338,8 +367,7 @@ describe('handle-email-status', () => {
 
       expect(result).toBe(true);
 
-      const captureCall = ddbSend.mock.calls[1][0];
-      expect(captureCall.__type).toBe('PutItem');
+      const captureCall = eventRecordPut();
       expect(captureCall.Item.timeToOpen).toBeUndefined();
     });
 
@@ -365,7 +393,7 @@ describe('handle-email-status', () => {
 
       await handler(event);
 
-      const captureCall = ddbSend.mock.calls[1][0];
+      const captureCall = eventRecordPut();
       expect(captureCall.Item.subscriberEmailHash.S).toMatch(/^[a-f0-9]{64}$/);
       expect(captureCall.Item.subscriberEmailHash.S.length).toBe(64);
     });
@@ -394,7 +422,7 @@ describe('handle-email-status', () => {
 
       await handler(event);
 
-      const captureCall = ddbSend.mock.calls[1][0];
+      const captureCall = eventRecordPut();
       expect(captureCall.Item.device.S).toBe('tablet');
     });
 
@@ -420,7 +448,7 @@ describe('handle-email-status', () => {
 
       await handler(event);
 
-      const captureCall = ddbSend.mock.calls[1][0];
+      const captureCall = eventRecordPut();
       expect(captureCall.Item.device.S).toBe('unknown');
     });
 
@@ -449,7 +477,7 @@ describe('handle-email-status', () => {
 
       await handler(event);
 
-      const captureCall = ddbSend.mock.calls[1][0];
+      const captureCall = eventRecordPut();
       const actualTTL = parseInt(captureCall.Item.ttl.N);
       expect(actualTTL).toBeGreaterThanOrEqual(expectedTTL - 5);
       expect(actualTTL).toBeLessThanOrEqual(expectedTTL + 5);
@@ -477,7 +505,7 @@ describe('handle-email-status', () => {
 
       await handler(event);
 
-      const captureCall = ddbSend.mock.calls[1][0];
+      const captureCall = eventRecordPut();
       expect(captureCall.Item.sk.S).toContain('01HQZX3Y4K5M6N7P8Q9R0S1T2U');
     });
 
@@ -511,7 +539,7 @@ describe('handle-email-status', () => {
       const result = await handler(event);
 
       expect(result).toBe(true);
-      const captureCall = ddbSend.mock.calls[1][0];
+      const captureCall = eventRecordPut();
       expect(captureCall.Item.timeToOpen.N).toBe('1800');
     });
   });
@@ -548,10 +576,9 @@ describe('handle-email-status', () => {
       const result = await handler(event);
 
       expect(result).toBe(true);
-      expect(ddbSend).toHaveBeenCalledTimes(2);
+      expect(ddbSend).toHaveBeenCalledTimes(1);
 
-      const captureCall = ddbSend.mock.calls[0][0];
-      expect(captureCall.__type).toBe('PutItem');
+      const captureCall = eventRecordPut();
       expect(captureCall.Item.pk.S).toBe('tenant123#issue-456');
       expect(captureCall.Item.sk.S).toMatch(/^bounce#\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z#[a-f0-9]{64}#01HQZX3Y4K5M6N7P8Q9R0S1T2U$/);
       expect(captureCall.Item.eventType.S).toBe('bounce');
@@ -589,7 +616,7 @@ describe('handle-email-status', () => {
 
       await handler(event);
 
-      const captureCall = ddbSend.mock.calls[0][0];
+      const captureCall = eventRecordPut();
       expect(captureCall.Item.bounceType.S).toBe('temporary');
       expect(captureCall.Item.bounceReason.S).toBe('smtp; 552 mailbox full');
     });
@@ -622,7 +649,7 @@ describe('handle-email-status', () => {
 
       await handler(event);
 
-      const captureCall = ddbSend.mock.calls[0][0];
+      const captureCall = eventRecordPut();
       expect(captureCall.Item.bounceType.S).toBe('suppressed');
     });
 
@@ -653,7 +680,7 @@ describe('handle-email-status', () => {
 
       await handler(event);
 
-      const captureCall = ddbSend.mock.calls[0][0];
+      const captureCall = eventRecordPut();
       expect(captureCall.Item.bounceReason.S).toBe('5.1.1');
     });
 
@@ -679,7 +706,7 @@ describe('handle-email-status', () => {
 
       await handler(event);
 
-      const captureCall = ddbSend.mock.calls[0][0];
+      const captureCall = eventRecordPut();
       expect(captureCall.Item.bounceReason.S).toBe('NoEmail');
     });
 
@@ -702,7 +729,7 @@ describe('handle-email-status', () => {
 
       await handler(event);
 
-      const captureCall = ddbSend.mock.calls[0][0];
+      const captureCall = eventRecordPut();
       expect(captureCall.Item.bounceReason.S).toBe('unknown');
     });
 
@@ -727,7 +754,7 @@ describe('handle-email-status', () => {
 
       await handler(event);
 
-      const captureCall = ddbSend.mock.calls[0][0];
+      const captureCall = eventRecordPut();
       expect(captureCall.Item.bounceType.S).toBe('temporary');
     });
 
@@ -752,7 +779,7 @@ describe('handle-email-status', () => {
 
       await handler(event);
 
-      const captureCall = ddbSend.mock.calls[0][0];
+      const captureCall = eventRecordPut();
       expect(captureCall.Item.subscriberEmailHash.S).toMatch(/^[a-f0-9]{64}$/);
       expect(captureCall.Item.subscriberEmailHash.S.length).toBe(64);
     });
@@ -781,7 +808,7 @@ describe('handle-email-status', () => {
 
       await handler(event);
 
-      const captureCall = ddbSend.mock.calls[0][0];
+      const captureCall = eventRecordPut();
       const actualTTL = parseInt(captureCall.Item.ttl.N);
       expect(actualTTL).toBeGreaterThanOrEqual(expectedTTL - 5);
       expect(actualTTL).toBeLessThanOrEqual(expectedTTL + 5);
@@ -808,7 +835,7 @@ describe('handle-email-status', () => {
 
       await handler(event);
 
-      const captureCall = ddbSend.mock.calls[0][0];
+      const captureCall = eventRecordPut();
       expect(captureCall.Item.sk.S).toContain('01HQZX3Y4K5M6N7P8Q9R0S1T2U');
     });
 
@@ -830,7 +857,7 @@ describe('handle-email-status', () => {
 
       await handler(event);
 
-      const captureCall = ddbSend.mock.calls[0][0];
+      const captureCall = eventRecordPut();
       expect(captureCall.Item.bounceType.S).toBe('temporary');
       expect(captureCall.Item.bounceReason.S).toBe('unknown');
     });
@@ -860,10 +887,9 @@ describe('handle-email-status', () => {
       const result = await handler(event);
 
       expect(result).toBe(true);
-      expect(ddbSend).toHaveBeenCalledTimes(2);
+      expect(ddbSend).toHaveBeenCalledTimes(1);
 
-      const captureCall = ddbSend.mock.calls[0][0];
-      expect(captureCall.__type).toBe('PutItem');
+      const captureCall = eventRecordPut();
       expect(captureCall.Item.pk.S).toBe('tenant123#issue-456');
       expect(captureCall.Item.sk.S).toMatch(/^complaint#\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z#[a-f0-9]{64}#01HQZX3Y4K5M6N7P8Q9R0S1T2U$/);
       expect(captureCall.Item.eventType.S).toBe('complaint');
@@ -893,7 +919,7 @@ describe('handle-email-status', () => {
 
       await handler(event);
 
-      const captureCall = ddbSend.mock.calls[0][0];
+      const captureCall = eventRecordPut();
       expect(captureCall.Item.complaintType.S).toBe('abuse');
     });
 
@@ -918,7 +944,7 @@ describe('handle-email-status', () => {
 
       await handler(event);
 
-      const captureCall = ddbSend.mock.calls[0][0];
+      const captureCall = eventRecordPut();
       expect(captureCall.Item.complaintType.S).toBe('abuse');
     });
 
@@ -943,7 +969,7 @@ describe('handle-email-status', () => {
 
       await handler(event);
 
-      const captureCall = ddbSend.mock.calls[0][0];
+      const captureCall = eventRecordPut();
       expect(captureCall.Item.complaintType.S).toBe('abuse');
     });
 
@@ -966,7 +992,7 @@ describe('handle-email-status', () => {
 
       await handler(event);
 
-      const captureCall = ddbSend.mock.calls[0][0];
+      const captureCall = eventRecordPut();
       expect(captureCall.Item.complaintType.S).toBe('spam');
     });
 
@@ -988,7 +1014,7 @@ describe('handle-email-status', () => {
 
       await handler(event);
 
-      const captureCall = ddbSend.mock.calls[0][0];
+      const captureCall = eventRecordPut();
       expect(captureCall.Item.complaintType.S).toBe('spam');
     });
 
@@ -1013,7 +1039,7 @@ describe('handle-email-status', () => {
 
       await handler(event);
 
-      const captureCall = ddbSend.mock.calls[0][0];
+      const captureCall = eventRecordPut();
       expect(captureCall.Item.subscriberEmailHash.S).toMatch(/^[a-f0-9]{64}$/);
       expect(captureCall.Item.subscriberEmailHash.S.length).toBe(64);
     });
@@ -1040,7 +1066,7 @@ describe('handle-email-status', () => {
 
       await handler(event);
 
-      const captureCall = ddbSend.mock.calls[0][0];
+      const captureCall = eventRecordPut();
       const actualTTL = parseInt(captureCall.Item.ttl.N);
       expect(actualTTL).toBeGreaterThanOrEqual(expectedTTL - 5);
       expect(actualTTL).toBeLessThanOrEqual(expectedTTL + 5);
@@ -1065,7 +1091,7 @@ describe('handle-email-status', () => {
 
       await handler(event);
 
-      const captureCall = ddbSend.mock.calls[0][0];
+      const captureCall = eventRecordPut();
       expect(captureCall.Item.sk.S).toContain('01HQZX3Y4K5M6N7P8Q9R0S1T2U');
     });
 
@@ -1088,7 +1114,7 @@ describe('handle-email-status', () => {
 
       await handler(event);
 
-      const captureCall = ddbSend.mock.calls[0][0];
+      const captureCall = eventRecordPut();
       expect(captureCall.Item.timestamp.S).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
     });
   });
@@ -1116,10 +1142,9 @@ describe('handle-email-status', () => {
       const result = await handler(event);
 
       expect(result).toBe(true);
-      expect(ddbSend).toHaveBeenCalledTimes(2);
+      expect(ddbSend).toHaveBeenCalledTimes(1);
 
-      const updateCall = ddbSend.mock.calls[1][0];
-      expect(updateCall.__type).toBe('UpdateItem');
+      const updateCall = statsUpdate();
       expect(updateCall.ExpressionAttributeNames['#stat']).toBe('bounces');
     });
 
@@ -1145,10 +1170,9 @@ describe('handle-email-status', () => {
       const result = await handler(event);
 
       expect(result).toBe(true);
-      expect(ddbSend).toHaveBeenCalledTimes(2);
+      expect(ddbSend).toHaveBeenCalledTimes(1);
 
-      const updateCall = ddbSend.mock.calls[1][0];
-      expect(updateCall.__type).toBe('UpdateItem');
+      const updateCall = statsUpdate();
       expect(updateCall.ExpressionAttributeNames['#stat']).toBe('complaints');
     });
 
@@ -1199,7 +1223,7 @@ describe('handle-email-status', () => {
       const result = await handler(event);
 
       expect(result).toBe(true);
-      expect(ddbSend).toHaveBeenCalledTimes(5);
+      expect(ddbSend).toHaveBeenCalledTimes(4);
     });
   });
 
@@ -1224,8 +1248,7 @@ describe('handle-email-status', () => {
       expect(result).toBe(true);
       expect(ddbSend).toHaveBeenCalledTimes(1);
 
-      const updateCall = ddbSend.mock.calls[0][0];
-      expect(updateCall.__type).toBe('UpdateItem');
+      const updateCall = statsUpdate();
       expect(updateCall.UpdateExpression).toContain('GSI1PK = if_not_exists(GSI1PK, :gsi1pk)');
       expect(updateCall.UpdateExpression).toContain('GSI1SK = if_not_exists(GSI1SK, :gsi1sk)');
       expect(updateCall.UpdateExpression).toContain('statsPhase = if_not_exists(statsPhase, :phase)');
@@ -1251,7 +1274,7 @@ describe('handle-email-status', () => {
 
       await handler(event);
 
-      const updateCall = ddbSend.mock.calls[0][0];
+      const updateCall = statsUpdate();
       expect(updateCall.ExpressionAttributeValues[':gsi1sk'].S).toBe('00007');
     });
 
@@ -1272,7 +1295,7 @@ describe('handle-email-status', () => {
 
       await handler(event);
 
-      const updateCall = ddbSend.mock.calls[0][0];
+      const updateCall = statsUpdate();
       expect(updateCall.ExpressionAttributeValues[':gsi1sk'].S).toBe('12345');
     });
   });
@@ -1362,40 +1385,93 @@ describe('handle-email-status', () => {
       expect(markerCheck.Key.sk.S).toBe('processed#msg-1#send#2025-01-21T10:30:00.000Z');
     });
 
-    it('writes the processed marker only after the stat update succeeds', async () => {
+    it('commits the marker and the stat in one transaction, marker guarded', async () => {
       ddbSend.mockResolvedValueOnce({ Item: null }); // marker GetItem
-      ddbSend.mockResolvedValueOnce({}); // stats UpdateItem
-      ddbSend.mockResolvedValueOnce({}); // marker PutItem
+      ddbSend.mockResolvedValueOnce({}); // TransactWriteItems
 
       const result = await handler(sendEvent('msg-2'));
 
       expect(result).toBe(true);
-      expect(ddbSend).toHaveBeenCalledTimes(3);
-      expect(ddbSend.mock.calls[1][0].__type).toBe('UpdateItem');
-      const marker = ddbSend.mock.calls[2][0];
-      expect(marker.__type).toBe('PutItem');
+      expect(ddbSend).toHaveBeenCalledTimes(2);
+
+      // One atomic write, not a stat update followed by a separate marker: a
+      // crash between the two is exactly the window that double-counted.
+      const commit = ddbSend.mock.calls[1][0];
+      expect(commit.__type).toBe('TransactWriteItems');
+
+      const marker = markerPut();
       expect(marker.Item.sk.S).toBe('processed#msg-2#send#2025-01-21T10:30:00.000Z');
       expect(marker.Item.ttl.N).toBeDefined();
+      // The conditional Put is the mutual exclusion between two concurrent
+      // first-time processors; a consistent read alone cannot provide it.
+      expect(marker.ConditionExpression).toContain('attribute_not_exists');
+
+      expect(statsUpdate().Key.sk.S).toBe('stats');
     });
 
-    it('leaves no marker when the stat update fails, so a retry reprocesses', async () => {
+    it('keeps the marker TTL beyond the 14-day DLQ retention', async () => {
+      ddbSend.mockResolvedValueOnce({ Item: null });
+      ddbSend.mockResolvedValueOnce({});
+
+      await handler(sendEvent('msg-ttl'));
+
+      // A marker expiring inside the DLQ window would let a legitimate late
+      // redrive read as a new event.
+      const ttl = Number(markerPut().Item.ttl.N);
+      const daysOut = (ttl - Math.floor(Date.now() / 1000)) / (24 * 60 * 60);
+      expect(daysOut).toBeGreaterThan(14);
+    });
+
+    it('treats a losing marker condition as a duplicate, not an error', async () => {
+      ddbSend.mockResolvedValueOnce({ Item: null }); // marker GetItem sees nothing
+      const cancelled = new Error('Transaction cancelled');
+      cancelled.name = 'TransactionCanceledException';
+      cancelled.CancellationReasons = [{ Code: 'ConditionalCheckFailed' }, { Code: 'None' }];
+      ddbSend.mockRejectedValueOnce(cancelled);
+
+      // The concurrent-duplicate case: both invocations passed the pre-check,
+      // one lost the conditional Put. That is success, not a retryable failure.
+      await expect(handler(sendEvent('msg-race'))).resolves.toBe(true);
+    });
+
+    it('rethrows a cancellation that is not the marker losing its race', async () => {
+      ddbSend.mockResolvedValueOnce({ Item: null });
+      const cancelled = new Error('Transaction cancelled');
+      cancelled.name = 'TransactionCanceledException';
+      cancelled.CancellationReasons = [{ Code: 'None' }, { Code: 'TransactionConflict' }];
+      ddbSend.mockRejectedValueOnce(cancelled);
+
+      await expect(handler(sendEvent('msg-conflict'))).rejects.toThrow('Transaction cancelled');
+    });
+
+    it('writes nothing when the commit fails, so a retry reprocesses cleanly', async () => {
       ddbSend.mockResolvedValueOnce({ Item: null }); // marker GetItem
-      ddbSend.mockRejectedValueOnce(new Error('throttled')); // stats UpdateItem
+      ddbSend.mockRejectedValueOnce(new Error('throttled')); // TransactWriteItems
 
       await expect(handler(sendEvent('msg-3'))).rejects.toThrow('throttled');
 
+      // Atomicity is the point: the marker and the stat were submitted in one
+      // transaction, so a rejected commit persists neither and the retry
+      // recomputes instead of skipping the stat it never recorded.
       expect(ddbSend).toHaveBeenCalledTimes(2);
-      expect(ddbSend.mock.calls.every(([command]) => command.__type !== 'PutItem')).toBe(true);
+      const commit = ddbSend.mock.calls[1][0];
+      expect(commit.__type).toBe('TransactWriteItems');
+      expect(markerPut()).toBeDefined();
+      expect(statsUpdate()).toBeDefined();
+      // No standalone write escaped the transaction.
+      expect(standaloneCommands().every((command) => command.__type === 'GetItem')).toBe(true);
     });
 
     it('processes events without a messageId, without dedup', async () => {
-      ddbSend.mockResolvedValueOnce({}); // stats UpdateItem
+      ddbSend.mockResolvedValueOnce({}); // TransactWriteItems
 
       const result = await handler(sendEvent(undefined));
 
       expect(result).toBe(true);
       expect(ddbSend).toHaveBeenCalledTimes(1);
-      expect(ddbSend.mock.calls[0][0].__type).toBe('UpdateItem');
+      expect(ddbSend.mock.calls[0][0].__type).toBe('TransactWriteItems');
+      expect(markerPut()).toBeUndefined();
+      expect(statsUpdate()).toBeDefined();
     });
 
     it('distinguishes two real clicks on different links from a redelivery', async () => {
@@ -1437,6 +1513,7 @@ describe('handle-email-status', () => {
         PutItemCommand: jest.fn((params) => ({ __type: 'PutItem', ...params })),
         UpdateItemCommand: jest.fn((params) => ({ __type: 'UpdateItem', ...params })),
         GetItemCommand: jest.fn((params) => ({ __type: 'GetItem', ...params })),
+        TransactWriteItemsCommand: jest.fn((params) => ({ __type: 'TransactWriteItems', ...params })),
       }));
 
       jest.unstable_mockModule('@aws-sdk/util-dynamodb', () => ({
@@ -1534,9 +1611,9 @@ describe('handle-email-status', () => {
       await handler(event);
 
       expect(mockLookupCountry).toHaveBeenCalledWith('8.8.8.8');
-      expect(ddbSend).toHaveBeenCalledTimes(5);
+      expect(ddbSend).toHaveBeenCalledTimes(4);
 
-      const linkUpdateCall = ddbSend.mock.calls[0][0];
+      const linkUpdateCall = linkClickUpdate();
       expect(linkUpdateCall.__type).toBe('UpdateItem');
       expect(linkUpdateCall.ExpressionAttributeValues[':country'].S).toBe('US');
     });
@@ -1566,9 +1643,9 @@ describe('handle-email-status', () => {
       await handler(event);
 
       expect(mockLookupCountry).not.toHaveBeenCalled();
-      expect(ddbSend).toHaveBeenCalledTimes(5);
+      expect(ddbSend).toHaveBeenCalledTimes(4);
 
-      const linkUpdateCall = ddbSend.mock.calls[0][0];
+      const linkUpdateCall = linkClickUpdate();
       expect(linkUpdateCall.ExpressionAttributeValues[':country'].S).toBe('unknown');
     });
 
@@ -1600,9 +1677,9 @@ describe('handle-email-status', () => {
       await handler(event);
 
       expect(mockLookupCountry).toHaveBeenCalledWith('10.0.0.1');
-      expect(ddbSend).toHaveBeenCalledTimes(5);
+      expect(ddbSend).toHaveBeenCalledTimes(4);
 
-      const linkUpdateCall = ddbSend.mock.calls[0][0];
+      const linkUpdateCall = linkClickUpdate();
       expect(linkUpdateCall.ExpressionAttributeValues[':country'].S).toBe('unknown');
     });
 
@@ -1635,7 +1712,7 @@ describe('handle-email-status', () => {
 
       await handler(event);
 
-      const linkUpdateCall = ddbSend.mock.calls[0][0];
+      const linkUpdateCall = linkClickUpdate();
       const marshalledValues = linkUpdateCall.ExpressionAttributeValues;
 
       const hasIpField = Object.keys(marshalledValues).some(key =>
@@ -1674,11 +1751,11 @@ describe('handle-email-status', () => {
       const result = await handler(event);
 
       expect(result).toBe(true);
-      expect(ddbSend).toHaveBeenCalledTimes(5);
+      expect(ddbSend).toHaveBeenCalledTimes(3);
 
-      const updateCalls = ddbSend.mock.calls
-        .map(([command]) => command)
-        .filter((command) => command.__type === 'UpdateItem');
+      // Both stat updates ride the same transaction as the marker: the variant
+      // stat can no longer fail on its own while the event is marked processed.
+      const updateCalls = updates();
       expect(updateCalls).toHaveLength(2);
 
       const aggregateCall = updateCalls.find((c) => c.Key.sk.S === 'stats');
@@ -1721,14 +1798,10 @@ describe('handle-email-status', () => {
       expect(result).toBe(true);
       expect(ddbSend).toHaveBeenCalledTimes(1);
 
-      const updateCalls = ddbSend.mock.calls
-        .map(([command]) => command)
-        .filter((command) => command.__type === 'UpdateItem');
+      const updateCalls = updates();
       expect(updateCalls).toHaveLength(1);
       expect(updateCalls[0].Key.sk.S).toBe('stats');
-
-      const variantCall = updateCalls.find((c) => c.Key.sk.S.startsWith('stats#v#'));
-      expect(variantCall).toBeUndefined();
+      expect(variantUpdate()).toBeUndefined();
     });
 
     it('should ignore an invalid variant value', async () => {
@@ -1752,11 +1825,10 @@ describe('handle-email-status', () => {
       expect(result).toBe(true);
       expect(ddbSend).toHaveBeenCalledTimes(1);
 
-      const updateCalls = ddbSend.mock.calls
-        .map(([command]) => command)
-        .filter((command) => command.__type === 'UpdateItem');
+      const updateCalls = updates();
       expect(updateCalls).toHaveLength(1);
       expect(updateCalls[0].Key.sk.S).toBe('stats');
+      expect(variantUpdate()).toBeUndefined();
     });
   });
 

--- a/__tests__/send-email-v2.test.mjs
+++ b/__tests__/send-email-v2.test.mjs
@@ -1442,6 +1442,82 @@ describe('send-email-v2 property-based tests', () => {
       expect(firstTrackingOrder).toBeLessThan(lastSesOrder);
     }, 30000);
 
+    test('checkpoints confirmed sends before propagating a send failure', async () => {
+      ddbInstance.send.mockResolvedValueOnce({
+        Items: [{
+          unmarshalled: {
+            senderId: 'sender-123',
+            email: 'sender@example.com',
+            verificationStatus: 'verified',
+            isDefault: false
+          }
+        }]
+      });
+      ddbInstance.send.mockResolvedValue({});
+      listSubscribers.mockResolvedValue({
+        subscribers: sixtySubscribers(),
+        lastEvaluatedKey: undefined
+      });
+
+      // Six succeed past the 50-send checkpoint, then one throws. A hard crash
+      // could not do better than the checkpoint, but a controlled failure can:
+      // the six already have their mail and must not be mailed again.
+      let sent = 0;
+      sesInstance.send.mockImplementation(() => {
+        sent++;
+        if (sent === 57) {
+          return Promise.reject(new Error('SES said no'));
+        }
+        return Promise.resolve({ MessageId: 'msg-123' });
+      });
+
+      await expect(handler(listEvent())).rejects.toThrow('SES said no');
+
+      expect(updateSubscriberSendMetadata).toHaveBeenCalledTimes(56);
+      expect(updateSubscriberSendMetadata).toHaveBeenCalledWith('tenant-123', 'reader55@example.com', 'tenant-123_42');
+      // The recipient that failed never got mail, so it must not be marked.
+      expect(updateSubscriberSendMetadata).not.toHaveBeenCalledWith('tenant-123', 'reader56@example.com', 'tenant-123_42');
+    }, 30000);
+
+    test('propagates the original send failure even when the final flush fails', async () => {
+      ddbInstance.send.mockResolvedValueOnce({
+        Items: [{
+          unmarshalled: {
+            senderId: 'sender-123',
+            email: 'sender@example.com',
+            verificationStatus: 'verified',
+            isDefault: false
+          }
+        }]
+      });
+      ddbInstance.send.mockResolvedValue({});
+      listSubscribers.mockResolvedValue({
+        subscribers: [
+          { email: 'reader0@example.com', lastIssueSent: null },
+          { email: 'reader1@example.com', lastIssueSent: null }
+        ],
+        lastEvaluatedKey: undefined
+      });
+
+      let sent = 0;
+      sesInstance.send.mockImplementation(() => {
+        sent++;
+        if (sent === 2) {
+          return Promise.reject(new Error('SES said no'));
+        }
+        return Promise.resolve({ MessageId: 'msg-123' });
+      });
+      updateSubscriberSendMetadata.mockRejectedValue(new Error('marker write down'));
+
+      try {
+        // The send error is the diagnosis; a secondary flush failure must not
+        // mask it.
+        await expect(handler(listEvent())).rejects.toThrow('SES said no');
+      } finally {
+        updateSubscriberSendMetadata.mockImplementation(() => Promise.resolve());
+      }
+    }, 30000);
+
     test('stops sending when a checkpoint flush fails, instead of outrunning its markers', async () => {
       ddbInstance.send.mockResolvedValueOnce({
         Items: [{

--- a/__tests__/send-email-v2.test.mjs
+++ b/__tests__/send-email-v2.test.mjs
@@ -1104,7 +1104,11 @@ describe('send-email-v2 property-based tests', () => {
      * should be incremented and lastSentAt timestamp should be updated
      * Validates: Requirements 4.4
      */
-    test('sender metrics are updated after successful email send', () => {
+    // Async property, awaited: unawaited fc.assert keeps its iterations
+    // running after the test "passes", mutating the shared mocks under every
+    // later test in the file and crashing the worker if one of them installs
+    // a rejecting mock.
+    test('sender metrics are updated after successful email send', async () => {
       const arbitraryEmail = fc.emailAddress();
       const arbitraryTenantId = fc.string({ minLength: 5, maxLength: 50 }).filter(s => s.trim().length > 0);
       const arbitrarySenderId = fc.string({ minLength: 5, maxLength: 50 }).filter(s => s.trim().length > 0);
@@ -1121,7 +1125,7 @@ describe('send-email-v2 property-based tests', () => {
         html: arbitraryHtml,
       });
 
-      fc.assert(
+      await fc.assert(
         fc.asyncProperty(arbitraryEmailData, async (data) => {
           jest.clearAllMocks();
 
@@ -1185,9 +1189,9 @@ describe('send-email-v2 property-based tests', () => {
           expect(() => new Date(timestamp)).not.toThrow();
           expect(new Date(timestamp).toISOString()).toBe(timestamp);
         }),
-        { numRuns: 100 }
+        { numRuns: 25 }
       );
-    });
+    }, 30000);
   });
 
   describe('Property 10: TPS rate limiting', () => {
@@ -1197,7 +1201,7 @@ describe('send-email-v2 property-based tests', () => {
      * sends should be at least the configured minimum delay based on TPS limit
      * Validates: Requirements 4.5
      */
-    test('emails are sent with appropriate delay based on TPS limit', () => {
+    test('emails are sent with appropriate delay based on TPS limit', async () => {
       const arbitraryTenantId = fc.string({ minLength: 5, maxLength: 50 }).filter(s => s.trim().length > 0);
       const arbitrarySenderId = fc.string({ minLength: 5, maxLength: 50 }).filter(s => s.trim().length > 0);
       const arbitrarySenderEmail = fc.emailAddress();
@@ -1218,7 +1222,7 @@ describe('send-email-v2 property-based tests', () => {
         html: arbitraryHtml,
       });
 
-      fc.assert(
+      await fc.assert(
         fc.asyncProperty(arbitraryBatchEmailData, async (data) => {
           jest.clearAllMocks();
 
@@ -1276,9 +1280,11 @@ describe('send-email-v2 property-based tests', () => {
           const endTime = Date.now();
           const totalTime = endTime - startTime;
 
-          // Property: Total time should be at least (recipients - 1) * delayMs
-          // TPS limit is 5, so delayMs = 1000/5 = 200ms
-          const tpsLimit = 5;
+          // Property: Total time should be at least (recipients - 1) * delayMs.
+          // The module reads SES_TPS_LIMIT at import time, before beforeAll
+          // sets it, so the default of 14 (72ms) is what actually pacing the
+          // loop - not the 5 the env var suggests.
+          const tpsLimit = 14;
           const expectedDelayMs = Math.ceil(1000 / tpsLimit);
           const minExpectedTime = (data.recipients.length - 1) * expectedDelayMs;
 
@@ -1306,9 +1312,9 @@ describe('send-email-v2 property-based tests', () => {
           // Verify all recipients received an email
           expect(sentEmails.length).toBe(data.recipients.length);
         }),
-        { numRuns: 100 }
+        { numRuns: 25 }
       );
-    });
+    }, 60000);
   });
 
   // The deferral is what carries a lead-time send: the workflow publishes ~26
@@ -1382,5 +1388,88 @@ describe('send-email-v2 property-based tests', () => {
       // It went out instead, and said so.
       expect(written.filter((item) => item.type === 'sending_started')).toHaveLength(1);
     });
+  });
+
+  describe('tracking checkpoints', () => {
+    // The markers are the only thing standing between a crashed send and a
+    // duplicate blast on retry, so they have to land DURING the loop - a
+    // 60-recipient list crosses the 50-send checkpoint once mid-flight.
+    const listEvent = () => ({
+      detail: {
+        subject: 'Issue Subject',
+        html: '<p>Issue content</p>',
+        to: { list: 'main-list' },
+        from: 'sender@example.com',
+        tenantId: 'tenant-123',
+        referenceNumber: 'tenant-123_42'
+      }
+    });
+
+    const sixtySubscribers = () => Array.from({ length: 60 }, (_, i) => ({
+      email: `reader${i}@example.com`,
+      lastIssueSent: null
+    }));
+
+    test('flushes lastIssueSent markers mid-loop, before the send completes', async () => {
+      ddbInstance.send.mockResolvedValueOnce({
+        Items: [{
+          unmarshalled: {
+            senderId: 'sender-123',
+            email: 'sender@example.com',
+            verificationStatus: 'verified',
+            isDefault: false
+          }
+        }]
+      });
+      ddbInstance.send.mockResolvedValue({});
+      sesInstance.send.mockResolvedValue({ MessageId: 'msg-123' });
+      listSubscribers.mockResolvedValue({
+        subscribers: sixtySubscribers(),
+        lastEvaluatedKey: undefined
+      });
+
+      const result = await handler(listEvent());
+
+      expect(result.recipients).toBe(60);
+      expect(updateSubscriberSendMetadata).toHaveBeenCalledTimes(60);
+      expect(updateSubscriberSendMetadata).toHaveBeenCalledWith('tenant-123', 'reader0@example.com', 'tenant-123_42');
+
+      // The 50th recipient's marker must be persisted before the 60th email
+      // goes out; if all markers waited for the end of the loop, the first
+      // tracking call would come after the last SES send.
+      const firstTrackingOrder = updateSubscriberSendMetadata.mock.invocationCallOrder[0];
+      const lastSesOrder = sesInstance.send.mock.invocationCallOrder.at(-1);
+      expect(firstTrackingOrder).toBeLessThan(lastSesOrder);
+    }, 30000);
+
+    test('stops sending when a checkpoint flush fails, instead of outrunning its markers', async () => {
+      ddbInstance.send.mockResolvedValueOnce({
+        Items: [{
+          unmarshalled: {
+            senderId: 'sender-123',
+            email: 'sender@example.com',
+            verificationStatus: 'verified',
+            isDefault: false
+          }
+        }]
+      });
+      ddbInstance.send.mockResolvedValue({});
+      sesInstance.send.mockResolvedValue({ MessageId: 'msg-123' });
+      listSubscribers.mockResolvedValue({
+        subscribers: sixtySubscribers(),
+        lastEvaluatedKey: undefined
+      });
+      updateSubscriberSendMetadata.mockRejectedValue(new Error('marker write down'));
+
+      try {
+        await expect(handler(listEvent())).rejects.toThrow(/Failed to persist subscriber tracking/);
+
+        // The flush fires at the 50-send checkpoint and throws; recipients
+        // 51-60 must not have been mailed past a failed marker write.
+        expect(sesInstance.send).toHaveBeenCalledTimes(50);
+      } finally {
+        updateSubscriberSendMetadata.mockImplementation(() => Promise.resolve());
+      }
+    }, 30000);
   });
 });

--- a/functions/__tests__/handle-email-status-transaction-retry.test.mjs
+++ b/functions/__tests__/handle-email-status-transaction-retry.test.mjs
@@ -1,0 +1,116 @@
+import { jest } from '@jest/globals';
+import { DynamoDBClient, GetItemCommand, TransactWriteItemsCommand } from '@aws-sdk/client-dynamodb';
+import { handler } from '../handle-email-status.mjs';
+
+describe('handle-email-status transaction retries', () => {
+  const originalSend = DynamoDBClient.prototype.send;
+  const originalTable = process.env.TABLE_NAME;
+  let mockSend;
+
+  const sendEvent = (messageId = 'msg-retry') => ({
+    detail: {
+      eventType: 'Send',
+      mail: {
+        messageId,
+        timestamp: '2026-08-19T12:00:00.000Z',
+        destination: ['reader@example.com'],
+        tags: { referenceNumber: ['tenant123_42'] }
+      }
+    }
+  });
+
+  const cancelled = (codes) => {
+    const err = new Error('Transaction cancelled');
+    err.name = 'TransactionCanceledException';
+    err.CancellationReasons = codes.map((Code) => ({ Code }));
+    return err;
+  };
+
+  beforeEach(() => {
+    process.env.TABLE_NAME = 'test-table';
+    mockSend = jest.fn();
+    DynamoDBClient.prototype.send = mockSend;
+    jest.spyOn(Math, 'random').mockReturnValue(0);
+  });
+
+  afterEach(() => {
+    DynamoDBClient.prototype.send = originalSend;
+    process.env.TABLE_NAME = originalTable;
+    jest.restoreAllMocks();
+  });
+
+  test.each([
+    'TransactionConflict',
+    'ThrottlingError',
+    'ProvisionedThroughputExceeded'
+  ])('retries transient transaction cancellation %s locally', async (reasonCode) => {
+    let transactAttempts = 0;
+    mockSend.mockImplementation((command) => {
+      if (command instanceof GetItemCommand) {
+        return Promise.resolve({ Item: null });
+      }
+      if (command instanceof TransactWriteItemsCommand) {
+        transactAttempts++;
+        if (transactAttempts === 1) {
+          return Promise.reject(cancelled(['None', reasonCode]));
+        }
+        return Promise.resolve({});
+      }
+      return Promise.resolve({});
+    });
+
+    await expect(handler(sendEvent())).resolves.toBe(true);
+    expect(transactAttempts).toBe(2);
+  });
+
+  test('does not locally retry a non-marker conditional failure', async () => {
+    let transactAttempts = 0;
+    mockSend.mockImplementation((command) => {
+      if (command instanceof GetItemCommand) {
+        return Promise.resolve({ Item: null });
+      }
+      if (command instanceof TransactWriteItemsCommand) {
+        transactAttempts++;
+        return Promise.reject(cancelled(['None', 'ConditionalCheckFailed']));
+      }
+      return Promise.resolve({});
+    });
+
+    await expect(handler(sendEvent())).rejects.toThrow('Transaction cancelled');
+    expect(transactAttempts).toBe(1);
+  });
+
+  test('still treats the processed-marker condition as duplicate success', async () => {
+    let transactAttempts = 0;
+    mockSend.mockImplementation((command) => {
+      if (command instanceof GetItemCommand) {
+        return Promise.resolve({ Item: null });
+      }
+      if (command instanceof TransactWriteItemsCommand) {
+        transactAttempts++;
+        return Promise.reject(cancelled(['ConditionalCheckFailed', 'None']));
+      }
+      return Promise.resolve({});
+    });
+
+    await expect(handler(sendEvent())).resolves.toBe(true);
+    expect(transactAttempts).toBe(1);
+  });
+
+  test('rethrows after the bounded transient retry budget is exhausted', async () => {
+    let transactAttempts = 0;
+    mockSend.mockImplementation((command) => {
+      if (command instanceof GetItemCommand) {
+        return Promise.resolve({ Item: null });
+      }
+      if (command instanceof TransactWriteItemsCommand) {
+        transactAttempts++;
+        return Promise.reject(cancelled(['None', 'TransactionConflict']));
+      }
+      return Promise.resolve({});
+    });
+
+    await expect(handler(sendEvent())).rejects.toThrow('Transaction cancelled');
+    expect(transactAttempts).toBe(4);
+  });
+});

--- a/functions/__tests__/handle-email-status.test.mjs
+++ b/functions/__tests__/handle-email-status.test.mjs
@@ -1,5 +1,5 @@
 import { jest } from '@jest/globals';
-import { DynamoDBClient, GetItemCommand, PutItemCommand, UpdateItemCommand } from '@aws-sdk/client-dynamodb';
+import { DynamoDBClient, GetItemCommand, PutItemCommand, UpdateItemCommand, TransactWriteItemsCommand } from '@aws-sdk/client-dynamodb';
 import { unmarshall } from '@aws-sdk/util-dynamodb';
 import crypto from 'crypto';
 import { handler } from '../handle-email-status.mjs';
@@ -68,18 +68,23 @@ describe('handle-email-status click position capture', () => {
       }
     });
 
-    const putCalls = mockSend.mock.calls.filter(([command]) => command instanceof PutItemCommand);
-    const clickEventCall = putCalls.find(([command]) => {
-      const item = unmarshall(command.input.Item);
-      return item.eventType === 'click';
-    });
+    // The click's analytics record and its stat now commit together inside one
+    // TransactWriteItems rather than as independent writes.
+    const commit = mockSend.mock.calls
+      .map(([command]) => command)
+      .find((command) => command instanceof TransactWriteItemsCommand);
+    expect(commit).toBeDefined();
 
-    expect(clickEventCall).toBeDefined();
-    const clickEvent = unmarshall(clickEventCall[0].input.Item);
-    expect(clickEvent.linkPosition).toBe(2);
+    const clickEventPut = commit.input.TransactItems
+      .map((item) => item.Put)
+      .filter(Boolean)
+      .find((put) => unmarshall(put.Item).eventType === 'click');
 
-    const updateCalls = mockSend.mock.calls.filter(([command]) => command instanceof UpdateItemCommand);
-    expect(updateCalls.length).toBeGreaterThan(0);
+    expect(clickEventPut).toBeDefined();
+    expect(unmarshall(clickEventPut.Item).linkPosition).toBe(2);
+
+    const statsUpdates = commit.input.TransactItems.map((item) => item.Update).filter(Boolean);
+    expect(statsUpdates.length).toBeGreaterThan(0);
   });
 });
 
@@ -109,23 +114,24 @@ describe('handle-email-status click tracking without link records', () => {
     return err;
   };
 
-  const statsUpdate = () =>
-    mockSend.mock.calls
+  const transactItems = () => {
+    const commit = mockSend.mock.calls
       .map(([command]) => command)
-      .find(
-        (command) =>
-          command instanceof UpdateItemCommand &&
-          unmarshall(command.input.Key).sk === 'stats'
-      );
+      .find((command) => command instanceof TransactWriteItemsCommand);
+    return commit ? commit.input.TransactItems : [];
+  };
+
+  const statsUpdate = () =>
+    transactItems()
+      .map((item) => item.Update)
+      .filter(Boolean)
+      .find((update) => unmarshall(update.Key).sk === 'stats');
 
   const clickEventPut = () =>
-    mockSend.mock.calls
-      .map(([command]) => command)
-      .find(
-        (command) =>
-          command instanceof PutItemCommand &&
-          unmarshall(command.input.Item).eventType === 'click'
-      );
+    transactItems()
+      .map((item) => item.Put)
+      .filter(Boolean)
+      .find((put) => unmarshall(put.Item).eventType === 'click');
 
   beforeEach(() => {
     originalTable = process.env.TABLE_NAME;
@@ -150,7 +156,7 @@ describe('handle-email-status click tracking without link records', () => {
 
     await expect(handler(clickEvent)).resolves.toBe(true);
 
-    expect(statsUpdate()?.input.ExpressionAttributeNames['#stat']).toBe('clicks');
+    expect(statsUpdate()?.ExpressionAttributeNames['#stat']).toBe('clicks');
     expect(clickEventPut()).toBeDefined();
   });
 
@@ -166,7 +172,7 @@ describe('handle-email-status click tracking without link records', () => {
 
     await expect(handler(clickEvent)).resolves.toBe(true);
 
-    expect(statsUpdate()?.input.ExpressionAttributeNames['#stat']).toBe('clicks');
+    expect(statsUpdate()?.ExpressionAttributeNames['#stat']).toBe('clicks');
     expect(clickEventPut()).toBeDefined();
   });
 
@@ -199,7 +205,7 @@ describe('handle-email-status click tracking without link records', () => {
 
     await expect(handler(clickEvent)).resolves.toBe(true);
 
-    expect(statsUpdate()?.input.ExpressionAttributeNames['#stat']).toBe('clicks');
+    expect(statsUpdate()?.ExpressionAttributeNames['#stat']).toBe('clicks');
   });
 });
 

--- a/functions/handle-email-status.mjs
+++ b/functions/handle-email-status.mjs
@@ -17,16 +17,79 @@ const padIssueNumber = (issueNumber) => {
   return String(issueNumber).padStart(5, '0');
 };
 
+/**
+ * Identity of one SES event, for dedup under EventBridge's at-least-once
+ * delivery. messageId + eventType alone is not unique - the same message can
+ * legitimately be opened or clicked many times - so the event's own timestamp
+ * (millisecond precision, identical on a redelivery, different on a real
+ * repeat) and, for clicks, the link disambiguate. Returns null when the event
+ * carries no messageId; such an event is processed without dedup rather than
+ * dropped.
+ */
+const processedMarkerSk = (detail) => {
+  const messageId = detail.mail?.messageId;
+  if (!messageId) {
+    return null;
+  }
+
+  const eventType = detail.eventType.toLowerCase();
+  const eventTimestamp = detail[eventType]?.timestamp || detail.mail.timestamp || '';
+  const linkDiscriminator = eventType === 'click' && detail.click?.link
+    ? `#${hash(detail.click.link)}`
+    : '';
+
+  return `processed#${messageId}#${eventType}#${eventTimestamp}${linkDiscriminator}`;
+};
+
+const wasEventProcessed = async (issueId, markerSk) => {
+  const result = await ddb.send(new GetItemCommand({
+    TableName: process.env.TABLE_NAME,
+    Key: marshall({ pk: issueId, sk: markerSk }),
+    // The redelivery being guarded against can arrive seconds after the
+    // original - an eventually-consistent read could miss its marker.
+    ConsistentRead: true,
+    ProjectionExpression: 'pk'
+  }));
+  return Boolean(result.Item);
+};
+
+// Written only after every write for the event has succeeded, so a failed
+// attempt leaves no marker and the retry reprocesses from the top. The TTL
+// only has to outlive the redelivery window (retries plus a manual DLQ
+// redrive), not the analytics records themselves.
+const markEventProcessed = async (issueId, markerSk) => {
+  await ddb.send(new PutItemCommand({
+    TableName: process.env.TABLE_NAME,
+    Item: marshall({
+      pk: issueId,
+      sk: markerSk,
+      ttl: Math.floor(Date.now() / 1000) + (7 * 24 * 60 * 60)
+    })
+  }));
+};
+
 export const handler = async (event) => {
+  const { detail } = event ?? {};
+  // Not one of ours (or a malformed relay) - nothing to retry, so don't throw.
+  if (!detail?.mail?.tags || !detail.eventType) {
+    console.warn('Ignoring email status event without mail tags or an event type');
+    return;
+  }
+
   try {
-    const { detail } = event;
     console.log(JSON.stringify(detail));
     const referenceNumber = detail.mail.tags.referenceNumber;
     if (!referenceNumber?.length) {
       return;
     }
 
+    const markerSk = processedMarkerSk(detail);
+
     const issueId = referenceNumber[0].replace(/_/g, '#');
+    if (markerSk && await wasEventProcessed(issueId, markerSk)) {
+      console.log('Skipping already-processed email status event', { issueId, eventType: detail.eventType });
+      return true;
+    }
     const [tenantId, issueNumber] = issueId.split('#');
     let stat;
     let failedEmail;
@@ -137,10 +200,22 @@ export const handler = async (event) => {
       }
     }
 
+    if (markerSk) {
+      await markEventProcessed(issueId, markerSk);
+    }
+
     return true;
   } catch (err) {
-    console.error(err);
-    return false;
+    // Rethrow so the platform retries and, once retries are exhausted, the
+    // event lands in the on-failure queue instead of evaporating. A swallowed
+    // error here used to lose the stat forever - including the bounce and
+    // complaint records that clean-bounced-subscribers and deliverability
+    // depend on.
+    console.error('Email status processing failed - rethrowing for retry', {
+      eventType: detail.eventType,
+      error: err.message
+    });
+    throw err;
   }
 };
 

--- a/functions/handle-email-status.mjs
+++ b/functions/handle-email-status.mjs
@@ -64,6 +64,40 @@ const wasEventProcessed = async (issueId, markerSk) => {
 // new event and double-count it. 30 days keeps headroom over that horizon.
 const PROCESSED_MARKER_TTL_SECONDS = 30 * 24 * 60 * 60;
 
+const TRANSACTION_MAX_ATTEMPTS = 4;
+const TRANSACTION_RETRY_BASE_MS = 20;
+const RETRYABLE_TRANSACTION_CANCELLATION_CODES = new Set([
+  'TransactionConflict',
+  'ThrottlingError',
+  'ProvisionedThroughputExceeded'
+]);
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * A transaction cancellation is locally retryable only when every concrete
+ * cancellation reason is transient. Conditional failures must escape so the
+ * caller can preserve their semantics: marker failure means duplicate success,
+ * while the first-open condition needs a fresh handler pass to reclassify the
+ * event as a reopen.
+ */
+const isRetryableTransactionCancellation = (reasons) => {
+  let sawRetryableReason = false;
+
+  for (const reason of reasons) {
+    const code = reason?.Code;
+    if (!code || code === 'None') {
+      continue;
+    }
+    if (!RETRYABLE_TRANSACTION_CANCELLATION_CODES.has(code)) {
+      return false;
+    }
+    sawRetryableReason = true;
+  }
+
+  return sawRetryableReason;
+};
+
 /**
  * Stable id for the event's analytics record, so a reprocessed event rewrites
  * the same row instead of creating a second physical record for one logical
@@ -178,27 +212,54 @@ const commitEventAccounting = async ({
     return true;
   }
 
-  try {
-    await ddb.send(new TransactWriteItemsCommand({ TransactItems: transactItems }));
-    return true;
-  } catch (err) {
-    if (err.name === 'TransactionCanceledException') {
+  for (let attempt = 1; attempt <= TRANSACTION_MAX_ATTEMPTS; attempt++) {
+    try {
+      await ddb.send(new TransactWriteItemsCommand({ TransactItems: transactItems }));
+      return true;
+    } catch (err) {
+      if (err.name !== 'TransactionCanceledException') {
+        throw err;
+      }
+
       const reasons = err.CancellationReasons ?? [];
+      const reasonCodes = reasons.map((reason) => reason?.Code);
+
       // The marker is always item 0 when present. Its condition failing means
       // another invocation got there first - that is a duplicate, not an error.
       if (markerSk && reasons[0]?.Code === 'ConditionalCheckFailed') {
         return false;
       }
-      // Anything else (e.g. two distinct opens racing on the unique-open
-      // marker) rethrows: nothing was written, so the retry recomputes - and
-      // the loser of that race correctly reclassifies its open as a reopen.
+
+      // DynamoDB does not SDK-retry transaction cancellations. Events for one
+      // issue all touch its stats item, so short-lived conflicts/throttling are
+      // normal contention and cheaper to absorb here than via Lambda's coarse
+      // async invocation retry. Do not retry other cancellation reasons: a
+      // first-open conditional failure, for example, needs a fresh read so it
+      // can be reclassified as a reopen.
+      if (attempt < TRANSACTION_MAX_ATTEMPTS && isRetryableTransactionCancellation(reasons)) {
+        const exponentialMs = TRANSACTION_RETRY_BASE_MS * (2 ** (attempt - 1));
+        const delayMs = exponentialMs + Math.floor(Math.random() * exponentialMs);
+        console.warn('Retrying transient email status accounting cancellation', {
+          issueId,
+          attempt,
+          maxAttempts: TRANSACTION_MAX_ATTEMPTS,
+          delayMs,
+          reasons: reasonCodes
+        });
+        await sleep(delayMs);
+        continue;
+      }
+
       console.warn('Email status accounting transaction cancelled', {
         issueId,
-        reasons: reasons.map((reason) => reason?.Code)
+        attempts: attempt,
+        reasons: reasonCodes
       });
+      throw err;
     }
-    throw err;
   }
+
+  throw new Error('Email status accounting retry loop exited unexpectedly');
 };
 
 export const handler = async (event) => {

--- a/functions/handle-email-status.mjs
+++ b/functions/handle-email-status.mjs
@@ -1,4 +1,4 @@
-import { DynamoDBClient, UpdateItemCommand, PutItemCommand, GetItemCommand } from '@aws-sdk/client-dynamodb';
+import { DynamoDBClient, UpdateItemCommand, GetItemCommand, TransactWriteItemsCommand } from '@aws-sdk/client-dynamodb';
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
 import { hash } from './utils/helpers.mjs';
 import { hashEmail } from './utils/hash-email.mjs';
@@ -41,31 +41,164 @@ const processedMarkerSk = (detail) => {
   return `processed#${messageId}#${eventType}#${eventTimestamp}${linkDiscriminator}`;
 };
 
+/**
+ * Cheap pre-check that skips the enrichment reads for the common redelivery
+ * case. It is NOT the idempotency guard - a consistent read gives no mutual
+ * exclusion between two invocations that both find no marker. The conditional
+ * Put inside commitEventAccounting is what actually decides who processes the
+ * event.
+ */
 const wasEventProcessed = async (issueId, markerSk) => {
   const result = await ddb.send(new GetItemCommand({
     TableName: process.env.TABLE_NAME,
     Key: marshall({ pk: issueId, sk: markerSk }),
-    // The redelivery being guarded against can arrive seconds after the
-    // original - an eventually-consistent read could miss its marker.
     ConsistentRead: true,
     ProjectionExpression: 'pk'
   }));
   return Boolean(result.Item);
 };
 
-// Written only after every write for the event has succeeded, so a failed
-// attempt leaves no marker and the retry reprocesses from the top. The TTL
-// only has to outlive the redelivery window (retries plus a manual DLQ
-// redrive), not the analytics records themselves.
-const markEventProcessed = async (issueId, markerSk) => {
-  await ddb.send(new PutItemCommand({
-    TableName: process.env.TABLE_NAME,
-    Item: marshall({
-      pk: issueId,
-      sk: markerSk,
-      ttl: Math.floor(Date.now() / 1000) + (7 * 24 * 60 * 60)
-    })
-  }));
+// Idempotency has to outlive every supported recovery path, not just the
+// automatic retries: EmailPipelineDLQ holds failed work for 14 days, so a
+// marker expiring at 7 would let a legitimate late redrive read as a brand
+// new event and double-count it. 30 days keeps headroom over that horizon.
+const PROCESSED_MARKER_TTL_SECONDS = 30 * 24 * 60 * 60;
+
+/**
+ * Stable id for the event's analytics record, so a reprocessed event rewrites
+ * the same row instead of creating a second physical record for one logical
+ * SES event. Falls back to a ULID when the event carries no messageId - such
+ * an event cannot be deduped anyway.
+ */
+const eventRecordId = (detail) => {
+  const messageId = detail.mail?.messageId;
+  if (!messageId) {
+    return ulid();
+  }
+
+  const eventType = detail.eventType.toLowerCase();
+  const linkPart = eventType === 'click' && detail.click?.link ? detail.click.link : '';
+  return crypto.createHash('sha256')
+    .update(`${messageId}#${eventType}#${linkPart}`)
+    .digest('hex')
+    .slice(0, 26);
+};
+
+/**
+ * Commit everything that counts as durable accounting for one SES event in a
+ * single all-or-nothing transaction: the processed marker (conditional, which
+ * is what makes concurrent duplicates mutually exclusive), the issue stats,
+ * the per-variant stats that decide A/B winners, the event's analytics record,
+ * and - for a first open - the unique-open marker.
+ *
+ * Doing these together closes the two windows a check-then-act sequence leaves
+ * open: two invocations both finding no marker and both proceeding, and a
+ * crash between the stat increment and the marker write that lets the retry
+ * count the same event twice. A cancelled transaction writes nothing, so a
+ * retry recomputes from scratch safely.
+ *
+ * @returns {Promise<boolean>} false when another invocation already claimed
+ * this event (its marker condition failed), true when this invocation owns it.
+ */
+const commitEventAccounting = async ({
+  issueId, tenantId, issueNumber, markerSk, stat, failedEmail, variantId, eventRecord, uniqueOpenItem
+}) => {
+  const transactItems = [];
+
+  if (markerSk) {
+    transactItems.push({
+      Put: {
+        TableName: process.env.TABLE_NAME,
+        Item: marshall({
+          pk: issueId,
+          sk: markerSk,
+          ttl: Math.floor(Date.now() / 1000) + PROCESSED_MARKER_TTL_SECONDS
+        }),
+        ConditionExpression: 'attribute_not_exists(pk) AND attribute_not_exists(sk)'
+      }
+    });
+  }
+
+  if (stat) {
+    transactItems.push({
+      Update: {
+        TableName: process.env.TABLE_NAME,
+        Key: marshall({ pk: issueId, sk: 'stats' }),
+        UpdateExpression: `ADD #stat :val SET GSI1PK = if_not_exists(GSI1PK, :gsi1pk), GSI1SK = if_not_exists(GSI1SK, :gsi1sk), statsPhase = if_not_exists(statsPhase, :phase)${failedEmail ? ', #failedAddresses = list_append(if_not_exists(#failedAddresses, :emptyList), :failedAddresses)' : ''}`,
+        ExpressionAttributeNames: {
+          '#stat': stat,
+          ...(failedEmail ? { '#failedAddresses': 'failedAddresses' } : {})
+        },
+        ExpressionAttributeValues: marshall({
+          ':val': 1,
+          ':gsi1pk': `${tenantId}#issue`,
+          ':gsi1sk': padIssueNumber(parseInt(issueNumber)),
+          ':phase': 'realtime',
+          ...(failedEmail ? { ':failedAddresses': [failedEmail], ':emptyList': [] } : {})
+        })
+      }
+    });
+
+    // Previously best-effort with a swallowed error, which let the main stat
+    // land, the variant stat fail, and the event still be marked processed -
+    // permanently skewing the numbers winner selection reads.
+    if (variantId === 'a' || variantId === 'b') {
+      transactItems.push({
+        Update: {
+          TableName: process.env.TABLE_NAME,
+          Key: marshall({ pk: issueId, sk: `stats#v#${variantId}` }),
+          UpdateExpression: 'ADD #stat :val SET statsPhase = if_not_exists(statsPhase, :phase)',
+          ExpressionAttributeNames: { '#stat': stat },
+          ExpressionAttributeValues: marshall({ ':val': 1, ':phase': 'realtime' })
+        }
+      });
+    }
+  }
+
+  if (eventRecord) {
+    transactItems.push({
+      Put: {
+        TableName: process.env.TABLE_NAME,
+        Item: marshall(eventRecord)
+      }
+    });
+  }
+
+  if (uniqueOpenItem) {
+    transactItems.push({
+      Put: {
+        TableName: process.env.TABLE_NAME,
+        Item: marshall(uniqueOpenItem),
+        ConditionExpression: 'attribute_not_exists(pk) AND attribute_not_exists(sk)'
+      }
+    });
+  }
+
+  if (transactItems.length === 0) {
+    return true;
+  }
+
+  try {
+    await ddb.send(new TransactWriteItemsCommand({ TransactItems: transactItems }));
+    return true;
+  } catch (err) {
+    if (err.name === 'TransactionCanceledException') {
+      const reasons = err.CancellationReasons ?? [];
+      // The marker is always item 0 when present. Its condition failing means
+      // another invocation got there first - that is a duplicate, not an error.
+      if (markerSk && reasons[0]?.Code === 'ConditionalCheckFailed') {
+        return false;
+      }
+      // Anything else (e.g. two distinct opens racing on the unique-open
+      // marker) rethrows: nothing was written, so the retry recomputes - and
+      // the loser of that race correctly reclassifies its open as a reopen.
+      console.warn('Email status accounting transaction cancelled', {
+        issueId,
+        reasons: reasons.map((reason) => reason?.Code)
+      });
+    }
+    throw err;
+  }
 };
 
 export const handler = async (event) => {
@@ -91,17 +224,23 @@ export const handler = async (event) => {
       return true;
     }
     const [tenantId, issueNumber] = issueId.split('#');
+    const recipient = detail.mail.destination?.[0];
+    const recordId = eventRecordId(detail);
     let stat;
     let failedEmail;
+    // Built here, written by the transaction below - nothing durable is
+    // recorded until the whole accounting set commits together.
+    let eventRecord = null;
+    let uniqueOpenItem = null;
     switch (detail.eventType.toLowerCase()) {
       case 'bounce':
-        await captureBounceEvent(issueId, detail.mail.destination[0], detail.bounce);
+        eventRecord = buildBounceEventRecord(issueId, recipient, detail.bounce, recordId);
         stat = 'bounces';
-        failedEmail = detail.mail.destination[0];
+        failedEmail = recipient;
         break;
       case 'reject':
         stat = 'rejects';
-        failedEmail = detail.mail.destination[0];
+        failedEmail = recipient;
         break;
       case 'send':
         stat = 'sends';
@@ -110,99 +249,51 @@ export const handler = async (event) => {
         stat = 'deliveries';
         break;
       case 'complaint':
-        await captureComplaintEvent(issueId, detail.mail.destination[0], detail.complaint);
+        eventRecord = buildComplaintEventRecord(issueId, recipient, detail.complaint, recordId);
         stat = 'complaints';
         break;
-      case 'open':
-        await captureOpenEvent(issueId, detail.mail.destination[0], detail.open, detail.mail.commonHeaders);
-        const isReopen = await trackUniqueOpen(issueId, detail.mail.destination[0], detail.open);
-        stat = isReopen ? 'reopens' : 'opens';
-        try {
-          await updateSubscriberEngagement(tenantId, detail.mail.destination[0], parseInt(issueNumber, 10));
-        } catch (err) {
-          console.error('Subscriber engagement update failed on open', { issueId, error: err.message });
+      case 'open': {
+        eventRecord = await buildOpenEventRecord(issueId, recipient, detail.open, detail.mail.commonHeaders, recordId);
+        // Read-only here; the unique-open marker rides the transaction so the
+        // open/reopen classification and the row that decides it commit as one.
+        const alreadyOpened = await hasUniqueOpen(issueId, recipient);
+        stat = alreadyOpened ? 'reopens' : 'opens';
+        if (!alreadyOpened) {
+          uniqueOpenItem = buildUniqueOpenItem(issueId, recipient, detail.open);
         }
-        await recordTimeZoneFromIp(tenantId, detail.mail.destination[0], parseInt(issueNumber, 10), detail.open?.ipAddress, 'open');
-        await recordOpenActivity(tenantId, detail.mail.destination[0], parseInt(issueNumber, 10), detail.open);
         break;
+      }
       case 'click':
+        eventRecord = await buildClickEventRecord(issueId, recipient, detail.click, recordId);
         stat = 'clicks';
-        // Every step below is a side effect of the click, and none of them may
-        // cost the click itself. `stat` is only applied after this switch, so a
-        // throw escaping here takes the counter, the click event, the engagement
-        // update, interest scoring, the timezone observation and the activity
-        // entry down with it — the handler's outer catch swallows the lot and
-        // the issue silently reports zero clicks. That is not hypothetical: an
-        // issue that shipped without its `link#` records lost every one of its
-        // email clicks to a ValidationException out of trackLinkClick.
-        try {
-          await trackLinkClick(issueId, detail.click.link, detail.click.ipAddress);
-        } catch (err) {
-          console.error('Link click counter update failed', { issueId, error: err.message });
-        }
-        try {
-          await captureClickEvent(issueId, detail.mail.destination[0], detail.click);
-        } catch (err) {
-          console.error('Click event capture failed', { issueId, error: err.message });
-        }
-        try {
-          await updateSubscriberEngagement(tenantId, detail.mail.destination[0], parseInt(issueNumber, 10));
-        } catch (err) {
-          console.error('Subscriber engagement update failed on click', { issueId, error: err.message });
-        }
-        // Interest scoring + auto-segmentation runs on the SES email-click path
-        // because that is the click event that identifies the subscriber
-        // (detail.mail.destination). The CloudFront/web-version redirect path is
-        // intentionally anonymous, so it never scores. processInterestScoring
-        // looks up the clicked link's topic (link#hash(url)) and increments the
-        // subscriber's interestScores, auto-creating an interest segment when a
-        // topic crosses the threshold. It swallows its own errors; the wrapper
-        // is defensive so a scoring failure never fails stat aggregation.
-        try {
-          await processInterestScoring(issueId, detail.mail.destination[0], detail.click.link);
-        } catch (err) {
-          console.error('Interest scoring failed on click', { issueId, error: err.message });
-        }
-        await recordTimeZoneFromIp(tenantId, detail.mail.destination[0], parseInt(issueNumber, 10), detail.click?.ipAddress, 'click');
-        await recordClickActivity(tenantId, detail.mail.destination[0], parseInt(issueNumber, 10), detail.click);
         break;
       default:
         console.warn(`Unsupported stat ${detail.eventType} was provided`);
         return;
     }
 
-    if (stat) {
-      const updateExpression = `ADD #stat :val SET GSI1PK = if_not_exists(GSI1PK, :gsi1pk), GSI1SK = if_not_exists(GSI1SK, :gsi1sk), statsPhase = if_not_exists(statsPhase, :phase)${failedEmail ? ', #failedAddresses = list_append(if_not_exists(#failedAddresses, :emptyList), :failedAddresses)' : ''}`;
+    const claimed = await commitEventAccounting({
+      issueId,
+      tenantId,
+      issueNumber,
+      markerSk,
+      stat,
+      failedEmail,
+      variantId: detail.mail.tags?.variant?.[0],
+      eventRecord,
+      uniqueOpenItem
+    });
 
-      await ddb.send(new UpdateItemCommand({
-        TableName: process.env.TABLE_NAME,
-        Key: marshall({
-          pk: issueId,
-          sk: 'stats'
-        }),
-        UpdateExpression: updateExpression,
-        ExpressionAttributeNames: {
-          '#stat': stat,
-          ...(failedEmail ? { '#failedAddresses': 'failedAddresses' } : {})
-        },
-        ExpressionAttributeValues: marshall({
-          ':val': 1,
-          ':gsi1pk': `${tenantId}#issue`,
-          ':gsi1sk': padIssueNumber(parseInt(issueNumber)),
-          ':phase': 'realtime',
-          ...(failedEmail ? { ':failedAddresses': [failedEmail], ':emptyList': [] } : {})
-        })
-      }));
-
-      const variantId = detail.mail.tags?.variant?.[0];
-      if (variantId === 'a' || variantId === 'b') {
-        await incrementVariantStat(issueId, variantId, stat);
-      }
+    if (!claimed) {
+      console.log('Another invocation already recorded this email status event', { issueId, eventType: detail.eventType });
+      return true;
     }
 
-    if (markerSk) {
-      await markEventProcessed(issueId, markerSk);
-    }
+    // Enrichment runs only after the accounting is durable, and never fails
+    // the invocation. Ordering matters: a retry that finds the marker skips
+    // straight past this, so running it before the transaction would let a
+    // failed commit replay these non-idempotent side effects.
+    await runEnrichment(detail, { issueId, tenantId, issueNumber, recipient });
 
     return true;
   } catch (err) {
@@ -281,29 +372,61 @@ const recordClickActivity = async (tenantId, email, issueNumber, clickEvent) => 
   }
 };
 
-const incrementVariantStat = async (issueId, variantId, stat) => {
-  try {
-    await ddb.send(new UpdateItemCommand({
-      TableName: process.env.TABLE_NAME,
-      Key: marshall({
-        pk: issueId,
-        sk: `stats#v#${variantId}`
-      }),
-      UpdateExpression: 'ADD #stat :val SET statsPhase = if_not_exists(statsPhase, :phase)',
-      ExpressionAttributeNames: {
-        '#stat': stat
-      },
-      ExpressionAttributeValues: marshall({
-        ':val': 1,
-        ':phase': 'realtime'
-      })
-    }));
-  } catch (err) {
-    console.error('Failed to increment per-variant stat', { issueId, variantId, stat, error: err.message });
+/**
+ * Everything that enriches a subscriber's profile off the back of an event:
+ * engagement recency, interest scoring, timezone inference, activity history,
+ * per-link click tallies. Deliberately outside the accounting transaction and
+ * deliberately unable to fail the invocation - none of it is what the issue's
+ * reported numbers or deliverability decisions are built from.
+ */
+const runEnrichment = async (detail, { issueId, tenantId, issueNumber, recipient }) => {
+  const issueNumeric = parseInt(issueNumber, 10);
+
+  if (detail.eventType.toLowerCase() === 'open') {
+    try {
+      await updateSubscriberEngagement(tenantId, recipient, issueNumeric);
+    } catch (err) {
+      console.error('Subscriber engagement update failed on open', { issueId, error: err.message });
+    }
+    await recordTimeZoneFromIp(tenantId, recipient, issueNumeric, detail.open?.ipAddress, 'open');
+    await recordOpenActivity(tenantId, recipient, issueNumeric, detail.open);
+    return;
   }
+
+  if (detail.eventType.toLowerCase() !== 'click') {
+    return;
+  }
+
+  // Each step is a side effect of the click and none of them may cost the
+  // others. An issue that shipped without its `link#` records once lost every
+  // one of its email clicks to a ValidationException out of trackLinkClick.
+  try {
+    await trackLinkClick(issueId, detail.click.link, detail.click.ipAddress);
+  } catch (err) {
+    console.error('Link click counter update failed', { issueId, error: err.message });
+  }
+  try {
+    await updateSubscriberEngagement(tenantId, recipient, issueNumeric);
+  } catch (err) {
+    console.error('Subscriber engagement update failed on click', { issueId, error: err.message });
+  }
+  // Interest scoring + auto-segmentation runs on the SES email-click path
+  // because that is the click event that identifies the subscriber
+  // (detail.mail.destination). The CloudFront/web-version redirect path is
+  // intentionally anonymous, so it never scores. processInterestScoring looks
+  // up the clicked link's topic (link#hash(url)) and increments the
+  // subscriber's interestScores, auto-creating an interest segment when a
+  // topic crosses the threshold.
+  try {
+    await processInterestScoring(issueId, recipient, detail.click.link);
+  } catch (err) {
+    console.error('Interest scoring failed on click', { issueId, error: err.message });
+  }
+  await recordTimeZoneFromIp(tenantId, recipient, issueNumeric, detail.click?.ipAddress, 'click');
+  await recordClickActivity(tenantId, recipient, issueNumeric, detail.click);
 };
 
-const captureOpenEvent = async (issueId, subscriberEmail, openEvent, commonHeaders) => {
+const buildOpenEventRecord = async (issueId, subscriberEmail, openEvent, commonHeaders, recordId) => {
   const openedAt = openEvent?.timestamp ? new Date(openEvent.timestamp) : new Date();
   const timestamp = openedAt.toISOString();
 
@@ -337,11 +460,9 @@ const captureOpenEvent = async (issueId, subscriberEmail, openEvent, commonHeade
     ? Math.floor((openedAt - new Date(sentAt)) / 1000)
     : null;
 
-  const eventId = ulid();
-
   const openEventRecord = {
     pk: issueId,
-    sk: `open#${timestamp}#${subscriberEmailHash}#${eventId}`,
+    sk: `open#${timestamp}#${subscriberEmailHash}#${recordId}`,
     eventType: 'open',
     timestamp,
     subscriberEmailHash,
@@ -351,13 +472,10 @@ const captureOpenEvent = async (issueId, subscriberEmail, openEvent, commonHeade
     ttl: Math.floor(Date.now() / 1000) + (90 * 24 * 60 * 60)
   };
 
-  await ddb.send(new PutItemCommand({
-    TableName: process.env.TABLE_NAME,
-    Item: marshall(openEventRecord)
-  }));
+  return openEventRecord;
 };
 
-const captureBounceEvent = async (issueId, subscriberEmail, bounceEvent) => {
+const buildBounceEventRecord = (issueId, subscriberEmail, bounceEvent, recordId) => {
   const bouncedAt = bounceEvent?.timestamp ? new Date(bounceEvent.timestamp) : new Date();
   const timestamp = bouncedAt.toISOString();
 
@@ -366,11 +484,9 @@ const captureBounceEvent = async (issueId, subscriberEmail, bounceEvent) => {
   const bounceType = categorizeBounceType(bounceEvent);
   const bounceReason = extractBounceReason(bounceEvent);
 
-  const eventId = ulid();
-
   const bounceEventRecord = {
     pk: issueId,
-    sk: `bounce#${timestamp}#${subscriberEmailHash}#${eventId}`,
+    sk: `bounce#${timestamp}#${subscriberEmailHash}#${recordId}`,
     eventType: 'bounce',
     timestamp,
     subscriberEmailHash,
@@ -379,13 +495,10 @@ const captureBounceEvent = async (issueId, subscriberEmail, bounceEvent) => {
     ttl: Math.floor(Date.now() / 1000) + (90 * 24 * 60 * 60)
   };
 
-  await ddb.send(new PutItemCommand({
-    TableName: process.env.TABLE_NAME,
-    Item: marshall(bounceEventRecord)
-  }));
+  return bounceEventRecord;
 };
 
-const captureComplaintEvent = async (issueId, subscriberEmail, complaintEvent) => {
+const buildComplaintEventRecord = (issueId, subscriberEmail, complaintEvent, recordId) => {
   const complainedAt = complaintEvent?.timestamp ? new Date(complaintEvent.timestamp) : new Date();
   const timestamp = complainedAt.toISOString();
 
@@ -393,11 +506,9 @@ const captureComplaintEvent = async (issueId, subscriberEmail, complaintEvent) =
 
   const complaintType = determineComplaintType(complaintEvent);
 
-  const eventId = ulid();
-
   const complaintEventRecord = {
     pk: issueId,
-    sk: `complaint#${timestamp}#${subscriberEmailHash}#${eventId}`,
+    sk: `complaint#${timestamp}#${subscriberEmailHash}#${recordId}`,
     eventType: 'complaint',
     timestamp,
     subscriberEmailHash,
@@ -405,10 +516,7 @@ const captureComplaintEvent = async (issueId, subscriberEmail, complaintEvent) =
     ttl: Math.floor(Date.now() / 1000) + (90 * 24 * 60 * 60)
   };
 
-  await ddb.send(new PutItemCommand({
-    TableName: process.env.TABLE_NAME,
-    Item: marshall(complaintEventRecord)
-  }));
+  return complaintEventRecord;
 };
 
 const determineComplaintType = (complaintEvent) => {
@@ -459,12 +567,27 @@ const extractBounceReason = (bounceEvent) => {
   return 'unknown';
 };
 
-const trackUniqueOpen = async (issueId, emailAddress, openEvent) => {
-  const timestamp = new Date().toISOString();
+/**
+ * Whether this subscriber has already opened the issue, which decides between
+ * the `opens` and `reopens` counters. Read-only and strongly consistent: the
+ * write that claims the first open rides the accounting transaction, so the
+ * classification and the row it depends on commit together or not at all.
+ */
+const hasUniqueOpen = async (issueId, emailAddress) => {
+  const result = await ddb.send(new GetItemCommand({
+    TableName: process.env.TABLE_NAME,
+    Key: marshall({ pk: issueId, sk: `opens#${emailAddress}` }),
+    ConsistentRead: true,
+    ProjectionExpression: 'pk'
+  }));
+  return Boolean(result.Item);
+};
+
+const buildUniqueOpenItem = (issueId, emailAddress, openEvent) => {
   const item = {
     pk: issueId,
     sk: `opens#${emailAddress}`,
-    createdAt: timestamp,
+    createdAt: new Date().toISOString(),
     ttl: Math.floor(Date.now() / 1000) + (7 * 24 * 60 * 60)
   };
 
@@ -480,19 +603,7 @@ const trackUniqueOpen = async (issueId, emailAddress, openEvent) => {
     item.openedAt = openEvent.timestamp;
   }
 
-  try {
-    await ddb.send(new PutItemCommand({
-      TableName: process.env.TABLE_NAME,
-      Item: marshall(item),
-      ConditionExpression: 'attribute_not_exists(pk) AND attribute_not_exists(sk)'
-    }));
-    return false;
-  } catch (err) {
-    if (err.name === 'ConditionalCheckFailedException') {
-      return true;
-    }
-    throw err;
-  }
+  return item;
 };
 
 /**
@@ -576,14 +687,13 @@ const getStoredLinkPosition = async (issueId, link) => {
   }
 };
 
-const captureClickEvent = async (issueId, subscriberEmail, clickEvent) => {
+const buildClickEventRecord = async (issueId, subscriberEmail, clickEvent, recordId) => {
   const clickedAt = clickEvent?.timestamp ? new Date(clickEvent.timestamp) : new Date();
   const timestamp = clickedAt.toISOString();
 
   const subscriberEmailHash = hashEmail(subscriberEmail);
   const linkUrl = clickEvent?.link || 'unknown';
   const linkId = crypto.createHash('md5').update(linkUrl).digest('hex').substring(0, 8);
-  const eventId = ulid();
 
   const ipAddress = clickEvent?.ipAddress || null;
   const countryData = ipAddress ? await lookupCountry(ipAddress) : null;
@@ -616,7 +726,7 @@ const captureClickEvent = async (issueId, subscriberEmail, clickEvent) => {
 
   const clickEventRecord = {
     pk: issueId,
-    sk: `click#${timestamp}#${subscriberEmailHash}#${linkId}#${eventId}`,
+    sk: `click#${timestamp}#${subscriberEmailHash}#${linkId}#${recordId}`,
     eventType: 'click',
     timestamp,
     subscriberEmailHash,
@@ -629,8 +739,5 @@ const captureClickEvent = async (issueId, subscriberEmail, clickEvent) => {
     ttl: Math.floor(Date.now() / 1000) + (90 * 24 * 60 * 60)
   };
 
-  await ddb.send(new PutItemCommand({
-    TableName: process.env.TABLE_NAME,
-    Item: marshall(clickEventRecord)
-  }));
+  return clickEventRecord;
 };

--- a/functions/send-email-v2.mjs
+++ b/functions/send-email-v2.mjs
@@ -749,7 +749,7 @@ const sendEmailsPhase = async (emailAddresses, emailConfig, senderEmail) => {
   const logInterval = Math.min(50, Math.ceil(totalCount / 10));
 
   for (const email of emailAddresses) {
-    await sendWithRetry(async () => {
+    const sendOne = () => sendWithRetry(async () => {
       // Apply personalization replacements
       let personalizedHtml = emailConfig.html;
 
@@ -845,6 +845,25 @@ const sendEmailsPhase = async (emailAddresses, emailConfig, senderEmail) => {
         ConfigurationSetName: process.env.CONFIGURATION_SET
       }));
     }, `Send email to ${email}`);
+
+    try {
+      await sendOne();
+    } catch (sendError) {
+      // A controlled failure does not have to behave like a hard crash. The
+      // recipients confirmed sent since the last checkpoint already have their
+      // mail; flushing their markers before propagating means the retry skips
+      // them rather than mailing them twice. Only a hard termination (timeout,
+      // OOM) can still strand a partial checkpoint, which is what the periodic
+      // flush above bounds.
+      try {
+        await flushTracking();
+      } catch (flushError) {
+        console.error('[SENDING] Could not checkpoint confirmed sends before failing', {
+          error: flushError.message
+        });
+      }
+      throw sendError;
+    }
 
     sentCount++;
     sentRecipients.push(email);

--- a/functions/send-email-v2.mjs
+++ b/functions/send-email-v2.mjs
@@ -38,6 +38,12 @@ const ddb = new DynamoDBClient();
 const tpsLimit = parseInt(process.env.SES_TPS_LIMIT || "14", 10);
 const delayMs = Math.ceil(1000 / tpsLimit);
 
+// How many sends may accumulate before their lastIssueSent markers are
+// flushed. Small enough that a crashed invocation re-mails at most one
+// batch on retry; large enough that the flush writes stay a rounding error
+// against the per-recipient SES pacing above.
+const TRACKING_CHECKPOINT_INTERVAL = 50;
+
 /**
  * Execute a phase with logging
  * @param {string} phaseName - Name of the phase
@@ -719,6 +725,25 @@ const sendEmailsPhase = async (emailAddresses, emailConfig, senderEmail) => {
   let sentCount = 0;
   const sentRecipients = [];
   const totalCount = emailAddresses.length;
+  // Index into sentRecipients up to which lastSentAt/lastIssueSent markers
+  // have been persisted.
+  let trackedThrough = 0;
+
+  // Persist the idempotency markers for everyone sent since the last flush.
+  // Runs every TRACKING_CHECKPOINT_INTERVAL sends rather than once after the
+  // loop: the markers are what filterIdempotentRecipientsPhase reads on the
+  // retry after a crash or timeout, and every sent-but-unmarked recipient is
+  // one that retry mails twice. A flush failure aborts the send for the same
+  // reason - stopping with accurate markers beats continuing to mail
+  // recipients a retry cannot distinguish from unsent ones.
+  const flushTracking = async () => {
+    if (!emailConfig.tenantId || trackedThrough >= sentRecipients.length) {
+      return;
+    }
+    const batch = sentRecipients.slice(trackedThrough);
+    await updateSubscriberTrackingPhase(emailConfig.tenantId, batch, emailConfig.referenceNumber);
+    trackedThrough = sentRecipients.length;
+  };
 
   // Calculate progress logging interval: every 10% or every 50 emails, whichever is smaller
   const logInterval = Math.min(50, Math.ceil(totalCount / 10));
@@ -824,6 +849,10 @@ const sendEmailsPhase = async (emailAddresses, emailConfig, senderEmail) => {
     sentCount++;
     sentRecipients.push(email);
 
+    if (sentRecipients.length - trackedThrough >= TRACKING_CHECKPOINT_INTERVAL) {
+      await flushTracking();
+    }
+
     // Log progress at intervals or when complete
     if (sentCount % logInterval === 0 || sentCount === totalCount) {
       console.log(`[SENDING] Progress: ${sentCount}/${totalCount} (${Math.round(sentCount / totalCount * 100)}%)`);
@@ -833,13 +862,19 @@ const sendEmailsPhase = async (emailAddresses, emailConfig, senderEmail) => {
     await new Promise(resolve => setTimeout(resolve, delayMs));
   }
 
+  await flushTracking();
+
   console.log(`[SENDING] Complete - sent ${sentCount} emails`);
   return { sentCount, sentRecipients };
 };
 
 /**
- * Update subscriber tracking fields (lastSentAt, lastIssueSent) after send completes.
- * Throws when subscriber metadata persistence fails for known subscribers.
+ * Update subscriber tracking fields (lastSentAt, lastIssueSent) for a batch of
+ * sent recipients. Called from sendEmailsPhase's checkpoint flush every
+ * TRACKING_CHECKPOINT_INTERVAL sends (and once for the remainder), so the
+ * concurrent write burst is capped at the batch size rather than the whole
+ * list. Throws when subscriber metadata persistence fails for known
+ * subscribers - the caller stops sending rather than outrun its markers.
  * @param {string} tenantId - Tenant identifier
  * @param {string[]} sentRecipients - Recipients that were successfully sent
  * @param {string|undefined} issueIdentifier - Issue identifier/reference that was sent
@@ -1365,10 +1400,10 @@ export const handler = async (event) => {
       }, senderEmail);
     });
 
-    // Phase 3.5: Subscriber Tracking Update (non-critical)
-    await executePhase('Subscriber Tracking Update', async () => {
-      return await updateSubscriberTrackingPhase(tenantId, sentRecipients, data.referenceNumber);
-    });
+    // Subscriber tracking (lastSentAt/lastIssueSent) is checkpointed inside
+    // sendEmailsPhase, batch by batch, so a crashed or timed-out send resumes
+    // where it left off on retry instead of re-mailing everyone. Nothing left
+    // to do for it here.
 
     // Phase 4: Metrics Update
     if (senderRecord) {

--- a/functions/send-email-v2.mjs
+++ b/functions/send-email-v2.mjs
@@ -42,6 +42,17 @@ const delayMs = Math.ceil(1000 / tpsLimit);
 // flushed. Small enough that a crashed invocation re-mails at most one
 // batch on retry; large enough that the flush writes stay a rounding error
 // against the per-recipient SES pacing above.
+//
+// What this does and does not guarantee: checkpointing bounds duplicates
+// caused by OUR failures - a crash, a timeout, a retried invocation. It
+// cannot make delivery exactly-once, because the SES boundary itself is
+// ambiguous: SES can accept a message and still return an error to the
+// caller, in which case the recipient never reaches sentRecipients, never
+// gets a marker, and a retry mails them again. No marker scheme can tell
+// that apart from a genuinely failed send, since the success acknowledgement
+// we would checkpoint on is exactly what went missing. Closing it would take
+// a per-recipient delivery ledger reconciled against SES message ids, which
+// is deliberately out of scope here.
 const TRACKING_CHECKPOINT_INTERVAL = 50;
 
 /**

--- a/template.yaml
+++ b/template.yaml
@@ -3919,9 +3919,16 @@ Resources:
   #     invocation record that WRAPS the original request payload alongside
   #     invocation metadata.
   # Replaying therefore means identifying the failure source, extracting the
-  # original event from whichever envelope carries it, and republishing it -
-  # not forwarding the raw SQS message. That normalizing replay tool does not
-  # exist yet; until it does, redrive is a deliberate manual operation.
+  # original event from whichever envelope carries it, and republishing it
+  # through EventBridge - not forwarding the raw SQS message.
+  #
+  # Decided during review of #396: one shared queue plus a source-aware
+  # normalizing replay step is the intended architecture, rather than
+  # splitting EventBridge and Lambda failures into separate queues. Splitting
+  # them would not materially improve recovery, since replay has to rebuild
+  # the original event either way. That replay tool does not exist yet; until
+  # it ships, redrive is a deliberate manual operation and this queue provides
+  # retention only.
   #
   # SSE-SQS rather than the aws/sqs KMS key: EventBridge cannot deliver to a
   # queue encrypted with the AWS-managed KMS key, whose policy cannot grant

--- a/template.yaml
+++ b/template.yaml
@@ -1718,8 +1718,8 @@ Resources:
               Action: sqs:SendMessage
               Resource: !GetAtt EmailPipelineDLQ.Arn
       # The handler rethrows on failure now instead of swallowing, so a
-      # bounce or complaint that cannot be recorded retries and then parks
-      # in the DLQ for redrive - previously it was silently lost, and the
+      # bounce or complaint that cannot be recorded retries and is then
+      # retained in the DLQ - previously it was silently lost, and the
       # bounce list clean-bounced-subscribers works from went stale.
       EventInvokeConfig:
         MaximumRetryAttempts: 2
@@ -2272,9 +2272,12 @@ Resources:
               Action: sqs:SendMessage
               Resource: !GetAtt EmailPipelineDLQ.Arn
       # A send event that exhausts its retries is an issue whose recipients
-      # are half-mailed. It parks in the DLQ for redrive instead of
-      # evaporating; the checkpointed lastIssueSent markers make the redrive
-      # resume where the send stopped rather than re-mail from the top.
+      # are half-mailed. It is retained in the DLQ instead of evaporating.
+      # Note the envelope: a Lambda OnFailure record wraps the original event
+      # rather than being one, so replaying means extracting the request
+      # payload first (see EmailPipelineDLQ). Once republished, the
+      # checkpointed lastIssueSent markers make the replay resume where the
+      # send stopped rather than re-mail from the top.
       EventInvokeConfig:
         MaximumRetryAttempts: 2
         DestinationConfig:
@@ -3900,12 +3903,25 @@ Resources:
           DLQ_URL: !Ref StripeEventDLQ
           ALERT_TOPIC_ARN: !Ref EventBridgeCriticalAlertsTopic
 
-  # Failed async email-pipeline work parks here for manual redrive: Send
-  # Email v2 events whose retries were exhausted (an issue send that would
-  # otherwise vanish, its recipients half-mailed) and SES status events
-  # (bounces, complaints, opens, clicks) that could not be recorded. It has
-  # no consumer on purpose - the 14-day retention IS the recovery window,
-  # and EmailPipelineDLQAlarm is what surfaces arrivals.
+  # Failed async email-pipeline work parks here: Send Email v2 events whose
+  # retries were exhausted (an issue send that would otherwise vanish, its
+  # recipients half-mailed) and SES status events (bounces, complaints, opens,
+  # clicks) that could not be recorded. It has no consumer on purpose - the
+  # 14-day retention IS the recovery window, and EmailPipelineDLQAlarm is what
+  # surfaces arrivals.
+  #
+  # IMPORTANT for recovery: this queue holds TWO message shapes, and neither
+  # can be handed straight back to the function that failed.
+  #   * EventBridge rule DeadLetterConfig (delivery never reached the function)
+  #     sends the original event plus EventBridge failure metadata - error
+  #     code, retry attempts, rule and target ARNs.
+  #   * Lambda OnFailure destinations (the function ran and threw) send an
+  #     invocation record that WRAPS the original request payload alongside
+  #     invocation metadata.
+  # Replaying therefore means identifying the failure source, extracting the
+  # original event from whichever envelope carries it, and republishing it -
+  # not forwarding the raw SQS message. That normalizing replay tool does not
+  # exist yet; until it does, redrive is a deliberate manual operation.
   #
   # SSE-SQS rather than the aws/sqs KMS key: EventBridge cannot deliver to a
   # queue encrypted with the AWS-managed KMS key, whose policy cannot grant
@@ -3942,7 +3958,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub "${AWS::StackName}-email-pipeline-dlq-messages"
-      AlarmDescription: "CRITICAL: send or SES-status events exhausted retries and are parked in the email pipeline DLQ - inspect and redrive within 14 days"
+      AlarmDescription: "CRITICAL: send or SES-status events exhausted retries and are parked in the email pipeline DLQ - inspect within the 14-day retention; replay requires unwrapping the envelope, see the queue definition"
       MetricName: ApproximateNumberOfVisibleMessages
       Namespace: AWS/SQS
       Statistic: Maximum

--- a/template.yaml
+++ b/template.yaml
@@ -1710,6 +1710,23 @@ Resources:
                 - dynamodb:PutItem
                 - dynamodb:UpdateItem
               Resource: !GetAtt SubscribersTable.Arn
+        - Version: 2012-10-17
+          Statement:
+            # Lambda delivers the failed async event to the OnFailure
+            # destination below with the function's own role.
+            - Effect: Allow
+              Action: sqs:SendMessage
+              Resource: !GetAtt EmailPipelineDLQ.Arn
+      # The handler rethrows on failure now instead of swallowing, so a
+      # bounce or complaint that cannot be recorded retries and then parks
+      # in the DLQ for redrive - previously it was silently lost, and the
+      # bounce list clean-bounced-subscribers works from went stale.
+      EventInvokeConfig:
+        MaximumRetryAttempts: 2
+        DestinationConfig:
+          OnFailure:
+            Type: SQS
+            Destination: !GetAtt EmailPipelineDLQ.Arn
       Environment:
         Variables:
           AWS_NODEJS_CONNECTION_REUSE_ENABLED: 1
@@ -1728,6 +1745,8 @@ Resources:
                 - Email Complaint Received
                 - Email Opened
                 - Email Clicked
+            DeadLetterConfig:
+              Arn: !GetAtt EmailPipelineDLQ.Arn
 
   CleanBouncedSubscribersFunction:
     Type: AWS::Serverless::Function
@@ -2247,6 +2266,21 @@ Resources:
                 - dynamodb:GetItem
                 - dynamodb:UpdateItem
               Resource: !GetAtt SubscribersTable.Arn
+            # Lambda delivers the failed async event to the OnFailure
+            # destination below with the function's own role.
+            - Effect: Allow
+              Action: sqs:SendMessage
+              Resource: !GetAtt EmailPipelineDLQ.Arn
+      # A send event that exhausts its retries is an issue whose recipients
+      # are half-mailed. It parks in the DLQ for redrive instead of
+      # evaporating; the checkpointed lastIssueSent markers make the redrive
+      # resume where the send stopped rather than re-mail from the top.
+      EventInvokeConfig:
+        MaximumRetryAttempts: 2
+        DestinationConfig:
+          OnFailure:
+            Type: SQS
+            Destination: !GetAtt EmailPipelineDLQ.Arn
       Environment:
         Variables:
           AWS_NODEJS_CONNECTION_REUSE_ENABLED: 1
@@ -2272,6 +2306,11 @@ Resources:
                 - newsletter-service
               detail-type:
                 - Send Email v2
+            # Catches events EventBridge could not hand to the function at
+            # all (throttled/unavailable); handler failures are covered by
+            # the EventInvokeConfig OnFailure destination above.
+            DeadLetterConfig:
+              Arn: !GetAtt EmailPipelineDLQ.Arn
 
   EvaluateAbWinnerFunction:
     Type: AWS::Serverless::Function
@@ -3861,6 +3900,101 @@ Resources:
           DLQ_URL: !Ref StripeEventDLQ
           ALERT_TOPIC_ARN: !Ref EventBridgeCriticalAlertsTopic
 
+  # Failed async email-pipeline work parks here for manual redrive: Send
+  # Email v2 events whose retries were exhausted (an issue send that would
+  # otherwise vanish, its recipients half-mailed) and SES status events
+  # (bounces, complaints, opens, clicks) that could not be recorded. It has
+  # no consumer on purpose - the 14-day retention IS the recovery window,
+  # and EmailPipelineDLQAlarm is what surfaces arrivals.
+  #
+  # SSE-SQS rather than the aws/sqs KMS key: EventBridge cannot deliver to a
+  # queue encrypted with the AWS-managed KMS key, whose policy cannot grant
+  # the service principal.
+  EmailPipelineDLQ:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub "${AWS::StackName}-email-pipeline-dlq"
+      MessageRetentionPeriod: 1209600 # 14 days
+      ReceiveMessageWaitTimeSeconds: 20 # Long polling
+      SqsManagedSseEnabled: true
+
+  # EventBridge delivers rule-level dead letters (events it could not hand to
+  # the function at all); Lambda's OnFailure destination permission rides the
+  # function roles.
+  EmailPipelineDLQPolicy:
+    Type: AWS::SQS::QueuePolicy
+    Properties:
+      Queues:
+        - !Ref EmailPipelineDLQ
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+            Action: sqs:SendMessage
+            Resource: !GetAtt EmailPipelineDLQ.Arn
+            Condition:
+              StringEquals:
+                aws:SourceAccount: !Ref AWS::AccountId
+
+  EmailPipelineDLQAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-email-pipeline-dlq-messages"
+      AlarmDescription: "CRITICAL: send or SES-status events exhausted retries and are parked in the email pipeline DLQ - inspect and redrive within 14 days"
+      MetricName: ApproximateNumberOfVisibleMessages
+      Namespace: AWS/SQS
+      Statistic: Maximum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: QueueName
+          Value: !GetAtt EmailPipelineDLQ.QueueName
+      AlarmActions:
+        - !Ref EventBridgeCriticalAlertsTopic
+      TreatMissingData: notBreaching
+
+  SendEmailV2ErrorsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-send-email-v2-errors"
+      AlarmDescription: "CRITICAL: an issue send invocation failed - it will retry twice, then land in the email pipeline DLQ"
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref SendEmailV2Function
+      AlarmActions:
+        - !Ref EventBridgeCriticalAlertsTopic
+      TreatMissingData: notBreaching
+
+  HandleEmailStatusErrorsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-email-status-errors"
+      AlarmDescription: "WARNING: SES status events (bounces, complaints, opens, clicks) are failing to record; sustained failures land in the email pipeline DLQ"
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 10
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref HandleEmailStatusFunction
+      AlarmActions:
+        - !Ref EventBridgeCriticalAlertsTopic
+      TreatMissingData: notBreaching
+
   # Dead Letter Queue for failed Stripe events
   StripeEventDLQ:
     Type: AWS::SQS::Queue
@@ -4456,6 +4590,20 @@ Resources:
               Action:
                 - dynamodb:DeleteItem
               Resource: !GetAtt SubscribersTable.Arn
+            # Lambda delivers the failed async event to the OnFailure
+            # destination below with the function's own role.
+            - Effect: Allow
+              Action: sqs:SendMessage
+              Resource: !GetAtt EmailPipelineDLQ.Arn
+      # The handler rethrows on failure expecting a DLQ behind the retries;
+      # this is that DLQ. A dropped complaint event means someone who hit
+      # "report spam" stays subscribed and keeps receiving mail.
+      EventInvokeConfig:
+        MaximumRetryAttempts: 2
+        DestinationConfig:
+          OnFailure:
+            Type: SQS
+            Destination: !GetAtt EmailPipelineDLQ.Arn
       Environment:
         Variables:
           AWS_NODEJS_CONNECTION_REUSE_ENABLED: 1
@@ -4468,6 +4616,8 @@ Resources:
                 - aws.ses
               detail-type:
                 - Email Complaint Received
+            DeadLetterConfig:
+              Arn: !GetAtt EmailPipelineDLQ.Arn
 
   BackfillStatsGSIFunction:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
Fixes the two P0 send-pipeline findings from the durability/compliance audit: a mid-send crash could duplicate mail to everyone already sent (and drop the rest of the list), and any failure while recording an SES status event silently lost it — including the bounces and complaints list hygiene depends on.

> Updated after two review passes. The SES event dedup is transactional with a bounded transient-conflict retry, the marker TTL outlives the DLQ retention, controlled send failures checkpoint before propagating, the DLQ replay semantics are documented accurately, and the delivery guarantee is stated precisely. Details inline.

## What changed

**`functions/send-email-v2.mjs` — checkpointed send loop.** The `lastIssueSent` idempotency markers used to be written only after the entire serial send loop finished, so a crash or timeout at recipient N meant the async retry's idempotency filter skipped nobody: all N already-mailed recipients got the issue again (up to two more times), and after the retries the event was dropped. Markers now flush every 50 sends, so a retry resumes where the send stopped. A failed flush aborts the send rather than mailing past markers a retry depends on, and the post-send write burst is capped at the batch size instead of the full list.

An ordinary SES/application exception additionally flushes the confirmed-sent remainder before propagating, so the guarantee splits cleanly: a controlled failure checkpoints everything actually sent, and only a hard termination (timeout, OOM) can strand a partial checkpoint. A secondary flush failure is logged without masking the original send error.

**`functions/handle-email-status.mjs` — retry-safe, and atomically idempotent.** The outer catch used to swallow every error and report success, so a transient DynamoDB throttle during a bounce permanently lost both the stat and the record `clean-bounced-subscribers` works from. The handler now rethrows so the platform retries.

Dedup is a single `TransactWriteItems` carrying the processed marker (conditional `Put`), the issue stats, the per-variant stats, the event's analytics record, and — for a first open — the unique-open marker. The conditional Put is what provides mutual exclusion between two concurrent first-time processors; the consistent read that remains is only a pre-check that skips enrichment reads on the common redelivery. Because a cancelled transaction writes nothing, a failed commit leaves no marker and the retry recomputes cleanly.

Cancellations are classified rather than blanket-retried: the marker's condition failing means a duplicate (success); `TransactionConflict` / throttling / throughput are absorbed locally with bounded exponential backoff and jitter, since every event for an issue transacts against the same stats item and DynamoDB does not SDK-retry cancellations; a non-marker conditional failure and any structural error escape, so a fresh invocation can re-read — which is what lets the loser of a first-open race reclassify as a reopen.

Analytics record ids derive from `messageId` (+ event type, + link for clicks) rather than a fresh ULID, so one logical SES event maps to one physical row. Per-variant stats moved inside the transaction — previously the main stat could land, the variant stat could fail silently, and the event was still marked processed, permanently skewing what winner selection reads. Marker TTL is 30 days, deliberately longer than the DLQ's 14-day retention so a legitimate late redrive cannot read as a new event.

Enrichment (engagement, interest scoring, timezone, activity history, per-link counters) stays best-effort and runs *after* the commit, so a failed commit cannot replay its non-idempotent side effects.

**`template.yaml` — a net under the async pipeline.** New `EmailPipelineDLQ` (deliberately consumer-less: the 14-day retention is the recovery window), wired as both the EventBridge rule dead-letter config and the Lambda `OnFailure` destination for `SendEmailV2Function`, `HandleEmailStatusFunction`, and `AutoUnsubscribeComplaintFunction` — whose handler already rethrew "to reach the DLQ" that never existed. Plus three alarms on the existing alerts topic: DLQ depth, send-function errors (threshold 1), and status-handler errors (threshold 10/5min). The queue uses SSE-SQS because EventBridge can't deliver to a queue encrypted with the AWS-managed KMS key.

**Test hygiene.** The two fast-check property suites called `fc.assert(fc.asyncProperty(...))` from non-async tests without awaiting, leaking ~100 iterations that kept mutating the shared mocks under every later test in the file (the long-standing "worker failed to exit gracefully" warning). They're now awaited with bounded runs, and the TPS expectation matches the limit the module actually loads at import time.

## What this does and does not guarantee

Checkpointing bounds duplicates caused by *our* failures — a crash, a timeout, a retried invocation. It does **not** make delivery exactly-once. SES can accept a message and still return an error to the caller, in which case the recipient never reaches `sentRecipients`, never gets a marker, and a retry mails them again. No marker scheme distinguishes that from a genuinely failed send, because the success acknowledgement we would checkpoint on is exactly what went missing. Closing it would require a per-recipient delivery ledger reconciled against SES message ids, which is deliberately out of scope here and documented at `TRACKING_CHECKPOINT_INTERVAL`.

## Testing

Covers: mid-loop marker flush ordering, flush-failure abort, controlled-failure flush (57th send throws → 56 markers written, the failed recipient unmarked), original-error preservation when the rescue flush fails, marker-exists skip, single-transaction commit with the marker guarded, TTL beyond the DLQ horizon, all three transient cancellation codes retrying, marker-duplicate short-circuit, non-marker conditional and structural cancellations escaping (the latter asserting a single commit attempt), retry-budget exhaustion, no-messageId fallback, and distinct-click discrimination.

Full suite: 109 suites / 1,499 tests pass; eslint clean; template validates and deploys.

## Notes for review

- **DLQ replay is a manual operation today.** The queue holds two message shapes — EventBridge rule dead-letters carry the original event plus failure metadata, while Lambda `OnFailure` records *wrap* the request payload — so replay means identifying the source, extracting the original event, and republishing, not forwarding the raw SQS message. This is documented at the queue definition; a normalizing replay tool is a follow-up PR.
- **Deferred to the observability PR (next):** alarms on `DestinationDeliveryFailures` and `InvocationsFailedToBeSentToDlq`, which catch the case where the DLQ itself cannot be reached and depth stays at zero. Held back because the EventBridge alarm must reference SAM's generated rule logical ids, better validated in a PR dedicated to alarms.
- **One deliberate behavior change:** the event's analytics record now shares the accounting transaction, so a failure writing it fails the whole commit and retries, where previously it was swallowed and the stat still counted.
- Known-remaining P1s in this area (out of scope): rendered-HTML payloads vs the 256KB EventBridge/Scheduler caps, A/B winner-evaluation hardening, Scheduler-entry DLQs, and stats-item write batching.
- The alerts topic these alarms target still has no subscriptions — that lands in the same follow-up quick-wins PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPzLDDjtduBYWdhNk5mwDh