### PR TITLE
fix(issues): stop discarding an issue over its analytics envelope

### DIFF
--- a/dashboard-ui/src/services/__tests__/issuesService.test.ts
+++ b/dashboard-ui/src/services/__tests__/issuesService.test.ts
@@ -1,0 +1,119 @@
+import { issuesService } from '../issuesService';
+import { apiClient } from '../api';
+import type { Issue, IssueAnalytics, IssueStats } from '@/types/issues';
+
+vi.mock('../api');
+
+const mockApiClient = vi.mocked(apiClient);
+
+/** A complete event-analytics slice — the shape the detail page renders. */
+const eventAnalytics: IssueAnalytics = {
+  links: [{ url: 'https://example.com', clicks: 4, percentOfTotal: 100, position: 0 }],
+  clickDecay: [{ hour: 0, clicks: 4, cumulativeClicks: 4 }],
+  geoDistribution: [{ country: 'US', clicks: 4, opens: 9 }],
+  deviceBreakdown: { desktop: 3, mobile: 6, tablet: 0 },
+  timingMetrics: {
+    medianTimeToOpen: 120,
+    p95TimeToOpen: 900,
+    medianTimeToClick: 300,
+    p95TimeToClick: 1800,
+  },
+  engagementType: { newClickers: 2, returningClickers: 2 },
+  trafficSource: { clicks: { email: 4, web: 0 } },
+  bounceReasons: { permanent: 1, temporary: 0, suppressed: 0 },
+  complaintDetails: [],
+};
+
+const baseStats: IssueStats = {
+  opens: 66,
+  clicks: 170,
+  deliveries: 527,
+  sends: 537,
+  bounces: 9,
+  complaints: 1,
+  subscribers: 3016,
+};
+
+/**
+ * The enriched report the aggregation pipeline writes over `stats.analytics`.
+ * `currentMetrics` is what marks it as the envelope.
+ */
+const envelope = (nested: IssueAnalytics | null) => ({
+  currentMetrics: { openRate: 33.1, clickThroughRate: 61.92, subscribers: 3016 },
+  healthScore: { score: 60, status: 'OK' },
+  insightCandidates: [],
+  eventAnalytics: nested,
+});
+
+const issueWith = (analytics: unknown): Issue =>
+  ({
+    id: '230',
+    issueNumber: 230,
+    subject: 'Agent memory is harder than it sounds',
+    status: 'published',
+    content: '<html></html>',
+    contentType: 'html',
+    createdAt: '2026-08-21T20:43:23.203Z',
+    stats: { ...baseStats, analytics },
+  }) as unknown as Issue;
+
+describe('issuesService.getIssue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('unwraps the report envelope down to its event analytics', async () => {
+    mockApiClient.get.mockResolvedValue({ success: true, data: issueWith(envelope(eventAnalytics)) });
+
+    const result = await issuesService.getIssue('230');
+
+    expect(mockApiClient.get).toHaveBeenCalledWith('/issues/230');
+    expect(result.success).toBe(true);
+    expect(result.data?.stats?.analytics).toEqual(eventAnalytics);
+  });
+
+  // The case that took the page down: an issue whose event analytics were never
+  // built still gets an envelope, carrying `eventAnalytics: null`. Reading that
+  // as "no envelope" left the whole report in place as if it were
+  // `IssueAnalytics`, which validation rejected, which failed the request.
+  it('keeps the issue when the envelope has no event analytics', async () => {
+    mockApiClient.get.mockResolvedValue({ success: true, data: issueWith(envelope(null)) });
+
+    const result = await issuesService.getIssue('230');
+
+    expect(result.success).toBe(true);
+    expect(result.data?.subject).toBe('Agent memory is harder than it sounds');
+    expect(result.data?.stats?.analytics).toBeUndefined();
+  });
+
+  it('passes a bare event-analytics slice through untouched', async () => {
+    mockApiClient.get.mockResolvedValue({ success: true, data: issueWith(eventAnalytics) });
+
+    const result = await issuesService.getIssue('230');
+
+    expect(result.success).toBe(true);
+    expect(result.data?.stats?.analytics).toEqual(eventAnalytics);
+  });
+
+  it('drops analytics it cannot read rather than failing the issue', async () => {
+    const unreadable = { ...eventAnalytics, links: 'not-an-array' };
+    mockApiClient.get.mockResolvedValue({ success: true, data: issueWith(unreadable) });
+
+    const result = await issuesService.getIssue('230');
+
+    expect(result.success).toBe(true);
+    expect(result.data?.stats?.analytics).toBeUndefined();
+    expect(result.data?.stats?.deliveries).toBe(527);
+  });
+
+  it('still fails when the core counters are wrong', async () => {
+    const data = issueWith(undefined);
+    (data.stats as unknown as Record<string, unknown>).deliveries = 'lots';
+    mockApiClient.get.mockResolvedValue({ success: true, data });
+
+    const result = await issuesService.getIssue('230');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/Invalid issue stats structure/);
+  });
+});

--- a/dashboard-ui/src/services/issuesService.ts
+++ b/dashboard-ui/src/services/issuesService.ts
@@ -1,7 +1,8 @@
 import { apiClient } from './api';
-import { validateIssueStats, validateTrendsData } from '@/utils/dataValidation';
+import { validateIssueAnalytics, validateIssueStats, validateTrendsData } from '@/utils/dataValidation';
 import type {
   Issue,
+  IssueAnalytics,
   IssueListItem,
   IssueMetrics,
   TrendsData,
@@ -18,6 +19,28 @@ import type {
 } from '@/types/issues';
 import type { ApiResponse } from '@/types';
 import { calculateCompositeScore } from '@/utils/analyticsCalculations';
+
+/** The enriched analytics report the aggregation pipeline writes over `stats.analytics`. */
+interface ReportEnvelope {
+  eventAnalytics?: IssueAnalytics | null;
+}
+
+/**
+ * Whether `stats.analytics` is the report envelope rather than the raw event
+ * analytics this UI renders.
+ *
+ * Keyed on `currentMetrics`, which is the marker the report builder itself
+ * uses to tell its own output apart from an event-analytics blob — and
+ * deliberately not on `eventAnalytics` being truthy. The envelope carries
+ * `eventAnalytics: null` for any issue that never produced that slice, and
+ * reading that as "not an envelope" hands the whole report object to the page
+ * as if it were `IssueAnalytics`. It has none of that shape, so validation
+ * rejects it, and the issue is discarded over an optional section.
+ */
+const isReportEnvelope = (analytics: unknown): boolean =>
+  !!analytics &&
+  typeof analytics === 'object' &&
+  'currentMetrics' in (analytics as Record<string, unknown>);
 
 /**
  * Service for managing newsletter issues through the API
@@ -62,16 +85,28 @@ class IssuesService {
     const response = await apiClient.get<Issue>(`/issues/${id}`);
 
     if (response.success && response.data?.stats) {
-      // The API may return analytics in an enriched envelope with nested
-      // eventAnalytics, benchmarks, insights, etc.  The frontend only needs
-      // the eventAnalytics slice which matches the IssueAnalytics shape.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const rawAnalytics = response.data.stats.analytics as any;
-      if (rawAnalytics?.eventAnalytics) {
-        response.data.stats.analytics = rawAnalytics.eventAnalytics;
+      const stats = response.data.stats;
+
+      // The API may return analytics in an enriched report envelope that wraps
+      // the raw event analytics alongside benchmarks, health scores and
+      // insight candidates. Only the nested slice matches `IssueAnalytics`.
+      if (isReportEnvelope(stats.analytics)) {
+        // `?? undefined`, not the envelope: an issue whose event analytics were
+        // never built carries `eventAnalytics: null`, and that means "no
+        // analytics", which is what the detail page's processing notice is for.
+        stats.analytics = (stats.analytics as unknown as ReportEnvelope).eventAnalytics ?? undefined;
       }
 
-      if (!validateIssueStats(response.data.stats)) {
+      // Analytics are an optional enrichment, so a slice this build cannot read
+      // costs the analytics panels and nothing else. Dropping it here rather
+      // than failing the request keeps the subject, content, timeline and
+      // counters on screen — those come from a different writer and are still
+      // good, and they are what somebody is on the page to see.
+      if (stats.analytics !== undefined && !validateIssueAnalytics(stats.analytics)) {
+        stats.analytics = undefined;
+      }
+
+      if (!validateIssueStats(stats)) {
         return {
           success: false,
           error: 'Invalid issue stats structure received from server',


### PR DESCRIPTION
## What broke

The issue detail page rendered an error for issue #230, an issue whose data was entirely fine. The console showed:

```
IssueAnalytics validation failed: invalid links
IssueStats validation failed: invalid analytics
```

(The `installHook.js` frames in the stack were just React DevTools wrapping `console.error` — the page was not crashing, it was rendering its own error state.)

## Why

The API returns `stats.analytics` as an enriched *report envelope* — `currentMetrics`, `benchmarks`, `healthScore`, `insightCandidates` — with the raw event analytics nested under `eventAnalytics`. `issuesService.getIssue` detected that envelope by testing whether `eventAnalytics` was **truthy**:

```js
const rawAnalytics = response.data.stats.analytics as any;
if (rawAnalytics?.eventAnalytics) { /* unwrap */ }
```

For an issue whose event analytics were never built, the envelope carries `eventAnalytics: null`. The unwrap was skipped, and the whole report object went to `validateIssueStats` as if it were `IssueAnalytics`. It has no `links` array — they live at `content.links` — so validation rejected it and `getIssue` returned `{ success: false, error: 'Invalid issue stats structure received from server' }`.

The entire issue was thrown away over an optional analytics section: subject, content, timeline and counters included.

## What changed

`dashboard-ui/src/services/issuesService.ts`:

1. **Detect the envelope by `currentMetrics`**, the same discriminator the backend's own `isEventAnalytics` uses in reverse (`functions/build-report-data.mjs:15` returns false when `currentMetrics` is present). A null nested slice now resolves to `undefined` — "no analytics yet", which is what the page's "Analytics Processing" notice exists to say.
2. **Validate the analytics slice separately from the counters.** Analytics are an optional enrichment, so one this build cannot read now costs the analytics panels and nothing else; the subject, content, timeline and stats still render. Genuinely broken counters still fail the request as before.

## Tests

New `dashboard-ui/src/services/__tests__/issuesService.test.ts` covers both envelope forms (populated and null), a bare event-analytics slice passing through untouched, graceful degradation on an unreadable slice, and that bad core counters still fail.

`tsc --noEmit` and `eslint` clean; new tests plus the 68 existing issue-page and `dataValidation` property tests pass.

## For the reviewer — a follow-up this does not fix

Issue #230's analytics sections will load but stay **empty**, because `eventAnalytics` really is `null` server-side, and I believe it is being destroyed on rebuild.

`functions/build-report-data.mjs:1215` reads the prior slice via `isEventAnalytics(stats.analytics)`, which returns `false` when `currentMetrics` is present — i.e. whenever it is reading back its own previous envelope. So every "Refresh insights" after the first rewrites the record with `eventAnalytics: null`, permanently dropping the per-link, geo, device and decay data. That is a separate backend change and is deliberately out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
